### PR TITLE
Document breaking change with bulk delete endpoint

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -388,7 +388,7 @@ Delete multiple messages in a single request. This endpoint can only be used on 
 The gateway will ignore any individual messages that do not exist or do not belong to this channel, but these will count towards the minimum and maximum message count. Duplicate snowflakes will only be counted once for these limits.
 
 > warn
-> This endpoint will not delete messages older than 2 weeks.
+> This endpoint will not delete messages older than 2 weeks, and will fail if any message provided is older than that.
 > An endpoint will be added in the future to prune messages older than 2 weeks from a channel.
 
 ###### JSON Params

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -387,6 +387,10 @@ Delete multiple messages in a single request. This endpoint can only be used on 
 
 The gateway will ignore any individual messages that do not exist or do not belong to this channel, but these will count towards the minimum and maximum message count. Duplicate snowflakes will only be counted once for these limits.
 
+> warn
+> This endpoint will not delete messages older than 2 weeks due to a [breaking change](https://github.com/hammerandchisel/discord-api-docs/issues/208).
+> An endpoint will be added in the future to prune messages older than 2 weeks from a channel.
+
 ###### JSON Params
 
 | Field | Type | Description |

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -388,7 +388,7 @@ Delete multiple messages in a single request. This endpoint can only be used on 
 The gateway will ignore any individual messages that do not exist or do not belong to this channel, but these will count towards the minimum and maximum message count. Duplicate snowflakes will only be counted once for these limits.
 
 > warn
-> This endpoint will not delete messages older than 2 weeks due to a [breaking change](https://github.com/hammerandchisel/discord-api-docs/issues/208).
+> This endpoint will not delete messages older than 2 weeks.
 > An endpoint will be added in the future to prune messages older than 2 weeks from a channel.
 
 ###### JSON Params

--- a/docs/topics/Response_Codes.md
+++ b/docs/topics/Response_Codes.md
@@ -68,6 +68,7 @@ Along with the HTTP error code, our API can also return more detailed error code
 | 50015 | Note is too long |
 | 50016 | Provided too few or too many messages to delete. Must provide at least 2 and fewer than 100 messages to delete. |
 | 50019 | A message can only be pinned to the channel it was sent in |
+| 50034 | A message provided was too old to bulk delete |
 | 90001 | Reaction Blocked |
 
 ###### JSON Error Response Example


### PR DESCRIPTION
Since there isn't any endpoint for purging messages in a channel, there's no way to document it, so for now I've documented that the endpoint won't delete messages older than 2 weeks.

In the future the the github link could be replaced with a link to the "purge channel" endpoint referenced in #208.