### PR TITLE
Remove read-state documentation in preparation of deprecation (see #13)

### DIFF
--- a/docs/resources/CHANNEL.md
+++ b/docs/resources/CHANNEL.md
@@ -76,28 +76,6 @@ DM Channels represent a one-to-one conversation between two users, outside of th
 }
 ```
 
-### Read States
-
-Read states represent the tracking of what messages and mentions have been read.
-
-###### Read State Structure
-
-| Field | Type | Description |
-|-------|------|-------------|
-| id | snowflake | channel id |
-| mention_count | integer | number of unread mentions in this channel |
-| last_message_id | snowflake | last message read in this channel |
-
-###### Example Read State
-
-```json
-{
-	"id": "78703938047582208",
-	"mention_count": 5,
-	"last_message_id": "72465239836196864"
-}
-```
-
 ### Messages Object
 
 Represents a message sent in a channel within Discord.

--- a/docs/topics/GATEWAY.md
+++ b/docs/topics/GATEWAY.md
@@ -247,7 +247,7 @@ To enable sharding on a connection, the user should send the `shard` array in th
 (guild_id >> 22) % num_shards == shard_id
 ```
 
-As an example, if you wanted to split the connection between three shards, you'd use the following values for `shard` for each connection: `[0, 3]`, `[1, 3]`, and `[2, 3]`. Note that only the first shard (`[0, 3]`) would receive DMs. 
+As an example, if you wanted to split the connection between three shards, you'd use the following values for `shard` for each connection: `[0, 3]`, `[1, 3]`, and `[2, 3]`. Note that only the first shard (`[0, 3]`) would receive DMs.
 
 
 
@@ -279,7 +279,6 @@ The ready event is dispatched when a client has completed the handshake with the
 | user | object | [user object](#DOCS_USER/user-object) (with email information) |
 | private_channels | array | array of [DM channel](#DOCS_CHANNEL/dm-channel-object) objects |
 | guilds | array | array of [Unavailable Guild](#DOCS_GUILD/unavailable-guild-object) objects |
-| read_state | array | array of [read state](#DOCS_CHANNEL/read-state-object) objects |
 | session_id | string | used for resuming connections |
 
 ### Channel Create


### PR DESCRIPTION
This PR removes all the read-state documentation in preparation of the deprecation we talked about in #13. 
