### PR TITLE
Consistency, spelling, and errors

### DIFF
--- a/docs/resources/CHANNEL.md
+++ b/docs/resources/CHANNEL.md
@@ -112,8 +112,8 @@ Represents a message sent in a channel within Discord.
 | content | string | contents of the message |
 | timestamp | timestamp | when this message was sent |
 | edited_timestamp | ?timestamp | when this message was edited (or null if never) |
-| tts | boolean | whether this was a TTS message |
-| mention_everyone | boolean | whether this message mentions everyone |
+| tts | bool | whether this was a TTS message |
+| mention_everyone | bool | whether this message mentions everyone |
 | mentions | array of [user objects](#DOCS_USER/user-object) | and users specifically mentioned in the message |
 | attachments | array of [attachment objects](#DOC_CHANNEL/attachment-object) | any attached files |
 | embeds | array of [embed objects](#DOC_CHANNEL/embed-object) | any embedded content |
@@ -206,11 +206,11 @@ Discord utilizes a subset of markdown for rendering message content on its clien
 
 ## Get Channel % GET /channels/{channel.id#DOCS_CHANNEL/channel-objects}
 
-Return a channel by ID. This returns a [guild channel](#DOCS_CHANNEL/guild-channel-object) or [dm channel](#DOCS_CHANNEL/dm-channel-object) object.
+Get a channel by ID. Returns a [guild channel](#DOCS_CHANNEL/guild-channel-object) or [dm channel](#DOCS_CHANNEL/dm-channel-object) object.
 
 ## Modify Channel % PUT/PATCH /channels/{channel.id#DOCS_CHANNEL/guild-channel-object}
 
-Update a channels settings. Requires the 'MANAGE_GUILD' permission for the guild. This returns a [guild channel](#DOCS_CHANNEL/guild-channel-object) on success, and a 400 BAD REQUEST on invalid parameters. Fires a [Channel Update](#DOCS_GATEWAY/channel-update) Gateway event.
+Update a channels settings. Requires the 'MANAGE_GUILD' permission for the guild. Returns a [guild channel](#DOCS_CHANNEL/guild-channel-object) on success, and a 400 BAD REQUEST on invalid parameters. Fires a [Channel Update](#DOCS_GATEWAY/channel-update) Gateway event.
 
 ###### JSON Params
 
@@ -223,11 +223,14 @@ Update a channels settings. Requires the 'MANAGE_GUILD' permission for the guild
 
 ## Delete/Close Channel % DELETE /channels/{channel.id#DOCS_CHANNEL/channel-objects}
 
-Delete a guild channel, or close a private message. Requires the 'MANAGE_GUILD' permission for the guild. Returns a [guild channel](#DOCS_CHANNEL/guild-channel-object) or [dm channel](#DOCS_CHANNEL/dm-channel-object) object on success. Fires a [Channel Delete](#DOCS_GATEWAY/channel-delete) Gateway event. Deleting a guild channel cannot be undone. Use with caution, as it is impossible to undo this action when performed on a guild channel. In contrast, when used with a private message, it is possible to undo the action by opening a private message with the recipient again.
+Delete a guild channel, or close a private message. Requires the 'MANAGE_GUILD' permission for the guild. Returns a [guild channel](#DOCS_CHANNEL/guild-channel-object) or [dm channel](#DOCS_CHANNEL/dm-channel-object) object on success. Fires a [Channel Delete](#DOCS_GATEWAY/channel-delete) Gateway event.
+
+>warn
+> Deleting a guild channel cannot be undone. Use this with caution, as it is impossible to undo this action when performed on a guild channel. In contrast, when used with a private message, it is possible to undo the action by opening a private message with the recipient again.
 
 ## Get Channel Messages % GET /channels/{channel.id#DOCS_CHANNEL/channel-objects}/messages
 
-Return the messages for a channel. If operating on a guild channel, this endpoint requires the 'READ_MESSAGES' permission to be present on the current user. Returns an array of [message](#DOCS_CHANNEL/message-object) objects on success.
+Returns the messages for a channel. If operating on a guild channel, this endpoint requires the 'READ_MESSAGES' permission to be present on the current user. Returns an array of [message](#DOCS_CHANNEL/message-object) objects on success.
 
 >info
 > The before and after keys are mutually exclusive, only one may be passed at a time.
@@ -270,7 +273,7 @@ Post a file to a guild text or DM channel. If operating on a guild channel, this
 
 ## Edit Message % PATCH /channels/{channel.id#DOCS_CHANNEL/channel-objects}/messages/{message.id#DOCS_CHANNEL/message-object}
 
-Edit a previously sent message. Returns a [message](#DOCS_CHANNEL/message-object) object. You can only edit messages that have been sent by the current user. Fires a [Message Update](#DOCS_GATEWAY/message-update) Gateway event.
+Edit a previously sent message. You can only edit messages that have been sent by the current user. Returns a [message](#DOCS_CHANNEL/message-object) object. Fires a [Message Update](#DOCS_GATEWAY/message-update) Gateway event.
 
 ###### JSON Params
 
@@ -291,7 +294,7 @@ Ack a message. Generally bots should **not** implement this route.
 
 ## Edit Channel Permissions % PUT /channels/{channel.id#DOCS_CHANNEL/guild-channel-object}/permissions/{overwrite.id}
 
-Edit the channel permission overwrites for a user or role in a channel. Only usable for guild channels. Requires the 'MANAGE_ROLES' permission. Returns a 204 empty response on success. For more information about permissions, see [permissions](#DOCS_PERMISSIONS/permissions)
+Edit the channel permission overwrites for a user or role in a channel. Only usable for guild channels. Requires the 'MANAGE_ROLES' permission. Returns a 204 empty response on success. For more information about permissions, see [permissions](#DOCS_PERMISSIONS/permissions).
 
 ###### JSON Params
 
@@ -302,11 +305,11 @@ Edit the channel permission overwrites for a user or role in a channel. Only usa
 
 ## Get Channel Invites % GET /channels/{channel.id#DOCS_CHANNEL/guild-channel-object}/invites
 
-Return a list of [invite](#DOCS_INVITE/invite-object) objects (with [invite metadata](#DOCS_INVITE/invite-metadata-object)) for the channel. Only usable for guild channels. Requires the 'MANAGE_CHANNELS' permission.
+Returns a list of [invite](#DOCS_INVITE/invite-object) objects (with [invite metadata](#DOCS_INVITE/invite-metadata-object)) for the channel. Only usable for guild channels. Requires the 'MANAGE_CHANNELS' permission.
 
 ## Create Channel Invite % POST /channels/{channel.id#DOCS_CHANNEL/guild-channel-object}/invites
 
-Create a new [invite](#DOCS_INVITE/invite-object) object for the channel. Only usable for guild channels. Requires the `CREATE_INSTANT_INVITE` permission. All JSON paramaters for this route are optional.
+Create a new [invite](#DOCS_INVITE/invite-object) object for the channel. Only usable for guild channels. Requires the `CREATE_INSTANT_INVITE` permission. All JSON paramaters for this route are optional. Returns an [invite](#DOCS_INVITE/invite-object) object.
 
 ###### JSON Params
 
@@ -314,13 +317,13 @@ Create a new [invite](#DOCS_INVITE/invite-object) object for the channel. Only u
 |-------|------|-------------|----------|
 | max_age | integer | duration of invite in seconds before expiry, or 0 for never | 86400 (24 hours) |
 | max_uses | integer | max number of uses or 0 for unlimited | 0 |
-| temporary | boolean | whether this invite only grants temporary membership | false |
-| xkcdpass | boolean | whether to generate an xkcdpass version of the invite code | false |
+| temporary | bool | whether this invite only grants temporary membership | false |
+| xkcdpass | bool | whether to generate an xkcdpass version of the invite code | false |
 
 ## Delete Channel Permission % DELETE /channels/{channel.id#DOCS_CHANNEL/guild-channel-object}/permissions/{overwrite.id#DOCS_CHANNEL/overwrite-object}
 
-Delete a channel permission overwrite for a user or role in a channel. Only usable for guild channels. Requires the 'MANAGE_ROLES' permission. Returns a 200 empty response on success. For more information about permissions, see [permissions](#DOCS_PERMISSIONS/permissions)
+Delete a channel permission overwrite for a user or role in a channel. Only usable for guild channels. Requires the 'MANAGE_ROLES' permission. Returns a 204 empty response on success. For more information about permissions, see [permissions](#DOCS_PERMISSIONS/permissions)
 
 ## Trigger Typing Indicator % POST /channels/{channel.id#DOCS_CHANNEL/channel-objects}/typing
 
-Post a typing indicator for the specified channel. Generally bots should **not** implement this route. However, if a bot is responding to a command and expects the computation to take a few seconds, this endpoint may be called to let the user know that the bot is processing their message. Fires a [Typing Start](#DOCS_GATEWAY/typing-start) Gateway event.
+Post a typing indicator for the specified channel. Generally bots should **not** implement this route. However, if a bot is responding to a command and expects the computation to take a few seconds, this endpoint may be called to let the user know that the bot is processing their message. Returns a 204 empty response on success. Fires a [Typing Start](#DOCS_GATEWAY/typing-start) Gateway event.

--- a/docs/resources/GUILD.md
+++ b/docs/resources/GUILD.md
@@ -54,7 +54,7 @@ Represents an Offline Guild, or a Guild whose information has not been provided 
 | Field | Type | Description |
 |-------|------|-------------|
 | id | snowflake | guild id |
-| unavailable | boolean | should always be true |
+| unavailable | bool | should always be true |
 
 ###### Example Unavailable Guild
 
@@ -118,8 +118,8 @@ Represents an Offline Guild, or a Guild whose information has not been provided 
 | id | snowflake | integration id |
 | name | string | integration name |
 | type | string | integration type (twitch, youtube, etc) |
-| enabled | boolean | is this integration enabled |
-| syncing | boolean | is this integration syncing |
+| enabled | bool | is this integration enabled |
+| syncing | bool | is this integration syncing |
 | role_id | snowflake | id that this integration uses for "subscribers" |
 | expire_behavior | integer | the behavior of expiring subscribers |
 | expire_grace_period | integer | the grace period before expiring subscribers |
@@ -145,8 +145,8 @@ Represents an Offline Guild, or a Guild whose information has not been provided 
 | id | snowflake | emoji id |
 | name | string | emoji name |
 | roles | array of [role object](#DOCS_PERMISSIONS/role-object) ids | roles this emoji is active for |
-| require_colons | boolean | whether this emoji must be wrapped in colons |
-| managed | boolean | whether this emoji is managed |
+| require_colons | bool | whether this emoji must be wrapped in colons |
+| managed | bool | whether this emoji is managed |
 
 ## Create Guild % POST /guilds
 
@@ -166,11 +166,11 @@ Create a new guild. Returns a [guild](#DOCS_GUILD/guild-object) object on succes
 
 ## Get Guild % GET /guilds/{guild.id#DOCS_GUILD/guild-object}
 
-Return a [guild](#DOCS_GUILD/guild-object) object for the given id.
+Returns the new [guild](#DOCS_GUILD/guild-object) object for the given id.
 
 ## Modify Guild % PATCH /guilds/{guild.id#DOCS_GUILD/guild-object}
 
-Modify a guilds settings. Returns a [guild](#DOCS_GUILD/guild-object) object on success. Fires a [Guild Update](#DOCS_GATEWAY/guild-update) Gateway event.
+Modify a guilds settings. Returns the updated [guild](#DOCS_GUILD/guild-object) object on success. Fires a [Guild Update](#DOCS_GATEWAY/guild-update) Gateway event.
 
 >info
 > All parameters to this endpoint are optional
@@ -190,11 +190,11 @@ Modify a guilds settings. Returns a [guild](#DOCS_GUILD/guild-object) object on 
 
 ## Delete Guild % DELETE /guilds/{guild.id#DOCS_GUILD/guild-object}
 
-Delete a guild permanently. User must be owner. Returns a [guild](#DOCS_GUILD/guild-object) object on success. Fires a [Guild Delete](#DOCS_GATEWAY/guild-delete) Gateway event.
+Delete a guild permanently. User must be owner. Returns the [guild](#DOCS_GUILD/guild-object) object on success. Fires a [Guild Delete](#DOCS_GATEWAY/guild-delete) Gateway event.
 
 ## Get Guild Channels % GET /guilds/{guild.id#DOCS_GUILD/guild-object}/channels
 
-Return a list of guild [channel](#DOCS_CHANNEL/guild-channel-object) objects.
+Returns a list of guild [channel](#DOCS_CHANNEL/guild-channel-object) objects.
 
 ## Create Guild Channel % POST /guilds/{guild.id#DOCS_GUILD/guild-object}/channels
 
@@ -210,7 +210,7 @@ Create a new [channel](#DOCS_CHANNEL/guild-channel-object) object for the guild.
 
 ## Modify Guild Channel % PATCH /guilds/{guild.id#DOCS_GUILD/guild-object}/channels
 
-Batch modify the position of channels in a guild. Requires the 'MANAGE_CHANNELS' permission. Fires a [Channel Update](#DOCS_GATEWAY/channel-update) Gateway event. This endpoint takes a JSON array of parameters in the following format:
+Batch modify the position of channels in a guild. Requires the 'MANAGE_CHANNELS' permission. Returns the updated [channel](#DOCS_CHANNEL/guild-channel-object) object on success. Fires a [Channel Update](#DOCS_GATEWAY/channel-update) Gateway event.
 
 ###### JSON Params
 
@@ -221,11 +221,11 @@ Batch modify the position of channels in a guild. Requires the 'MANAGE_CHANNELS'
 
 ## Get Guild Member % GET /guilds/{guild.id#DOCS_GUILD/guild-object}/members/{user.id#DOCS_USER/user-object}
 
-Return a [guild member](#DOCS_GUILD/guild-member-object) object for the specified user.
+Returns a [guild member](#DOCS_GUILD/guild-member-object) object for the specified user.
 
 ## List Guild Members % GET /guilds/{guild.id#DOCS_GUILD/guild-object}/members
 
-Return a list of [guild member](#GUILD/guild-member-object) objects that are members of the guild.
+Returns a list of [guild member](#GUILD/guild-member-object) objects that are members of the guild.
 
 >info
 > All parameters to this endpoint are optional
@@ -239,7 +239,7 @@ Return a list of [guild member](#GUILD/guild-member-object) objects that are mem
 
 ## Modify Guild Member % PATCH /guilds/{guild.id#DOCS_GUILD/guild-object}/members/{user.id#DOCS_USER/user-object}
 
-Modify attributes of a [guild member](#DOCS_GUILD/guild-member-object). Fires a [Guild Member Update](#DOCS_GATEWAY/guild-member-update) Gateway event.
+Modify attributes of a [guild member](#DOCS_GUILD/guild-member-object). Returns the updated [guild member](#DOCS_GUILD/guild-member-object) object on success. Fires a [Guild Member Update](#DOCS_GATEWAY/guild-member-update) Gateway event.
 
 >info
 > When moving members to channels, the API user _must_ have permissions to both connect to the
@@ -257,15 +257,15 @@ Modify attributes of a [guild member](#DOCS_GUILD/guild-member-object). Fires a 
 
 ## Remove Guild Member % DELETE /guilds/{guild.id#DOCS_GUILD/guild-object}/members/{user.id#DOCS_USER/user-object}
 
-Remove a member from a guild. Requires 'KICK_MEMBERS' permission. Fires a [Guild Member Remove](#DOCS_GATEWAY/guild-member-remove) Gateway event.
+Remove a member from a guild. Requires 'KICK_MEMBERS' permission. Returns a 204 empty response on success. Fires a [Guild Member Remove](#DOCS_GATEWAY/guild-member-remove) Gateway event.
 
 ## Get Guild Bans % GET /guilds/{guild.id#DOCS_GUILD/guild-object}/bans
 
-Return a list of [user](#DOCS_USER/user-object) objects that are banned from this guild. Requires the 'BAN_MEMBERS' permission.
+Returns a list of [user](#DOCS_USER/user-object) objects that are banned from this guild. Requires the 'BAN_MEMBERS' permission.
 
 ## Create Guild Ban % PUT /guilds/{guild.id#DOCS_GUILD/guild-object}/bans/{user.id#DOCS_USER/user-object}
 
-Create a guild ban, and optionally delete previous messages sent by the banned user. Requires the 'BAN_MEMBERS' permission. Fires a [Guild Ban Add](#DOCS_GATEWAY/guild-ban-add) Gateway event.
+Create a guild ban, and optionally delete previous messages sent by the banned user. Requires the 'BAN_MEMBERS' permission. Returns a 204 empty response on success. Fires a [Guild Ban Add](#DOCS_GATEWAY/guild-ban-add) Gateway event.
 
 ###### JSON Params
 
@@ -275,22 +275,22 @@ Create a guild ban, and optionally delete previous messages sent by the banned u
 
 ## Remove Guild Ban % DELETE /guilds/{guild.id#DOCS_GUILD/guild-object}/bans/{user.id#DOCS_USER/user-object}
 
-Remove the ban for a user. Requires the 'BAN_MEMBERS' permissions. Fires a [Guild Ban Remove](#DOCS_GATEWAY/guild-ban-remove) Gateway event.
+Remove the ban for a user. Requires the 'BAN_MEMBERS' permissions. Returns a 204 empty response on success. Fires a [Guild Ban Remove](#DOCS_GATEWAY/guild-ban-remove) Gateway event.
 
 ## Get Guild Roles % GET /guilds/{guild.id#DOCS_GUILD/guild-object}/roles
 
-Return a list of [role](#DOCS_PERMISSIONS/role-object) objects for the guild. Requires the 'MANAGE_ROLES' permission.
+Returns a list of [role](#DOCS_PERMISSIONS/role-object) objects for the guild. Requires the 'MANAGE_ROLES' permission.
 
 ## Create Guild Role % POST /guilds/{guild.id#DOCS_GUILD/guild-object}/roles
 
-Create a new empty [role](#DOCS_PERMISSIONS/role-object) object for the guild. Requires the 'MANAGE_ROLES' permission. Fires a [Guild Role Create](#DOCS_GATEWAY/guild-role-create) Gateway event.
+Create a new empty [role](#DOCS_PERMISSIONS/role-object) object for the guild. Requires the 'MANAGE_ROLES' permission. Returns the new [role](#DOCS_PERMISSIONS/role-object) object on success. Fires a [Guild Role Create](#DOCS_GATEWAY/guild-role-create) Gateway event.
 
 >warn
 > This endpoint only creates a blank role, it does not allow you to set attributes for the role on creation. Instead, you must create the role and then modify it with a PATCH request.
 
 ## Batch Modify Guild Role % PATCH /guilds/{guild.id#DOCS_GUILD/guild-object}/roles
 
-Batch modify a set of [role](#DOCS_PERMISSIONS/role-object) objects for the guild. Requires the 'MANAGE_ROLES' permission. Fires a [Guild Role Update](#DOCS_GATEWAY/guild-role-update) Gateway event.
+Batch modify a set of [role](#DOCS_PERMISSIONS/role-object) objects for the guild. Requires the 'MANAGE_ROLES' permission. Returns a list of all of the guild's [role](#DOCS_PERMISSIONS/role-object) objects on success. Fires a [Guild Role Update](#DOCS_GATEWAY/guild-role-update) Gateway event.
 
 >warn
 > This endpoint should *only* be used for modifying a batch set of roles.
@@ -310,7 +310,7 @@ This endpoint takes a JSON array of parameters in the following format:
 
 ## Modify Guild Role % PATCH /guilds/{guild.id#DOCS_GUILD/guild-object}/roles/{role.id#DOCS_PERMISSIONS/role-object}
 
-Modify a guild role. Requires the 'MANAGE_ROLES' permission. Returns the [role](#DOCS_PERMISSIONS/role-object) on success. Fires a [Guild Role Update](#DOCS_GATEWAY/guild-role-update) Gateway event.
+Modify a guild role. Requires the 'MANAGE_ROLES' permission. Returns the updated [role](#DOCS_PERMISSIONS/role-object) on success. Fires a [Guild Role Update](#DOCS_GATEWAY/guild-role-update) Gateway event.
 
 ###### JSON Params
 
@@ -328,7 +328,7 @@ Delete a guild role. Requires the 'MANAGE_ROLES' permission. Returns the [role](
 
 ## Get Guild Prune Count % GET /guilds/{guild.id#DOCS_GUILD/guild-object}/prune
 
-Return an object with one 'pruned' key indicating the number of members that would be removed in a prune operation. Requires the 'KICK_MEMBERS' permission.
+Returns an object with one 'pruned' key indicating the number of members that would be removed in a prune operation. Requires the 'KICK_MEMBERS' permission.
 
 ###### JSON Params
 
@@ -338,7 +338,7 @@ Return an object with one 'pruned' key indicating the number of members that wou
 
 ## Begin Guild Prune % POST /guilds/{guild.id#DOCS_GUILD/guild-object}/prune
 
-Begin a prune operation. Requires the 'KICK_MEMBERS' permission. Fires multiple [Guild Member Remove](#DOCS_GATEWAY/guild-member-remove) Gateway events.
+Begin a prune operation. Requires the 'KICK_MEMBERS' permission. Returns an object with one 'pruned' key indicating the number of members that were removed in the prune operation. Fires multiple [Guild Member Remove](#DOCS_GATEWAY/guild-member-remove) Gateway events.
 
 ###### JSON Params
 
@@ -348,19 +348,19 @@ Begin a prune operation. Requires the 'KICK_MEMBERS' permission. Fires multiple 
 
 ## Get Guild Voice Regions % GET /guilds/{guild.id#DOCS_GUILD/guild-object}/regions
 
-Return a list of [voice region](#DOCS_VOICE/voice-region-object) objects for the guild. Unlike the similar `/voice` route, this returns VIP servers when the guild is VIP-enabled.
+Returns a list of [voice region](#DOCS_VOICE/voice-region-object) objects for the guild. Unlike the similar `/voice` route, this returns VIP servers when the guild is VIP-enabled.
 
 ## Get Guild Invites % GET /guilds/{guild.id#DOCS_GUILD/guild-object}/invites
 
-Return a list of [invite](#DOCS_INVITE/invite-object) objects (with [invite metadata](#DOCS_INVITE/invite-metadata-object)) for the guild. Requires the 'MANAGE_GUILD' permission.
+Returns a list of [invite](#DOCS_INVITE/invite-object) objects (with [invite metadata](#DOCS_INVITE/invite-metadata-object)) for the guild. Requires the 'MANAGE_GUILD' permission.
 
 ## Get Guild Integrations % GET /guilds/{guild.id#DOCS_GUILD/guild-object}/integrations
 
-Return a list of [integration](#DOCS_GUILD/integration-object) objects for the guild. Requires the 'MANAGE_GUILD' permission.
+Returns a list of [integration](#DOCS_GUILD/integration-object) objects for the guild. Requires the 'MANAGE_GUILD' permission.
 
 ## Create Guild Integration % POST /guilds/{guild.id#DOCS_GUILD/guild-object}/integrations
 
-Attach an [integration](#DOCS_GUILD/integration-object) object from the current user to the guild. Requires the 'MANAGE_GUILD' permission. Fires a [Guild Integrations Update](#DOCS_GATEWAY/guild-integrations-update) Gateway event.
+Attach an [integration](#DOCS_GUILD/integration-object) object from the current user to the guild. Requires the 'MANAGE_GUILD' permission. Returns a 204 empty response on success. Fires a [Guild Integrations Update](#DOCS_GATEWAY/guild-integrations-update) Gateway event.
 
 ###### JSON Params
 
@@ -371,7 +371,7 @@ Attach an [integration](#DOCS_GUILD/integration-object) object from the current 
 
 ## Modify Guild Integration % PATCH /guilds/{guild.id#DOCS_GUILD/guild-object}/integrations/{integration.id#DOCS_GUILD/integration-object}
 
-Modify the behavior and settings of a [integration](#DOCS_INTEGRATION/integration-object) object for the guild. Requires the 'MANAGE_GUILD' permission. Fires a [Guild Integrations Update](#DOCS_GATEWAY/guild-integrations-update) Gateway event.
+Modify the behavior and settings of a [integration](#DOCS_INTEGRATION/integration-object) object for the guild. Requires the 'MANAGE_GUILD' permission. Returns a 204 empty response on success. Fires a [Guild Integrations Update](#DOCS_GATEWAY/guild-integrations-update) Gateway event.
 
 ###### JSON Params
 
@@ -383,16 +383,16 @@ Modify the behavior and settings of a [integration](#DOCS_INTEGRATION/integratio
 
 ## Delete Guild Integration % DELETE /guilds/{guild.id#DOCS_GUILD/guild-object}/integrations/{integration.id#DOCS_INTEGRATION/integration-object}
 
-Delete the attached [integration](#DOCS_INTEGRATION/integration-object) object for the guild. Requires the 'MANAGE_GUILD' permission. Fires a [Guild Integrations Update](#DOCS_GATEWAY/guild-integrations-update) Gateway event.
+Delete the attached [integration](#DOCS_INTEGRATION/integration-object) object for the guild. Requires the 'MANAGE_GUILD' permission. Returns a 204 empty response on success. Fires a [Guild Integrations Update](#DOCS_GATEWAY/guild-integrations-update) Gateway event.
 
 ## Sync Guild Integration % POST /guilds/{guild.id#DOCS_GUILD/guild-object}/integrations/{integration.id#DOCS_INTEGRATION/integration-object}/sync
 
-Sync an integration. Requires the 'MANAGE_GUILD' permission.
+Sync an integration. Requires the 'MANAGE_GUILD' permission. Returns a 204 empty response on success.
 
 ## Get Guild Embed % GET /guilds/{guild.id#DOCS_GUILD/guild-object}/embed
 
-Return a [guild embed](#DOCS_GUILD/guild-embed-object) object. Requires the 'MANAGE_GUILD' permission.
+Returns the [guild embed](#DOCS_GUILD/guild-embed-object) object. Requires the 'MANAGE_GUILD' permission.
 
 ## Modify Guild Embed % PATCH /guilds/{guild.id#DOCS_GUILD/guild-object}/embed
 
-Modify a [guild embed](#DOCS_GUILD/guild-embed-object) object for the guild. All attributes may be passed in with JSON and modified. Requires the 'MANAGE_GUILD' permission.
+Modify a [guild embed](#DOCS_GUILD/guild-embed-object) object for the guild. All attributes may be passed in with JSON and modified. Requires the 'MANAGE_GUILD' permission. Returns the updated [guild embed](#DOCS_GUILD/guild-embed-object) object.

--- a/docs/resources/INVITE.md
+++ b/docs/resources/INVITE.md
@@ -34,9 +34,9 @@ Represents a code that when used, adds a user to a guild.
 | uses | integer | number of times this invite has been used |
 | max_uses | integer | max number of times this invite can be used |
 | max_age | integer | duration (in seconds) after which the invite expires |
-| temporary | boolean | whether this invite only grants temporary membership |
+| temporary | bool | whether this invite only grants temporary membership |
 | created_at | datetime | when this invite was created |
-| revoked | boolean | whether this invite is revoked |
+| revoked | bool | whether this invite is revoked |
 
 ###### Example Invite Metadata
 
@@ -98,12 +98,12 @@ Represents the channel an invite is for.
 
 ## Get Invite % GET /invites/{invite.id#DOCS_INVITE/invite-object}
 
-Return an [invite object](#DOCS_INVITE/invite-object) for the given id.
+Returns an [invite object](#DOCS_INVITE/invite-object) for the given id.
 
 ## Delete Invite % DELETE /invites/{invite.id#DOCS_INVITE/invite-object}
 
-Delete an invite. Requires the `MANAGE_CHANNELS` permission.
+Delete an invite. Requires the `MANAGE_CHANNELS` permission. Returns an [invite object](#DOCS_INVITE/invite-object) on success.
 
 ## Accept Invite % POST /invites/{invite.id#DOCS_INVITE/invite-object}
 
-Accept an invite. This is not available to bot accounts, and requires the `guilds.join` OAuth2 scope for normal users.
+Accept an invite. This is not available to bot accounts, and requires the `guilds.join` OAuth2 scope to accept on behalf of normal users. Returns an [invite object](#DOCS_INVITE/invite-object) on success.

--- a/docs/resources/USER.md
+++ b/docs/resources/USER.md
@@ -50,7 +50,7 @@ A brief version of a [guild](#DOCS_GUILD/guild-object) object
 | id | snowflake | guild.id |
 | name | string | guild.name |
 | icon | string | guild.icon |
-| owner | boolean | true if the user is an owner of the guild |
+| owner | bool | true if the user is an owner of the guild |
 | permissions | integer | bitwise of the user's enabled/disabled permissions |
 
 ###### Example User Guild
@@ -67,7 +67,7 @@ A brief version of a [guild](#DOCS_GUILD/guild-object) object
 
 ## Query Users % GET /users
 
-Return a list of [user](#DOCS_USER/user-object) objects for a given query. Only returns users that share a mutual guild with the requestor.
+Returns a list of [user](#DOCS_USER/user-object) objects for a given query. Only returns users that share a mutual guild with the requestor.
 
 ###### HTTP Params
 
@@ -78,15 +78,15 @@ Return a list of [user](#DOCS_USER/user-object) objects for a given query. Only 
 
 ## Get Current User % GET /users/{@me#DOCS_USER/user-object}
 
-Return the [user](#DOCS_USER/user-object) object of the requestors account. For OAuth2, this requires the `identify` scope, which will return the object _without_ an email, and optionally the `email` scope, which returns the object _with_ an email.
+Returns the [user](#DOCS_USER/user-object) object of the requestors account. For OAuth2, this requires the `identify` scope, which will return the object _without_ an email, and optionally the `email` scope, which returns the object _with_ an email.
 
 ## Get User % GET /users/{user.id#DOCS_USER/user-object}
 
-Return a [user](#DOCS_USER/user-object) for a given user ID.
+Returns a [user](#DOCS_USER/user-object) for a given user ID.
 
 ## Modify Current User % PATCH /users/{@me#DOCS_USER/user-object}
 
-Modify the requestors user account settings.
+Modify the requestors user account settings. Returns a [user](#DOCS_USER/user-object) object on success.
 
 ###### JSON Params
 
@@ -97,19 +97,19 @@ Modify the requestors user account settings.
 
 ## Get Current User Guilds % GET /users/{@me#DOCS_USER/user-object}/guilds
 
-Return a list of [user guild](#DOCS_USER/user-guild-object) objects the current user is a member of. Requires the `guilds` OAuth2 scope.
+Returns a list of [user guild](#DOCS_USER/user-guild-object) objects the current user is a member of. Requires the `guilds` OAuth2 scope.
 
 ## Leave Guild % DELETE /users/{@me#DOCS_USER/user-object}/guilds/{guild.id#DOCS_GUILD/guild-object}
 
-Leave a guild.
+Leave a guild. Returns a 204 empty response on success.
 
 ## Get User DMs % GET /users/{@me#DOCS_USER/user-object}/channels
 
-Return a list of  [DM](#DOCS_CHANNEL/dm-channel-object) channel objects.
+Returns a list of [DM](#DOCS_CHANNEL/dm-channel-object) channel objects.
 
 ## Create DM % POST /users/{@me#DOCS_USER/user-object}/channels
 
-Create a new [DM](#DOCS_CHANNEL/dm-channel-object) channel.
+Create a new DM channel with a user. Returns a [DM channel](#DOCS_CHANNEL/dm-channel-object) object.
 
 ###### JSON Params
 
@@ -119,4 +119,4 @@ Create a new [DM](#DOCS_CHANNEL/dm-channel-object) channel.
 
 ## Get Users Connections % GET /users/{@me#DOCS_USER/user-object}/connections
 
-Return a list of [connection](#DOCS_USER/connection-object) objects. Requires the `connections` OAuth2 scope.
+Returns a list of [connection](#DOCS_USER/connection-object) objects. Requires the `connections` OAuth2 scope.

--- a/docs/resources/VOICE.md
+++ b/docs/resources/VOICE.md
@@ -48,4 +48,4 @@ Used to represent a users voice connection status.
 
 ## List Voice Regions % GET /voice/regions
 
-Return an array of [voice region](#DOCS_VOICE/voice-region-object) objects that can be used when creating servers.
+Returns an array of [voice region](#DOCS_VOICE/voice-region-object) objects that can be used when creating servers.

--- a/docs/topics/GATEWAY.md
+++ b/docs/topics/GATEWAY.md
@@ -87,7 +87,7 @@ Used to trigger the initial handshake with the gateway.
 |-------|------|-------------|
 | token | string | authentication token |
 | properties | object | connection properties |
-| compress | boolean | whether this connection supports compression of the initial ready packet |
+| compress | bool | whether this connection supports compression of the initial ready packet |
 | large_threshold | integer | value between 50 and 250, total number of members where the gateway will stop sending offline members in the guild member list |
 
 ###### Example Gateway Identify Example
@@ -139,8 +139,8 @@ Sent when a client wants to join, move, or disconnect from a voice channel.
 |-------|------|-------------|
 | guild_id | snowflake | id of the guild |
 | channel_id | ?snowflake | id of the voice channel client wants to join (null if disconnecting) |
-| self_mute | boolean | is the client muted |
-| self_deaf | boolean | is the client deafened |
+| self_mute | bool | is the client muted |
+| self_deaf | bool | is the client deafened |
 
 ###### Gateway Voice State Update Example
 
@@ -320,7 +320,7 @@ Sent when a guild becomes unavailable during a guild outage, or when the user le
 | Field | Type | Description |
 |-------|------|-------------|
 | id | snowflake | id of the guild |
-| unavailable | boolean | whether the guild is unavailable, should always be true. if not set, this signifies that the user was removed from the guild |
+| unavailable | bool | whether the guild is unavailable, should always be true. if not set, this signifies that the user was removed from the guild |
 
 ### Guild Integrations Update
 


### PR DESCRIPTION
Consistently use bool instead of boolean
Added missing returns descriptions to endpoints
Moved Delete/Close Channel warning to warn block
