### PR TITLE
Update Game Object Examples

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -177,7 +177,8 @@ Used to trigger the initial handshake with the gateway.
 	"shard": [1, 10],
 	"presence": {
 		"game": {
-			"name": "Cards Against Humanity"
+			"name": "Cards Against Humanity",
+			"type": 0
 		},
 		"status": "dnd",
 		"since": 91879201,
@@ -263,7 +264,8 @@ Sent by the client to indicate a presence or status update.
 {
 	"since": 91879201,
 	"game": {
-		"name": "Save the Oxford Comma"
+		"name": "Save the Oxford Comma",
+		"type": 0
 	},
 	"status": "online",
 	"afk": false


### PR DESCRIPTION
Since a recent change required the `type` field to always be present in the Game Object, should probably update the JSON examples to have it as well.