### PR TITLE
Fix an endpoint that points to a 404

### DIFF
--- a/docs/resources/Audit_Log.md
+++ b/docs/resources/Audit_Log.md
@@ -129,7 +129,7 @@ Whenever an admin action is performed on the API, an entry is added to the respe
 | type | any | string/int | type of entity created - can be of [channel type](#DOCS_CHANNEL/channel-object-channel-types) or a string like "role" |
 
 
-## Get Guild Audit Log % GET /guilds/{guild.id#DOCS_GUILD/guild-object}/audit-log
+## Get Guild Audit Log % GET /guilds/{guild.id#DOCS_GUILD/guild-object}/audit-logs
 
 Returns an an [audit log object](#DOCS_AUDIT_LOG/audit-log-object) for the guild. Requires the 'VIEW_AUDIT_LOG' permission.
 


### PR DESCRIPTION
It's still `/guilds/{guild.id}/audit-logs` 🤔 

![obrazek](https://user-images.githubusercontent.com/17570452/28747732-0cff49f6-74a6-11e7-8448-df277bd21a88.png)
![obrazek](https://user-images.githubusercontent.com/17570452/28747721-c99691e2-74a5-11e7-86e4-9eca3eac52e6.png)

