### PR TITLE
We should allow fixing of spelling/grammatical errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,11 @@
 1. Fixes to incorrect statements or inaccuracies within the documentation.
 2. Rewording or extending documentation to clarify unclear wording or complicated explanations.
 3. Additions that fill gaps or missing pieces in the current documentation.
+4. Fixing of spelling and grammatical errors in the documentation.
 
 ## Unwanted Changes
 
-1. Spelling, grammar or whitespace/formatting changes.
+1. Whitespace or formatting changes.
 2. Modifications to the overall structure and format of the API docs.
 3. Additions that replicate or needlessly restructure current documentation.
 


### PR DESCRIPTION
These are the lowest hanging fruit for contributors to fix. No reason to not want them.
