### PR TITLE
Added presence field to identify object

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -150,6 +150,7 @@ Used to trigger the initial handshake with the gateway.
 | compress | bool | whether this connection supports compression of the initial ready packet |
 | large_threshold | integer | value between 50 and 250, total number of members where the gateway will stop sending offline members in the guild member list |
 | shard | array of two integers (shard_id, num_shards) | used for [Guild Sharding](#DOCS_GATEWAY/sharding) |
+| presence | [presence](#DOCS_GATEWAY/gateway-status-update) | presence structure for initial presence information |
 
 ###### Gateway Identify Connection Properties
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -146,7 +146,7 @@ Used to trigger the initial handshake with the gateway.
 | Field | Type | Description |
 |-------|------|-------------|
 | token | string | authentication token |
-| properties | object | [connection properties](#DOCS_GATEWAY/gateway-identify-connection-properties) |
+| properties | object | [connection properties](#DOCS_GATEWAY/gateway-identify-gateway-identify-connection-properties) |
 | compress | bool | whether this connection supports compression of the initial ready packet |
 | large_threshold | integer | value between 50 and 250, total number of members where the gateway will stop sending offline members in the guild member list |
 | shard | array of two integers (shard_id, num_shards) | used for [Guild Sharding](#DOCS_GATEWAY/sharding) |

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -146,7 +146,7 @@ Used to trigger the initial handshake with the gateway.
 | Field | Type | Description |
 |-------|------|-------------|
 | token | string | authentication token |
-| properties | object | [connection properties](#DOCS_GATEWAY/gateway-identify-gateway-identify-connection-properties) |
+| properties | object | [connection properties](#DOCS_GATEWAY/gateway-identify-connection-properties) |
 | compress | bool | whether this connection supports compression of the initial ready packet |
 | large_threshold | integer | value between 50 and 250, total number of members where the gateway will stop sending offline members in the guild member list |
 | shard | array of two integers (shard_id, num_shards) | used for [Guild Sharding](#DOCS_GATEWAY/sharding) |
@@ -160,7 +160,7 @@ Used to trigger the initial handshake with the gateway.
 | $browser | string | your library name |
 | $device | string | your library name
 
-###### Example Gateway Identify Example
+###### Gateway Identify Example
 
 ```json
 {
@@ -172,7 +172,15 @@ Used to trigger the initial handshake with the gateway.
 	},
 	"compress": true,
 	"large_threshold": 250,
-	"shard": [1, 10]
+	"shard": [1, 10],
+	"presence": {
+		"game": {
+			"name": "Cards Against Humanity"
+		},
+		"status": "dnd",
+		"since": 91879201,
+		"afk": false
+	}
 }
 ```
 


### PR DESCRIPTION
Should this field be prefixed with a `?` as it is optional? I didn't do it here because other fields that are optional like `shard` are not marked as such either.