### PR TITLE
Document Hash-Related Image URL Structures

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -131,11 +131,11 @@ Discord utilizes a subset of markdown for rendering message content on its clien
 | Role | `<@&ROLE_SNOWFLAKE_ID>` | `<@&165511591545143296>` |
 | Custom Emoji | `<:NAME:ID>` | `<:mmLol:216154654256398347>` |
 
-Using the markdown for either users, roles or channels will mention the target(s) accordingly.
+Using the markdown for either users, roles, or channels will mention the target(s) accordingly.
 
-## URL Formatting
+## Image Formatting
 
-Discord utilizes the id's and hashes from specific objects to provide the images rendered in the client. This functionality uses the following formats:
+Discord uses ids and hashes to render images in the client. These hashes can be retrieved through various API requests, like [Get User](#DOCS_USER/get-user). Below are the formats, size limitations, and CDN endpoints for images in Discord:
 
 ###### Image Formats
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -116,3 +116,46 @@ The HTTP API implements a process for limiting and preventing excessive requests
 ## Gateway (WebSocket) API
 
 Discord's Gateway API is used for maintaining persistent, stateful websocket connections between your client and our servers. These connections are used for sending and receiving real-time events your client can use to track and update local state. The Gateway API uses secure websocket connections as specified in [RFC 6455](https://tools.ietf.org/html/rfc6455). For information on opening Gateway connections, please see the [Gateway API](#DOCS_GATEWAY/gateways) section.
+
+## Message Formatting
+
+Discord utilizes a subset of markdown for rendering message content on its clients, while also adding some custom functionality to enable things like mentioning users and channels. This functionality uses the following formats:
+
+###### Formats
+
+| Type | Structure | Example |
+|---------|-------------|-------------|
+| User | `<@USER_SNOWFLAKE_ID>` | `<@80351110224678912>` |
+| User (Nickname) | `<@!USER_SNOWFLAKE_ID>` | `<@!80351110224678912>` |
+| Channel | `<#CHANNEL_SNOWFLAKE_ID>` | `<#103735883630395392>` |
+| Role | `<@&ROLE_SNOWFLAKE_ID>` | `<@&165511591545143296>` |
+| Custom Emoji | `<:NAME:ID>` | `<:mmLol:216154654256398347>` |
+
+Using the markdown for either users, roles or channels will mention the target(s) accordingly.
+
+## URL Formatting
+
+Discord utilizes the id's and hashes from specific objects to provide the images rendered in the client. This functionality uses the following formats:
+
+###### Image Formats
+
+| Name | Extension |
+|-------|------------|
+| JPEG | .jpg, .jpeg |
+| PNG | .png |
+| WebP | .webp |
+| GIF | .gif ([user](#DOCS_USER/user-object) avatars only) |
+
+###### Image Sizes
+
+Power of 2 between 16 and 1024.
+
+###### CDN Endpoints
+
+| Type | URL |
+|---------|-----------------|
+| Custom Emoji | https://cdn.discordapp.com/emojis/[{emoji.id}](#DOCS_GUILD/emoji-object).png |
+| Guild Icon | https://cdn.discordapp.com/icons/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.icon}](#DOCS_GUILD/guild-object).[{format}](#DOCS_CHANNEL/image-formats)?size=[{size}](#DOCS_CHANNEL/image-sizes) |
+| Guild Splash | https://cdn.discordapp.com/splashes/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.splash}](#DOCS_GUILD/guild-object).[{format}](#DOCS_CHANNEL/image-formats)?size=2048 |
+| Default User Avatar | https://cdn.discordapp.com/embed/avatars/{[user.discriminator](#DOCS_USER/user-object) % 5}.png |
+| User Avatar | https://cdn.discordapp.com/avatars/[{user.id}](#DOCS_USER/user-object)/[{user.avatar](#DOCS_USER/user-object).[{format}](#DOCS_CHANNEL/image-formats)?size=[{size}](#DOCS_CHANNEL/image-sizes) |

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -155,7 +155,7 @@ Power of 2 between 16 and 1024.
 | Type | URL |
 |---------|-----------------|
 | Custom Emoji | https://cdn.discordapp.com/emojis/[{emoji.id}](#DOCS_GUILD/emoji-object).png |
-| Guild Icon | https://cdn.discordapp.com/icons/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.icon}](#DOCS_GUILD/guild-object).[{format}](#DOCS_CHANNEL/image-formats)?size=[{size}](#DOCS_CHANNEL/image-sizes) |
-| Guild Splash | https://cdn.discordapp.com/splashes/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.splash}](#DOCS_GUILD/guild-object).[{format}](#DOCS_CHANNEL/image-formats)?size=2048 |
+| Guild Icon | https://cdn.discordapp.com/icons/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.icon}](#DOCS_GUILD/guild-object).[{format}](#DOCS_REFERENCE/image-formats)?size=[{size}](#DOCS_REFERENCE/image-sizes) |
+| Guild Splash | https://cdn.discordapp.com/splashes/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.splash}](#DOCS_GUILD/guild-object).[{format}](#DOCS_REFERENCE/image-formats)?size=2048 |
 | Default User Avatar | https://cdn.discordapp.com/embed/avatars/{[user.discriminator](#DOCS_USER/user-object) % 5}.png |
-| User Avatar | https://cdn.discordapp.com/avatars/[{user.id}](#DOCS_USER/user-object)/[{user.avatar](#DOCS_USER/user-object).[{format}](#DOCS_CHANNEL/image-formats)?size=[{size}](#DOCS_CHANNEL/image-sizes) |
+| User Avatar | https://cdn.discordapp.com/avatars/[{user.id}](#DOCS_USER/user-object)/[{user.avatar](#DOCS_USER/user-object).[{format}](#DOCS_REFERENCE/image-formats)?size=[{size}](#DOCS_REFERENCE/image-sizes) |

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -353,9 +353,9 @@ Power of 2 between 16 and 1024.
 
 | Type | Structure |
 |---------|-----------------|
-| Custom Emoji | https://discordapp.com/api/emojis/[{emoji.id}](#DOCS_GUILD/emoji-object).png |
+| Custom Emoji | https://cdn.discordapp.com/api/emojis/[{emoji.id}](#DOCS_GUILD/emoji-object).png |
 | Guild Icon | https://cdn.discordapp.com/icons/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.icon}](#DOCS_GUILD/guild-object).[{format}](#DOCS_CHANNEL/image-formats)?size=[{size}](#DOCS_CHANNEL/image-sizes) |
-| Guild Splash | https://discordapp.com/splashes/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.splash}](#DOCS_GUILD/guild-object).jpg?size=2048 |
+| Guild Splash | https://cdn.discordapp.com/splashes/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.splash}](#DOCS_GUILD/guild-object).[{format}](#DOCS_CHANNEL/image-formats)?size=2048 |
 | Invite Code | http://discord.gg/[{invite.code}](#DOCS_INVITE/invite-structure) |
 | Default User Avatar | https://cdn.discordapp.com/embed/avatars/{[user.discriminator](#DOCS_USER/user-object) % 5}.png |
 | User Avatar | https://cdn.discordapp.com/avatars/[{user.id}](#DOCS_USER/user-object)/[{user.avatar](#DOCS_USER/user-object).[{format}](#DOCS_CHANNEL/image-formats)?size=[{size}](#DOCS_CHANNEL/image-sizes) |

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -316,50 +316,6 @@ To facilitate showing rich content, rich embeds do not follow the traditional li
 
 In addition to the limits above, the sum of all characters in an embed structure must not exceed 6000 characters.
 
-## Message Formatting
-
-Discord utilizes a subset of markdown for rendering message content on its clients, while also adding some custom functionality to enable things like mentioning users and channels. This functionality uses the following formats:
-
-###### Formats
-
-| Type | Structure | Example |
-|---------|-------------|-------------|
-| User | `<@USER_SNOWFLAKE_ID>` | `<@80351110224678912>` |
-| User (Nickname) | `<@!USER_SNOWFLAKE_ID>` | `<@!80351110224678912>` |
-| Channel | `<#CHANNEL_SNOWFLAKE_ID>` | `<#103735883630395392>` |
-| Role | `<@&ROLE_SNOWFLAKE_ID>` | `<@&165511591545143296>` |
-| Custom Emoji | `<:NAME:ID>` | `<:mmLol:216154654256398347>` |
-
-Using the markdown for either users, roles or channels will mention the target(s) accordingly.
-
-## URL Formatting
-
-Discord utilizes the id's and hashes from specific objects to provide the images rendered in the client. This functionality uses the following formats:
-
-###### Image Formats
-
-| Name | Extension |
-|-------|------------|
-| JPEG | .jpg, .jpeg |
-| PNG | .png |
-| WebP | .webp |
-| GIF | .gif ([user](#DOCS_USER/user-object) avatars only) |
-
-###### Image Sizes
-
-Power of 2 between 16 and 1024.
-
-###### Urls
-
-| Type | Structure |
-|---------|-----------------|
-| Custom Emoji | https://cdn.discordapp.com/emojis/[{emoji.id}](#DOCS_GUILD/emoji-object).png |
-| Guild Icon | https://cdn.discordapp.com/icons/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.icon}](#DOCS_GUILD/guild-object).[{format}](#DOCS_CHANNEL/image-formats)?size=[{size}](#DOCS_CHANNEL/image-sizes) |
-| Guild Splash | https://cdn.discordapp.com/splashes/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.splash}](#DOCS_GUILD/guild-object).[{format}](#DOCS_CHANNEL/image-formats)?size=2048 |
-| Invite Code | http://discord.gg/[{invite.code}](#DOCS_INVITE/invite-structure) |
-| Default User Avatar | https://cdn.discordapp.com/embed/avatars/{[user.discriminator](#DOCS_USER/user-object) % 5}.png |
-| User Avatar | https://cdn.discordapp.com/avatars/[{user.id}](#DOCS_USER/user-object)/[{user.avatar](#DOCS_USER/user-object).[{format}](#DOCS_CHANNEL/image-formats)?size=[{size}](#DOCS_CHANNEL/image-sizes) |
-
 ## Get Channel % GET /channels/{channel.id#DOCS_CHANNEL/channel-object}
 
 Get a channel by ID. Returns a [guild channel](#DOCS_CHANNEL/channel-object) or [dm channel](#DOCS_CHANNEL/channel-object) object.
@@ -407,7 +363,7 @@ Returns a specific message in the channel. If operating on a guild channel, this
 
 ## Create Message % POST /channels/{channel.id#DOCS_CHANNEL/channel-object}/messages
 
-Post a message to a guild text or DM channel. If operating on a guild channel, this endpoint requires the 'SEND_MESSAGES' permission to be present on the current user. Returns a [message](#DOCS_CHANNEL/message-object) object. Fires a [Message Create](#DOCS_GATEWAY/message-create) Gateway event. See [message formatting](#DOCS_CHANNEL/message-formatting) for more information on how to properly format messages.
+Post a message to a guild text or DM channel. If operating on a guild channel, this endpoint requires the 'SEND_MESSAGES' permission to be present on the current user. Returns a [message](#DOCS_CHANNEL/message-object) object. Fires a [Message Create](#DOCS_GATEWAY/message-create) Gateway event. See [message formatting](#DOCS_REFERENCE/message-formatting) for more information on how to properly format messages.
 
 >warn
 > This endpoint supports both JSON and form data bodies. It does require multipart/form-data requests instead of the normal JSON request type when uploading files. Make sure you set your `Content-Type` to `multipart/form-data` if you're doing that. Note that in that case, the `embed` field cannot be used, but you can pass an url-encoded JSON body as a form value for `payload_json`.

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -355,7 +355,7 @@ Power of 2 between 16 and 1024.
 |---------|-----------------|
 | Custom Emoji | https://discordapp.com/api/emojis/[{emoji.id}](#DOCS_GUILD/emoji-object).png |
 | Guild Icon | https://cdn.discordapp.com/icons/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.icon}](#DOCS_GUILD/guild-object).[{format}](#DOCS_CHANNEL/image-formats)?size=[{size}](#DOCS_CHANNEL/image-sizes) |
-| Invite Splash | https://discordapp.com/splashes/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.splash}](#DOCS_GUILD/guild-object).jpg?size=2048 |
+| Guild Splash | https://discordapp.com/splashes/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.splash}](#DOCS_GUILD/guild-object).jpg?size=2048 |
 | Invite Code | http://discord.gg/[{invite.code}](#DOCS_INVITE/invite-structure) |
 | Default User Avatar | https://cdn.discordapp.com/embed/avatars/{[user.discriminator](#DOCS_USER/user-object) % 5}.png |
 | User Avatar | https://cdn.discordapp.com/avatars/[{user.id}](#DOCS_USER/user-object)/[{user.avatar](#DOCS_USER/user-object).[{format}](#DOCS_CHANNEL/image-formats)?size=[{size}](#DOCS_CHANNEL/image-sizes) |

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -353,7 +353,7 @@ Power of 2 between 16 and 1024.
 
 | Type | Structure |
 |---------|-----------------|
-| Custom Emoji | https://cdn.discordapp.com/api/emojis/[{emoji.id}](#DOCS_GUILD/emoji-object).png |
+| Custom Emoji | https://cdn.discordapp.com/emojis/[{emoji.id}](#DOCS_GUILD/emoji-object).png |
 | Guild Icon | https://cdn.discordapp.com/icons/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.icon}](#DOCS_GUILD/guild-object).[{format}](#DOCS_CHANNEL/image-formats)?size=[{size}](#DOCS_CHANNEL/image-sizes) |
 | Guild Splash | https://cdn.discordapp.com/splashes/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.splash}](#DOCS_GUILD/guild-object).[{format}](#DOCS_CHANNEL/image-formats)?size=2048 |
 | Invite Code | http://discord.gg/[{invite.code}](#DOCS_INVITE/invite-structure) |

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -332,6 +332,34 @@ Discord utilizes a subset of markdown for rendering message content on its clien
 
 Using the markdown for either users, roles or channels will mention the target(s) accordingly.
 
+## URL Formatting
+
+Discord utilizes the id's and hashes from specific objects to provide the images rendered in the client. This functionality uses the following formats:
+
+###### Image Formats
+
+| Name | Extension |
+|-------|------------|
+| JPEG | .jpg, .jpeg |
+| PNG | .png |
+| WebP | .webp |
+| GIF | .gif ([user](#DOCS_USER/user-object) avatars only) |
+
+###### Image Sizes
+
+Power of 2 between 16 and 1024.
+
+###### Urls
+
+| Type | Structure |
+|---------|-----------------|
+| Custom Emoji | https://discordapp.com/api/emojis/[{emoji.id}](#DOCS_GUILD/emoji-object).png |
+| Guild Icon | https://cdn.discordapp.com/icons/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.icon}](#DOCS_GUILD/guild-object).[{format}](#DOCS_CHANNEL/image-formats)?size=[{size}](#DOCS_CHANNEL/image-sizes) |
+| Invite Splash | https://discordapp.com/splashes/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.splash}](#DOCS_GUILD/guild-object).jpg?size=2048 |
+| Invite Code | http://discord.gg/[{invite.code}](#DOCS_INVITE/invite-structure) |
+| Default User Avatar | https://cdn.discordapp.com/embed/avatars/{[user.discriminator](#DOCS_USER/user-object) % 5}.png |
+| User Avatar | https://cdn.discordapp.com/avatars/[{user.id}](#DOCS_USER/user-object)/[{user.avatar](#DOCS_USER/user-object).[{format}](#DOCS_CHANNEL/image-formats)?size=[{size}](#DOCS_CHANNEL/image-sizes) |
+
 ## Get Channel % GET /channels/{channel.id#DOCS_CHANNEL/channel-object}
 
 Get a channel by ID. Returns a [guild channel](#DOCS_CHANNEL/channel-object) or [dm channel](#DOCS_CHANNEL/channel-object) object.

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -10,8 +10,8 @@ Guilds in Discord represent an isolated collection of users and channels, and ar
 |-------|------|-------------|
 | id | snowflake | guild id |
 | name | string | guild name (2-100 characters) |
-| icon | string | [icon hash](#DOCS_REFERENCE/url-formatting) |
-| splash | string | [splash hash](#DOCS_REFERENCE/url-formatting) |
+| icon | string | [icon hash](#DOCS_REFERENCE/image-formatting) |
+| splash | string | [splash hash](#DOCS_REFERENCE/image-formatting) |
 | owner\_id | snowflake | id of owner |
 | region | string | {voice\_region.id} |
 | afk\_channel\_id | snowflake | id of afk channel |
@@ -189,7 +189,7 @@ A partial [guild](#DOCS_GUILD/guild-object) object. Represents an Offline Guild,
 
 | Field | Type | Description |
 |-------|------|-------------|
-| id | snowflake | [emoji id](#DOCS_REFERENCE/url-formatting) |
+| id | snowflake | [emoji id](#DOCS_REFERENCE/image-formatting) |
 | name | string | emoji name |
 | roles | array of [role object](#DOCS_PERMISSIONS/role-object) ids | roles this emoji is active for |
 | require_colons | bool | whether this emoji must be wrapped in colons |

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -10,8 +10,8 @@ Guilds in Discord represent an isolated collection of users and channels, and ar
 |-------|------|-------------|
 | id | snowflake | guild id |
 | name | string | guild name (2-100 characters) |
-| icon | string | icon hash |
-| splash | string | splash hash |
+| icon | string | icon hash, [url format](#DOCS_CHANNEL/url-formatting) |
+| splash | string | splash hash, [url format](#DOCS_CHANNEL/url-formatting) |
 | owner\_id | snowflake | id of owner |
 | region | string | {voice\_region.id} |
 | afk\_channel\_id | snowflake | id of afk channel |
@@ -189,7 +189,7 @@ A partial [guild](#DOCS_GUILD/guild-object) object. Represents an Offline Guild,
 
 | Field | Type | Description |
 |-------|------|-------------|
-| id | snowflake | emoji id |
+| id | snowflake | emoji id, [url format](#DOCS_CHANNEL/url-formatting) |
 | name | string | emoji name |
 | roles | array of [role object](#DOCS_PERMISSIONS/role-object) ids | roles this emoji is active for |
 | require_colons | bool | whether this emoji must be wrapped in colons |

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -10,8 +10,8 @@ Guilds in Discord represent an isolated collection of users and channels, and ar
 |-------|------|-------------|
 | id | snowflake | guild id |
 | name | string | guild name (2-100 characters) |
-| icon | string | icon hash, [url format](#DOCS_CHANNEL/url-formatting) |
-| splash | string | splash hash, [url format](#DOCS_CHANNEL/url-formatting) |
+| icon | string | [icon hash](#DOCS_REFERENCE/url-formatting) |
+| splash | string | [splash hash](#DOCS_REFERENCE/url-formatting) |
 | owner\_id | snowflake | id of owner |
 | region | string | {voice\_region.id} |
 | afk\_channel\_id | snowflake | id of afk channel |
@@ -189,7 +189,7 @@ A partial [guild](#DOCS_GUILD/guild-object) object. Represents an Offline Guild,
 
 | Field | Type | Description |
 |-------|------|-------------|
-| id | snowflake | emoji id, [url format](#DOCS_CHANNEL/url-formatting) |
+| id | snowflake | [emoji id](#DOCS_REFERENCE/url-formatting) |
 | name | string | emoji name |
 | roles | array of [role object](#DOCS_PERMISSIONS/role-object) ids | roles this emoji is active for |
 | require_colons | bool | whether this emoji must be wrapped in colons |

--- a/docs/resources/Invite.md
+++ b/docs/resources/Invite.md
@@ -8,7 +8,7 @@ Represents a code that when used, adds a user to a guild.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| code | string | the invite code (unique ID) |
+| code | string | the invite code (unique ID), [url format](#DOCS_CHANNEL/url-formatting) |
 | guild | partial [guild](#DOCS_GUILD/guild-object) object | the guild this invite is for |
 | channel | partial [channel](#DOCS_CHANNEL/channel-object) object | the channel this invite is for |
 

--- a/docs/resources/Invite.md
+++ b/docs/resources/Invite.md
@@ -8,7 +8,7 @@ Represents a code that when used, adds a user to a guild.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| code | string | the invite code (unique ID), [url format](#DOCS_CHANNEL/url-formatting) |
+| code | string | the invite code (unique ID) |
 | guild | partial [guild](#DOCS_GUILD/guild-object) object | the guild this invite is for |
 | channel | partial [channel](#DOCS_CHANNEL/channel-object) object | the channel this invite is for |
 

--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -35,7 +35,7 @@ There are other rules and restrictions not shared here for the sake of spam and 
 | id | snowflake | the user's id | identify |
 | username | string | the user's username, not unique across the platform | identify |
 | discriminator | string | the user's 4-digit discord-tag | identify |
-| avatar | string | the user's [avatar hash](#DOCS_REFERENCE/url-formatting) | identify |
+| avatar | string | the user's [avatar hash](#DOCS_REFERENCE/image-formatting) | identify |
 | bot | bool | whether the user belongs to an OAuth2 application | identify |
 | mfa_enabled | bool | whether the user has two factor enabled on their account | identify |
 | verified | bool | whether the email on this account has been verified | email |

--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -35,7 +35,7 @@ There are other rules and restrictions not shared here for the sake of spam and 
 | id | snowflake | the user's id | identify |
 | username | string | the user's username, not unique across the platform | identify |
 | discriminator | string | the user's 4-digit discord-tag | identify |
-| avatar | string | the user's avatar hash | identify |
+| avatar | string | the user's avatar hash, [url format](#DOCS_CHANNEL/url-formatting) | identify |
 | bot | bool | whether the user belongs to an OAuth2 application | identify |
 | mfa_enabled | bool | whether the user has two factor enabled on their account | identify |
 | verified | bool | whether the email on this account has been verified | email |

--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -35,7 +35,7 @@ There are other rules and restrictions not shared here for the sake of spam and 
 | id | snowflake | the user's id | identify |
 | username | string | the user's username, not unique across the platform | identify |
 | discriminator | string | the user's 4-digit discord-tag | identify |
-| avatar | string | the user's avatar hash, [url format](#DOCS_CHANNEL/url-formatting) | identify |
+| avatar | string | the user's [avatar hash](#DOCS_REFERENCE/url-formatting) | identify |
 | bot | bool | whether the user belongs to an OAuth2 application | identify |
 | mfa_enabled | bool | whether the user has two factor enabled on their account | identify |
 | verified | bool | whether the email on this account has been verified | email |


### PR DESCRIPTION
Wasn't exactly sure where the best place to put this is, chose to put it by the message formatting section since this is generally related to structure of discord client-specific things.

I realize this probably isnt the best design, so wouldn't mind suggestions about: 
1. the description at the top could use some work (if even needed at all)
2. http(s):// should probably be taken out of the table values? probably dont want this to render as a link, but don't want to confuse people into thinking they don't need it. not sure 
3. general table design

People ask about these url's in the discord api server all the time, so would be nice to have it documented.