### PR TITLE
Clarify timestamp in TYPING_START.

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -578,7 +578,7 @@ Sent when a user starts typing in a channel.
 |-------|------|-------------|
 | channel_id | snowflake | id of the channel |
 | user_id | snowflake | id of the user |
-| timestamp | timestamp | when the user started typing |
+| timestamp | integer | unix time (in seconds) of when the user started typing |
 
 ### User Settings Update
 


### PR DESCRIPTION
The type 'timestamp' is used in the Message object to refer to ISO format
strings and is being overloaded here to refer to Unix time.