### PR TITLE
Clarification on "default channel" ID

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -8,7 +8,7 @@ Represents a guild or DM channel within Discord.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| id | snowflake | the id of this channel (will be equal to the guild if it's the "general" channel) |
+| id | snowflake | the id of this channel |
 | type | integer | the [type of channel](#DOCS_CHANNEL/channel-object-channel-types) |
 | guild\_id? | snowflake | the id of the guild |
 | position? | integer | sorting position of the channel |


### PR DESCRIPTION
Fixes statement about the channel created by default sharing the same ID as the parent guild. See #329 for more info.