### PR TITLE
removing misleading and redundant voice state update example

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -627,18 +627,6 @@ Sent when properties about the user change. Inner payload is a [user](#DOCS_USER
 
 Sent when someone joins/leaves/moves voice channels. Inner payload is a [voice state](#DOCS_VOICE/voice-state-object) object.
 
->warn
-> `user_id` and `session_id` are the only required fields for this event. All other fields from [voice state](#DOCS_VOICE/voice-state-object) object are optional.
-
-###### Example Voice State Update Event
-
-```json
-{
-	"user_id": "104694319306248192",
-	"session_id": "my_session_id"
-}
-```
-
 ### Voice Server Update
 
 Sent when a guild's voice server is updated. This is sent when initially connecting to voice, and when the current voice instance fails over to a new server.

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -627,6 +627,9 @@ Sent when properties about the user change. Inner payload is a [user](#DOCS_USER
 
 Sent when someone joins/leaves/moves voice channels. Inner payload is a [voice state](#DOCS_VOICE/voice-state-object) object.
 
+>warn
+> `user_id` and `session_id` are the only required fields for this event. All other fields from [voice state](#DOCS_VOICE/voice-state-object) object are optional.
+
 ###### Example Voice State Update Event
 
 ```json


### PR DESCRIPTION
I found this example to be misleading, because it implies that there are only 2 fields in the message, and if you put all the fields there, it's redundant, because it's already defined on the linked page.