### PR TITLE
Fix a typo

### DIFF
--- a/docs/resources/Invite.md
+++ b/docs/resources/Invite.md
@@ -41,7 +41,7 @@ Represents a code that when used, adds a user to a guild.
 ```json
 {
 	"inviter": {},
-	"users": 0,
+	"uses": 0,
 	"max_uses": 0,
 	"max_age": 0,
 	"temporary": false,

--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -23,7 +23,7 @@ data:image/jpeg;base64,MY_BASE64_IMAGE_DATA_HERE
 | username | string | the user's username, not unique across the platform | identify |
 | discriminator | string | the user's 4-digit discord-tag | identify |
 | avatar | string | the user's avatar hash | identify |
-| bot | bool | whether the user belongs to a OAuth2 application | identify |
+| bot | bool | whether the user belongs to an OAuth2 application | identify |
 | mfa_enabled | bool | whether the user has two factor enabled on their account | identify |
 | verified | bool | whether the email on this account has been verified | email |
 |  email | string | the user's email | email |


### PR DESCRIPTION
For invite metadata object, change "users" to "uses" in JSON response example
