### PR TITLE
Link to Avatar Data where raw data is used

### DIFF
--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -7,11 +7,13 @@ although similar, bot users are automated users that are "owned" by other users.
 
 ## Avatar Data
 
-Avatars are base64 encoded jpeg images, in the following format:
+Avatar data is a [Data URI scheme](https://en.wikipedia.org/wiki/Data_URI_scheme) and supports JPG, GIF, and PNG formats. An example Data URI format is:
 
 ```
-data:image/jpeg;base64,MY_BASE64_IMAGE_DATA_HERE
+data:image/jpeg;base64,BASE64_ENCODED_JPEG_IMAGE_DATA
 ```
+
+Ensure you use the proper header type (`image/jpeg`, `image/png`, `image/gif`) that matches the image data being provided.
 
 ## User Object
 

--- a/docs/resources/Webhook.md
+++ b/docs/resources/Webhook.md
@@ -46,7 +46,7 @@ Create a new webhook. Returns a [webhook](#DOCS_WEBHOOK/webhook-object) object o
 | Field | Type | Description |
 |-------|------|-------------|
 | name | string | name of the webhook (2-100 characters) |
-| avatar | string | base64 128x128 jpeg image for the default webhook avatar |
+| avatar | [avatar data](#DOCS_USER/avatar-data) | base64 128x128 jpeg image for the default webhook avatar |
 
 ## Get Channel Webhooks % GET /channels/{channel.id#DOCS_CHANNEL/channel-object}/webhooks
 


### PR DESCRIPTION
Based off the description of the `avatar` field I was passing a base64 encoded version of the blob, which never worked. It wasn't until someone mentioned that Modify Current User also sets Avatar Data that I did some research into the User API format. There I discovered reference to the Avatar Data section only present at the top of the User resource section. Since Webhooks share the data format it is much more beneficial to also link to the Avatar Data section, instead of merely calling it a "string".

For the current doc flow, see:

https://discordapp.com/developers/docs/resources/webhook#create-webhook

And compare to:

https://discordapp.com/developers/docs/resources/user#modify-current-user

Which links to (higher up on the page):

https://discordapp.com/developers/docs/resources/user#avatar-data