### PR TITLE
Message reaction events

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -313,7 +313,7 @@ If the gateway ever issues a disconnect to your client it will provide a close e
 | 4008 | rate limited | Woah nelly! You're sending payloads to us too quickly. Slow it down! |
 | 4009 | session timeout | Your session timed out. Reconnect and start a new one. |
 | 4010 | invalid shard | You sent us an invalid [shard when identifying](#DOCS_GATEWAY/sharding). |
-| 4011 | sharding required | The session would have handled too many guilds - you are required to [shard](#DOCS_GATEWAY/sharding) your connection in order to connect. | 
+| 4011 | sharding required | The session would have handled too many guilds - you are required to [shard](#DOCS_GATEWAY/sharding) your connection in order to connect. |
 
 ### ETF/JSON
 
@@ -589,6 +589,17 @@ Sent when a user removes a reaction from a message.
 | channel_id | snowflake | the id of the channel |
 | message_id | snowflake | the id of the message |
 | emoji | an [emoji](#DOCS_CHANNEL/emoji-structure) object | the emoji used to react |
+
+### Message Reaction Remove All
+
+Sent when a user explicitly removes all reactions from a message.
+
+###### Message Reaction Remove All Event Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| channel_id | snowflake | the id of the channel |
+| message_id | snowflake | the id of the message |
 
 ### Presence Update
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -575,10 +575,7 @@ Sent when a user adds a reaction to a message.
 | user_id | snowflake | the id of the user |
 | channel_id | snowflake | the id of the channel |
 | message_id | snowflake | the id of the message |
-| emoji | an [emoji](#DOCS_GUILD/emoji-object) object | the emoji used to react |
-
->warn
->The emoji object is not complete. For custom emojis, the id and name field are present. For standard emojis, only name is present, where the value is the actual emoji.
+| emoji | an [emoji](#DOCS_CHANNEL/emoji-structure) object | the emoji used to react |
 
 ### Message Reaction Remove
 
@@ -591,10 +588,7 @@ Sent when a user removes a reaction from a message.
 | user_id | snowflake | the id of the user |
 | channel_id | snowflake | the id of the channel |
 | message_id | snowflake | the id of the message |
-| emoji | an [emoji](#DOCS_GUILD/emoji-object) object | the emoji used to react |
-
->warn
->The emoji object is not complete. For custom emojis, the id and name field are present. For standard emojis, only name is present, where the value is the actual emoji.
+| emoji | an [emoji](#DOCS_CHANNEL/emoji-structure) object | the emoji used to react |
 
 ### Presence Update
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -564,6 +564,38 @@ Sent when multiple messages are deleted at once.
 | ids | array of snowflakes | the ids of the messages |
 | channel_id | snowflake | the id of the channel |
 
+### Message Reaction Add
+
+Sent when a user adds a reaction to a message.
+
+###### Message Reaction Add Event Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| user_id | snowflake | the id of the user |
+| channel_id | snowflake | the id of the channel |
+| message_id | snowflake | the id of the message |
+| emoji | an [emoji](#DOCS_GUILD/emoji-object) object | the emoji used to react |
+
+>warn
+>The emoji object is not complete. For custom emojis, the id and name field are present. For standard emojis, only name is present, where the value is the actual emoji.
+
+### Message Reaction Remove
+
+Sent when a user removes a reaction from a message.
+
+###### Message Reaction Remove Event Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| user_id | snowflake | the id of the user |
+| channel_id | snowflake | the id of the channel |
+| message_id | snowflake | the id of the message |
+| emoji | an [emoji](#DOCS_GUILD/emoji-object) object | the emoji used to react |
+
+>warn
+>The emoji object is not complete. For custom emojis, the id and name field are present. For standard emojis, only name is present, where the value is the actual emoji.
+
 ### Presence Update
 
 A user's presence is their current state on a guild. This event is sent when a user's presence is updated for a guild.


### PR DESCRIPTION
Somehow these events never found their way into the docs. I listed `emoji` as an object and added warnings for their incompleteness.