### PR TITLE
Editing overwrite permissions requires 'type'

### DIFF
--- a/docs/resources/CHANNEL.md
+++ b/docs/resources/CHANNEL.md
@@ -307,6 +307,7 @@ Edit the channel permission overwrites for a user or role in a channel. Only usa
 |-------|------|-------------|
 | allow | integer | the bitwise value of all allowed permissions |
 | deny | integer | the bitwise value of all disallowed permissions |
+| type | string | "member" for a user or "role" for a role |
 
 ## Get Channel Invites % GET /channels/{channel.id#DOCS_CHANNEL/guild-channel-object}/invites
 


### PR DESCRIPTION
Not having the field 'type' will result in a 500 error with as message`'type'` (including quotes).
When it isn't "role" or "member", a 404 error with as message `Unknown Overwrite` _(code 10009)_.
Specifying "role" for a user or "user" for a role will result in the same error.
