### PR TITLE
Add permissions calculator link

### DIFF
--- a/docs/topics/OAuth2.md
+++ b/docs/topics/OAuth2.md
@@ -72,6 +72,8 @@ https://discordapp.com/api/oauth2/authorize?client_id=157730590492196864&scope=b
 
 `client_id` is your _bot_ application's ID and permissions is an integer following the [permissions](#DOCS_PERMISSIONS/bitwise-permission-flags) format.
 
+You can also use [this permissions calculator](https://discordapi.com/permissions.html) to generate a URL for your bot.
+
 ### Adding Webhooks to Channels
 
 A URL can be generated that redirects authenticated users to the add-webhook flow, by using the following format (this utilizes the OAuth2 authentication authorization code flow, which requires a server-side application):

--- a/docs/topics/Permissions.md
+++ b/docs/topics/Permissions.md
@@ -4,6 +4,8 @@ Permissions in Discord are a way to limit and grant certain abilities to users. 
 
 Permissions in Discord are stored within a 53-bit integer and are calculated using bitwise operations. Permissions for a user in a given channel can be calculated by ORing together their guild-level role permission integers, and their channel-level role permission integers. For more information about bitwise operations and flags, see [this page](https://en.wikipedia.org/wiki/Bit_field).
 
+You can also use [this permissions calculator](https://discordapi.com/permissions.html) to calculate the appropriate integer for a set of permissions.
+
 ###### Bitwise Permission Flags
 
 | Permission | Value | Description |


### PR DESCRIPTION
This gem appears only in the Discord API server faq, and I thought it should also appear in the docs because it's really useful. 

I wasn't sure if the authors' names should appear here, but I decided to omit them because their names appear on the calculator when the window is large enough.

I think it falls under either 2 or 3 in CONTRIBUTING.md ("clarifying...complicated explanations", "missing pieces"), but I understand if this PR is rejected because the calculator isn't official. 