### PR TITLE
Gateway Dispatch event typo.

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -402,7 +402,7 @@ Sent when a user is unbanned from a guild. The inner payload is a [user](#DOCS_U
 
 ### Guild Emojis Update
 
-Sent when a guilds emojis have been updated.
+Sent when a guild's emojis have been updated.
 
 ###### Guild Emojis Update Event Fields
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -400,11 +400,11 @@ Sent when a user is banned from a guild. The inner payload is a [user](#DOCS_USE
 
 Sent when a user is unbanned from a guild. The inner payload is a [user](#DOCS_USER/user-object) object, with an extra guild_id key.
 
-### Guild Emoji Update
+### Guild Emojis Update
 
 Sent when a guilds emojis have been updated.
 
-###### Guild Emoji Update Event Fields
+###### Guild Emojis Update Event Fields
 
 | Field | Type | Description |
 |-------|------|-------------|


### PR DESCRIPTION
There is a discrepancy between the docs and payload received. The docs show "Guild Emoji Update", while the payload shows "GUILD_EMOJIS_UPDATE".
