### PR TITLE
Added documentation for account deletion

### DIFF
--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -149,3 +149,16 @@ Create a new group DM channel with multiple users. Returns a [DM channel](#DOCS_
 ## Get User Connections % GET /users/@me/connections
 
 Returns a list of [connection](#DOCS_USER/connection-object) objects. Requires the `connections` OAuth2 scope.
+
+## Delete Account % POST /users/@me/delete
+
+Deletes the requester's user account permanently. Returns a [placeholder here for what this returns].
+
+>danger
+> This will immediately delete the account, closing this and all other sessions on the account permanently. Use with caution.
+
+###### JSON Params
+
+| Field | Type | Description |
+|-------|------|-------------|
+| password | string | the requesting account's password |


### PR DESCRIPTION
Thought I'd just make this for the upcoming account deletion endpoint seen [here](https://github.com/DJScias/Discord-Datamining/commit/b07d6e2f1083401e9968ac9e53aa27f26235c1c2#commitcomment-24173244). Currently, this endpoint is not active and will return a 404, and therefore this PR will need modification before merging.

Thanks,
Pointy