### PR TITLE
Fix Markdown for CDN Endpoints

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -153,9 +153,12 @@ Power of 2 between 16 and 1024.
 ###### CDN Endpoints
 
 | Type | URL |
-|---------|-----------------|
-| Custom Emoji | https://cdn.discordapp.com/emojis/[{emoji.id}](#DOCS_GUILD/emoji-object).png |
-| Guild Icon | https://cdn.discordapp.com/icons/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.icon}](#DOCS_GUILD/guild-object).[{format}](#DOCS_REFERENCE/image-formats)?size=[{size}](#DOCS_REFERENCE/image-sizes) |
-| Guild Splash | https://cdn.discordapp.com/splashes/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.splash}](#DOCS_GUILD/guild-object).[{format}](#DOCS_REFERENCE/image-formats)?size=2048 |
-| Default User Avatar | https://cdn.discordapp.com/embed/avatars/{[user.discriminator](#DOCS_USER/user-object) % 5}.png |
-| User Avatar | https://cdn.discordapp.com/avatars/[{user.id}](#DOCS_USER/user-object)/[{user.avatar](#DOCS_USER/user-object).[{format}](#DOCS_REFERENCE/image-formats)?size=[{size}](#DOCS_REFERENCE/image-sizes) |
+|-------|-----------------|
+| Custom Emoji | cdn.discordapp.com/emojis/[{emoji.id}](#DOCS_GUILD/emoji-object).png |
+| Guild Icon | cdn.discordapp.com/icons/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.icon}](#DOCS_GUILD/guild-object).[{format}](#DOCS_REFERENCE/image-formats)?size=[{size}](#DOCS_REFERENCE/image-sizes) |
+| Guild Splash | cdn.discordapp.com/splashes/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.splash}](#DOCS_GUILD/guild-object).[{format}](#DOCS_REFERENCE/image-formats)?size=2048 |
+| Default User Avatar | cdn.discordapp.com/embed/avatars/{[user.discriminator](#DOCS_USER/user-object) % 5}.png |
+| User Avatar | cdn.discordapp.com/avatars/[{user.id}](#DOCS_USER/user-object)/[{user.avatar](#DOCS_USER/user-object).[{format}](#DOCS_REFERENCE/image-formats)?size=[{size}](#DOCS_REFERENCE/image-sizes) |
+
+>info
+> All CDN Enpoints should be prefixed with https://

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -161,4 +161,4 @@ Power of 2 between 16 and 1024.
 | User Avatar | cdn.discordapp.com/avatars/[{user.id}](#DOCS_USER/user-object)/[{user.avatar](#DOCS_USER/user-object).[{format}](#DOCS_REFERENCE/image-formats)?size=[{size}](#DOCS_REFERENCE/image-sizes) |
 
 >info
-> All CDN Enpoints should be prefixed with https://
+>All CDN Enpoints should be prefixed with `https://`

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -155,10 +155,10 @@ Power of 2 between 16 and 1024.
 | Type | URL |
 |-------|-----------------|
 | Custom Emoji | cdn.discordapp.com/emojis/[{emoji.id}](#DOCS_GUILD/emoji-object).png |
-| Guild Icon | cdn.discordapp.com/icons/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.icon}](#DOCS_GUILD/guild-object).[{format}](#DOCS_REFERENCE/image-formats)?size=[{size}](#DOCS_REFERENCE/image-sizes) |
-| Guild Splash | cdn.discordapp.com/splashes/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.splash}](#DOCS_GUILD/guild-object).[{format}](#DOCS_REFERENCE/image-formats)?size=2048 |
+| Guild Icon | cdn.discordapp.com/icons/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.icon}](#DOCS_GUILD/guild-object).[{format}](#DOCS_REFERENCE/image-formatting-image-formats)?size=[{size}](#DOCS_REFERENCE/image-formatting-image-sizes) |
+| Guild Splash | cdn.discordapp.com/splashes/[{guild.id}](#DOCS_GUILD/guild-object)/[{guild.splash}](#DOCS_GUILD/guild-object).[{format}](#DOCS_REFERENCE/image-formatting-image-formats)?size=2048 |
 | Default User Avatar | cdn.discordapp.com/embed/avatars/{[user.discriminator](#DOCS_USER/user-object) % 5}.png |
-| User Avatar | cdn.discordapp.com/avatars/[{user.id}](#DOCS_USER/user-object)/[{user.avatar](#DOCS_USER/user-object).[{format}](#DOCS_REFERENCE/image-formats)?size=[{size}](#DOCS_REFERENCE/image-sizes) |
+| User Avatar | cdn.discordapp.com/avatars/[{user.id}](#DOCS_USER/user-object)/[{user.avatar](#DOCS_USER/user-object).[{format}](#DOCS_REFERENCE/image-formatting-image-formats)?size=[{size}](#DOCS_REFERENCE/image-formatting-image-sizes) |
 
 >info
 >All CDN Enpoints should be prefixed with `https://`

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -161,4 +161,4 @@ Power of 2 between 16 and 1024.
 | User Avatar | cdn.discordapp.com/avatars/[{user.id}](#DOCS_USER/user-object)/[{user.avatar](#DOCS_USER/user-object).[{format}](#DOCS_REFERENCE/image-formatting-image-formats)?size=[{size}](#DOCS_REFERENCE/image-formatting-image-sizes) |
 
 >info
->All CDN Enpoints should be prefixed with `https://`
+>All CDN Endpoints should be prefixed with `https://`


### PR DESCRIPTION
The `URL` field had https:// in the entries which rendered them as actual links (oops). Removing will fix it, this is a suggestion for still denoting they are https. Sorry about that Mason