### PR TITLE
Updated type column in Modify Channel docs

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -346,13 +346,13 @@ Update a channels settings. Requires the 'MANAGE_CHANNELS' permission for the gu
 
 | Field | Type | Description | Channel Type |
 |-------|------|-------------|--------------|
-| name | string | 2-100 character channel name | Both |
-| position | integer | the position of the channel in the left-hand listing | Both |
+| name | string | 2-100 character channel name | All |
+| position | integer | the position of the channel in the left-hand listing | All |
 | topic | string | 0-1024 character channel topic | Text |
 | bitrate | integer | the bitrate (in bits) of the voice channel; 8000 to 96000 (128000 for VIP servers) | Voice |
 | user_limit | integer | the user limit of the voice channel; 0 refers to no limit, 1 to 99 refers to a user limit | Voice |
 | permission_overwrites | array of [overwrite](#DOCS_CHANNEL/overwrite-object) objects | channel or category-specific permissions | All |
-| parent_id | snowflake | id of the new parent category for a channel |
+| parent_id | snowflake | id of the new parent category for a channel | Text, Voice |
 
 ## Delete/Close Channel % DELETE /channels/{channel.id#DOCS_CHANNEL/channel-object}
 


### PR DESCRIPTION
Since there are now 3 different types of channels that can be modified (Text, Voice, Category) the "Both" should be replaced with "All".
In addition I have updated the type for `parent_id` as it is only used for Text and Voice.