### PR TITLE
Add Response Code 50021

### DIFF
--- a/docs/topics/Response_Codes.md
+++ b/docs/topics/Response_Codes.md
@@ -68,6 +68,7 @@ Along with the HTTP error code, our API can also return more detailed error code
 | 50015 | Note is too long |
 | 50016 | Provided too few or too many messages to delete. Must provide at least 2 and fewer than 100 messages to delete. |
 | 50019 | A message can only be pinned to the channel it was sent in |
+| 50021 | Cannot execute action on a system message |
 | 50034 | A message provided was too old to bulk delete |
 | 90001 | Reaction Blocked |
 


### PR DESCRIPTION
Can't seem to find any documentation or implementation of this.

```{"code": 50021, "message": "Cannot execute action on a system message"}```

For reference, this happened on an event to add a message reaction and hit a message that happened to be a pinned message notification ["user pinned a message to this channel. See all the pins."] - which is a system message that cannot have a reaction added to it.