### PR TITLE
Added Discordia to libraries

### DIFF
--- a/docs/topics/Libraries.md
+++ b/docs/topics/Libraries.md
@@ -9,6 +9,7 @@ The Discord team curates the following list of officially vetted libraries that 
 | [Discord.Net](https://github.com/RogueException/Discord.Net) | C# |
 | [Discord4j](https://github.com/austinv11/Discord4J) | Java |
 | [JDA](https://github.com/DV8FromTheWorld/JDA) | Java |
+| [Discordia](https://github.com/SinisterRectus/Discordia) | Lua |
 | [discord.js](https://github.com/hydrabolt/discord.js) | NodeJS |
 | [Eris](https://github.com/abalabahaha/eris) | NodeJS |
 | [DiscordPHP](https://github.com/teamreflex/DiscordPHP) | PHP |


### PR DESCRIPTION
[Discordia](https://github.com/SinisterRectus/Discordia) has been completely rewritten, and includes updated ratelimit handling. The current version is 1.0.0-rc.1. If all goes well, a final release should be out within a week.

Relevant code:

- [Mutex class](https://github.com/SinisterRectus/Discordia/blob/1784ce38f71491809f9714e718d0ad88353d8979/discordia/utils/Mutex.lua)
- [API class that handles requests](https://github.com/SinisterRectus/Discordia/blob/6dacade242432231f8ee86026729a7da1bdc0269/discordia/client/API.lua)
- [General request method](https://github.com/SinisterRectus/Discordia/blob/6dacade242432231f8ee86026729a7da1bdc0269/discordia/client/API.lua#L65)

Ratelimiting is intended to behave in the following manner:

Per-Route
- Mutex objects are used to sequence requests per-route.
- A minimum delay for unlocking a mutex is maintained (default: 300 ms).
- If `X-RateLimit-Remaining` is `0`, the delay is set to the difference between the `Date` and `X-RateLimit-Reset` headers.
- If a 429 is encountered, the delay is set to the `retry_after` attribute in the JSON response, and the request is queued for a retry with a limit of 5 attempts.

Global
- Requests are not globally sequenced until after a global 429 is encountered.
- If a global 429 is encountered according to the `global` attribute of the JSON response, a global mutex locks until the `retry_after` time has elapsed.
- The global mutex will remain in use until its queue has emptied with a minimum default delay of 10 ms between requests.