### PR TITLE
Clarify POST /api/invites requirements

### DIFF
--- a/docs/resources/Invite.md
+++ b/docs/resources/Invite.md
@@ -106,4 +106,7 @@ Delete an invite. Requires the `MANAGE_CHANNELS` permission. Returns an [invite 
 
 ## Accept Invite % POST /invites/{invite.code#DOCS_INVITE/invite-object}
 
-Accept an invite. This is not available to bot accounts, and requires the `guilds.join` OAuth2 scope to accept on behalf of normal users. Returns an [invite object](#DOCS_INVITE/invite-object) on success.
+Accept an invite. Requires the `guilds.join` OAuth2 scope to accept on behalf of normal users. Returns an [invite object](#DOCS_INVITE/invite-object) on success.
+
+>warn
+> This endpoint requires your application has a linked bot account, and that the bot account is present in the server the invite belongs to.

--- a/docs/resources/Invite.md
+++ b/docs/resources/Invite.md
@@ -106,7 +106,4 @@ Delete an invite. Requires the `MANAGE_CHANNELS` permission. Returns an [invite 
 
 ## Accept Invite % POST /invites/{invite.code#DOCS_INVITE/invite-object}
 
-Accept an invite. Requires the `guilds.join` OAuth2 scope to accept on behalf of normal users. Returns an [invite object](#DOCS_INVITE/invite-object) on success.
-
->warn
-> This endpoint requires your application has a linked bot account, and that the bot account is present in the server the invite belongs to.
+Accept an invite. This requires the `guilds.join` OAuth2 scope to be able to accept invites on behalf of normal users (via an OAuth2 Bearer token). Bot users are disallowed. Returns an [invite object](#DOCS_INVITE/invite-object) on success.


### PR DESCRIPTION
As described in [Jake's comment](https://github.com/hammerandchisel/discord-api-docs/issues/258#issuecomment-298264441) in #258 , I don't think this was immediately clear in this endpoints documentation.

I removed the language "This is not available to bot accounts" - by which it is actually referring to `Bot` tokens I believe (i.e., the request is made through `Bearer`) - but a bot account is required to exist and it might seem contradictory or confusing with the note this PR adds. 