### PR TITLE
Update List Guild Members documentation for the sake of compatibility

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -264,7 +264,7 @@ Returns a list of [guild member](#GUILD/guild-member-object) objects that are me
 | Field | Type | Description | Default |
 |-------|------|-------------|---------|
 | limit | integer | max number of members to return (1-1000) | 1 |
-| after | integer | the highest user id in the previous page | 0 |
+| after | snowflake | the highest user id in the previous page | 0 |
 
 ## Add Guild Member % PUT /guilds/{guild.id#DOCS_GUILD/guild-object}/members/{user.id#DOCS_USER/user-object}
 


### PR DESCRIPTION
`after` should be a user id according to the description, which is usually a snowflake, not simply an integer.
While I understand that `after` **can** be *any* integer by design, due to the type definition a PHP library - which validates these fields based on these docs before sending them to the API - throws an error, because on 32-bit platforms the Guild ID, when cast to the integer from string, overflows and turns into a float, no longer satisfying the integer restriction.

Changing the field type to `snowflake` would use the validation that's used everywhere else for user IDs preventing this error.