### PR TITLE
Fix Guild Ban Add / Guild Ban Remove inaccuracies

### DIFF
--- a/docs/topics/GATEWAY.md
+++ b/docs/topics/GATEWAY.md
@@ -279,11 +279,11 @@ Sent when a channel relevant to the current user is deleted. The inner payload i
 
 ### Guild Ban Add
 
-Sent when a user is banned from a guild. The inner payload is a [user](#DOCS_USER/user-object) object.
+Sent when a user is banned from a guild. The inner payload is a [user](#DOCS_USER/user-object) object, with an extra guild_id key.
 
 ### Guild Ban Remove
 
-Sent when a user is unbanned from a guild. The inner payload is a [user](#DOCS_USER/user-object) object.
+Sent when a user is unbanned from a guild. The inner payload is a [user](#DOCS_USER/user-object) object, with an extra guild_id key.
 
 ### Guild Create
 


### PR DESCRIPTION
The `GUILD_BAN_ADD`/`GUILD_BAN_REMOVE` documentation fails to mention that there is a `guild_id` key also present in the data. Whilst this might be fairly obvious, it's still a good idea to include it in the official documentation.
