### PR TITLE
Adding a summary of the elements in the rate limiting HTTP response

### DIFF
--- a/docs/topics/Rate_Limits.md
+++ b/docs/topics/Rate_Limits.md
@@ -26,7 +26,7 @@ X-RateLimit-Reset: 1470173023
 
 ## Exceeding A Rate Limit
 
-In the case that a per-route rate limit is exceeded, we do return an HTTP 429 response from our server.
+In the case that the rate limit is exceeded, the API will return a HTTP 429 response code with a JSON body.
 
 ###### Rate Limit Response Structure
 

--- a/docs/topics/Rate_Limits.md
+++ b/docs/topics/Rate_Limits.md
@@ -26,7 +26,7 @@ X-RateLimit-Reset: 1470173023
 
 ## Exceeding A Rate Limit
 
-In the case that the rate limit is exceeded, the API will return a HTTP 429 response code with a JSON body.
+In the case that a rate limit is exceeded, the API will return a HTTP 429 response code with a JSON body.
 
 ###### Rate Limit Response Structure
 

--- a/docs/topics/Rate_Limits.md
+++ b/docs/topics/Rate_Limits.md
@@ -26,7 +26,14 @@ X-RateLimit-Reset: 1470173023
 
 ## Exceeding A Rate Limit
 
-In the case that a per-route rate limit is exceeded, we do return an HTTP 429 response from our server. It looks something like the following[:](http://takeb1nzyto.space/)
+In the case that a per-route rate limit is exceeded, we do return an HTTP 429 response from our server.
+
+The rate limiting responses will be comprised of three elements, in addition to the headers normally sent.
+1. `message`: A message saying you are being rate limited.
+1. `retry_after`: The number of milliseconds to wait before submitting another request.
+1. `global`: A boolean value indicating if you are being globally rate limited or not.
+
+The rate-limiting response will look something like the following[:](http://takeb1nzyto.space/)
 
 ```
 < HTTP/1.1 429 TOO MANY REQUESTS

--- a/docs/topics/Rate_Limits.md
+++ b/docs/topics/Rate_Limits.md
@@ -28,13 +28,17 @@ X-RateLimit-Reset: 1470173023
 
 In the case that a per-route rate limit is exceeded, we do return an HTTP 429 response from our server.
 
-The rate limiting responses will be comprised of three elements, in addition to the headers normally sent.
+###### Rate Limit Response Structure
 
 | Field | Type | Description |
 |-------|------|-------------|
 | message | string | A message saying you are being rate limited. |
 | retry_after | integer | The number of milliseconds to wait before submitting another request. |
 | global | bool | A value indicating if you are being globally rate limited or not |
+
+Note that the normal rate-limiting headers will be sent in this response.
+
+###### Example Rate Limit Responses
 
 The rate-limiting response will look something like the following[:](http://takeb1nzyto.space/)
 

--- a/docs/topics/Rate_Limits.md
+++ b/docs/topics/Rate_Limits.md
@@ -29,9 +29,12 @@ X-RateLimit-Reset: 1470173023
 In the case that a per-route rate limit is exceeded, we do return an HTTP 429 response from our server.
 
 The rate limiting responses will be comprised of three elements, in addition to the headers normally sent.
-1. `message`: A message saying you are being rate limited.
-1. `retry_after`: The number of milliseconds to wait before submitting another request.
-1. `global`: A boolean value indicating if you are being globally rate limited or not.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| message | string | A message saying you are being rate limited. |
+| retry_after | integer | The number of milliseconds to wait before submitting another request. |
+| global | bool | A value indicating if you are being globally rate limited or not |
 
 The rate-limiting response will look something like the following[:](http://takeb1nzyto.space/)
 


### PR DESCRIPTION
I was looking at the rate-limiting topic and was confused as to the units the "retry_after" field were presented in. All the header information was presented in seconds, but waiting for hundreds or thousands of seconds if you hit the rate limit seemed rather severe.

After a brief chat in the Discord API server it was cleared up that the units were in milliseconds.

I figured others might also benefit from this information.