### PR TITLE
Add DiscordGo to the list of libraries.

### DIFF
--- a/docs/topics/Libraries.md
+++ b/docs/topics/Libraries.md
@@ -7,6 +7,7 @@ The Discord team curates the following list of officially vetted libraries that 
 | [discordcr](https://github.com/meew0/discordcr) | Crystal |
 | [dscord](https://github.com/b1naryth1ef/dscord) | D |
 | [Discord.Net](https://github.com/RogueException/Discord.Net) | C# |
+| [DiscordGo](https://github.com/bwmarrin/discordgo) |Go |
 | [Discord4j](https://github.com/austinv11/Discord4J) | Java |
 | [JDA](https://github.com/DV8FromTheWorld/JDA) | Java |
 | [discord.js](https://github.com/hydrabolt/discord.js) | NodeJS |


### PR DESCRIPTION
Sorry this one took a while, I wanted to make sure the rate limiting was tested thoroughly.

We respect all the rate limit headers now, here's the code that handles it:
https://github.com/bwmarrin/discordgo/blob/master/ratelimit.go

Our limiting respects routes and the global lock.