### PR TITLE
Add discord.py to the list of libraries.

### DIFF
--- a/docs/topics/Libraries.md
+++ b/docs/topics/Libraries.md
@@ -14,6 +14,7 @@ The Discord team curates the following list of officially vetted libraries that 
 | [discord.js](https://github.com/hydrabolt/discord.js) | NodeJS |
 | [Eris](https://github.com/abalabahaha/eris) | NodeJS |
 | [DiscordPHP](https://github.com/teamreflex/DiscordPHP) | PHP |
+| [discord.py](https://github.com/Rapptz/discord.py) | Python |
 | [disco](https://github.com/b1naryth1ef/disco) | Python |
 | [discordrb](https://github.com/meew0/discordrb) | Ruby |
 | [discord-rs](https://github.com/SpaceManiac/discord-rs) | Rust |


### PR DESCRIPTION
I implement the headers now. Basically just a modified version of my previous scheme (i.e. lock all coroutines until the bucket is released).

It's released on PyPI under v0.16.1.

Source can be found here: https://github.com/Rapptz/discord.py/commit/fdd835e8f1e0a9651dd11587d9fe6d991f995c34