### PR TITLE
Doc. HTTP requirement for gateway login

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -70,7 +70,7 @@ User-Agent: DiscordBot ($url, $versionNumber)
 The HTTP API implements a process for limiting and preventing excessive requests in accordance with [RFC 6585](https://tools.ietf.org/html/rfc6585#section-4). API users that regularly hit and ignore rate limits will have their API keys revoked, and be blocked from the platform. For more information on rate limiting of requests, please see the [Rate Limits](#DOCS_RATE_LIMITS/rate-limits) section.
 
 >warn
-> New bot accounts must be authorized through the Gateway API once before being used to send messages through the HTTP API.
+> A bot account must connect to the gateway (wss://gateway.discord.gg) at least once before being able to send messages.
 
 ## Gateway (WebSocket) API
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -69,6 +69,9 @@ User-Agent: DiscordBot ($url, $versionNumber)
 
 The HTTP API implements a process for limiting and preventing excessive requests in accordance with [RFC 6585](https://tools.ietf.org/html/rfc6585#section-4). API users that regularly hit and ignore rate limits will have their API keys revoked, and be blocked from the platform. For more information on rate limiting of requests, please see the [Rate Limits](#DOCS_RATE_LIMITS/rate-limits) section.
 
+>warn
+> New bot accounts must connect to the API via the gateway at least once before sending messages through the HTTP REST API. Once the bot makes a successful connection, it can then be used through the HTTP REST API without issue, and does not need to remain connected to the gateway for use. This requirement is not needed if you don't intend to send messages.
+
 ## Gateway (WebSocket) API
 
 Discord's Gateway API is used for maintaining persistent, stateful websocket connections between your client and our servers. These connections are used for sending and receiving real-time events your client can use to track and update local state. The Gateway API uses secure websocket connections as specified in [RFC 6455](https://tools.ietf.org/html/rfc6455). For information on opening Gateway connections, please see the [Gateway API](#DOCS_GATEWAY/gateways) section.

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -70,7 +70,7 @@ User-Agent: DiscordBot ($url, $versionNumber)
 The HTTP API implements a process for limiting and preventing excessive requests in accordance with [RFC 6585](https://tools.ietf.org/html/rfc6585#section-4). API users that regularly hit and ignore rate limits will have their API keys revoked, and be blocked from the platform. For more information on rate limiting of requests, please see the [Rate Limits](#DOCS_RATE_LIMITS/rate-limits) section.
 
 >warn
-> New bot accounts must connect to the API via the gateway at least once before sending messages through the HTTP REST API. Once the bot makes a successful connection, it can then be used through the HTTP REST API without issue, and does not need to remain connected to the gateway for use. This requirement is not needed if you don't intend to send messages.
+> New bot accounts must be authorized through the Gateway API once before being used to send messages through the HTTP API.
 
 ## Gateway (WebSocket) API
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -70,7 +70,7 @@ User-Agent: DiscordBot ($url, $versionNumber)
 The HTTP API implements a process for limiting and preventing excessive requests in accordance with [RFC 6585](https://tools.ietf.org/html/rfc6585#section-4). API users that regularly hit and ignore rate limits will have their API keys revoked, and be blocked from the platform. For more information on rate limiting of requests, please see the [Rate Limits](#DOCS_RATE_LIMITS/rate-limits) section.
 
 >warn
-> A bot account must connect to the gateway (wss://gateway.discord.gg) at least once before being able to send messages.
+> A bot account must connect and identify to the gateway (wss://gateway.discord.gg) at least once before being able to send messages.
 
 ## Gateway (WebSocket) API
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -70,7 +70,7 @@ User-Agent: DiscordBot ($url, $versionNumber)
 The HTTP API implements a process for limiting and preventing excessive requests in accordance with [RFC 6585](https://tools.ietf.org/html/rfc6585#section-4). API users that regularly hit and ignore rate limits will have their API keys revoked, and be blocked from the platform. For more information on rate limiting of requests, please see the [Rate Limits](#DOCS_RATE_LIMITS/rate-limits) section.
 
 >warn
-> A bot account must connect and identify to the gateway (wss://gateway.discord.gg) at least once before being able to send messages.
+> A bot account must connect and identify to a [Gateway](#DOCS_GATEWAY/connecting) at least once before being able to send messages.
 
 ## Gateway (WebSocket) API
 


### PR DESCRIPTION
Document the requirement for needing to connect to the gateway at least once before using the HTTP REST API for certain POST actions.

PR for Issue #198.