### PR TITLE
Clarify Opcode Actions

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -91,7 +91,7 @@ Used by the gateway to notify the client of events.
 
 ### Gateway Heartbeat
 
-Used to maintain an active gateway connection. Must be sent every `heartbeat_interval` milliseconds after the [Hello](#DOCS_GATEWAY/gateway-hello) payload is received. Note that this interval already has room for error, and that client implementations do not need to send a heartbeat faster than what's specified. The inner `d` key must be set to the last seq (`s`) received by the client. If none has yet been received you should send `null` (you cannot send a heartbeat before authenticating, however).
+Used to maintain an active gateway connection. Must be sent every `heartbeat_interval` milliseconds after the [Hello](#DOCS_GATEWAY/gateway-hello) payload is received. Note that this interval already has room for error, and that client implementations do not need to send a heartbeat faster than what's specified. The inner `d` key must be set to the last seq (`s`) received by the client. If none has yet been received you should send `null` (you cannot send a heartbeat before authenticating, however). If this payload is received, Discord is wanting to keep your connection alive; in this case, you should immediately send this payload back with the `d` key the same as your last received seq (`s`).
 
 >info
 > It is worth noting that in the event of a service outage where you stay connected to the gateway, you should continue to heartbeat and receive ACKs. The gateway will eventually respond and issue a session once it is able to.

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -59,20 +59,20 @@ The Discord Gateway has a versioning system which is separate from the core APIs
 
 ###### Gateway OP Codes
 
-| Code | Name | Description |
-|------|------|-------------|
-| 0 | Dispatch | dispatches an event |
-| 1 | Heartbeat | used for ping checking |
-| 2 | Identify | used for client handshake |
-| 3 | Status Update | used to update the client status |
-| 4 | Voice State Update | used to join/move/leave voice channels |
-| 5 | Voice Server Ping | used for voice ping checking |
-| 6 | Resume | used to resume a closed connection |
-| 7 | Reconnect | used to tell clients to reconnect to the gateway |
-| 8 | Request Guild Members | used to request guild members |
-| 9 | Invalid Session | used to notify client they have an invalid session id |
-| 10 | Hello | sent immediately after connecting, contains heartbeat and server debug information |
-| 11 | Heartbeat ACK | sent immediately following a client heartbeat that was received |
+| Code | Name | Client Action | Description |
+|------|------|------|-------------|
+| 0 | Dispatch | Receive | dispatches an event |
+| 1 | Heartbeat | Send/Receive | used for ping checking |
+| 2 | Identify | Send | used for client handshake |
+| 3 | Status Update | Send | used to update the client status |
+| 4 | Voice State Update | Send | used to join/move/leave voice channels |
+| 5 | Voice Server Ping | Send | used for voice ping checking |
+| 6 | Resume | Send | used to resume a closed connection |
+| 7 | Reconnect | Receive | used to tell clients to reconnect to the gateway |
+| 8 | Request Guild Members | Send | used to request guild members |
+| 9 | Invalid Session | Receive | used to notify client they have an invalid session id |
+| 10 | Hello | Receive | sent immediately after connecting, contains heartbeat and server debug information |
+| 11 | Heartbeat ACK | Receive | sent immediately following a client heartbeat that was received |
 
 ### Gateway Dispatch
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -91,7 +91,9 @@ Used by the gateway to notify the client of events.
 
 ### Gateway Heartbeat
 
-Used to maintain an active gateway connection. Must be sent every `heartbeat_interval` milliseconds after the [Hello](#DOCS_GATEWAY/gateway-hello) payload is received. Note that this interval already has room for error, and that client implementations do not need to send a heartbeat faster than what's specified. The inner `d` key must be set to the last seq (`s`) received by the client. If none has yet been received you should send `null` (you cannot send a heartbeat before authenticating, however). If this payload is received, Discord is wanting to keep your connection alive; in this case, you should immediately send this payload back with the `d` key the same as your last received seq (`s`).
+Used to maintain an active gateway connection. Must be sent every `heartbeat_interval` milliseconds after the [Hello](#DOCS_GATEWAY/gateway-hello) payload is received. *Note that this interval already has room for error, and that client implementations do not need to send a heartbeat faster than what's specified.* The inner `d` key must be set to the last seq (`s`) received by the client. If none has yet been received you should send `null` (you cannot send a heartbeat before authenticating, however).
+
+This OP code is also bidirectional. The gateway may request a heartbeat from you in some situations, and you should send a heartbeat back to the gateway as you normally would.
 
 >info
 > It is worth noting that in the event of a service outage where you stay connected to the gateway, you should continue to heartbeat and receive ACKs. The gateway will eventually respond and issue a session once it is able to.


### PR DESCRIPTION
Although the description column in the [opcodes](https://github.com/hammerandchisel/discord-api-docs/blob/master/docs/topics/Gateway.md#gateway-op-codes) table can be used to figure out which opcodes are supposed to be sent or received by the client, it would still be nice to add an extra column to be explicit about the action the client takes for each one.

Additionally, since heartbeat (OP 1) can be received and has meaning (believe it is for when discord will/wants to keep your connection alive) it technically does both actions. The receive meaning isn't mentioned in the [heartbeat](https://github.com/hammerandchisel/discord-api-docs/blob/master/docs/topics/Gateway.md#gateway-heartbeat) section, so maybe that should be added in this PR if you want to be true to which actions take place for each OP.

Finally, most libs implement guild sync (OP 12) but that isn't shown on the table. Unless it intentionally isn't documented, another possible addition to the docs?