### PR TITLE
Clarify gateway requirements to send messages

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -118,7 +118,7 @@ Discord's Gateway API is used for maintaining persistent, stateful websocket con
 
 >warn
 >A bot must connect and identify to a gateway at least once before being able to use the [Create Message](#DOCS_CHANNEL/create-message) endpoint.
->If you only want to send messages, consider using a [Webhook](#DOCS_WEBHOOK) instead.
+>If you only want to send messages and don't need to read them, consider using a [Webhook](#DOCS_WEBHOOK) instead.
 
 ## Message Formatting
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -118,6 +118,7 @@ Discord's Gateway API is used for maintaining persistent, stateful websocket con
 
 >warn
 >A bot must connect and identify to a gateway at least once before being able to use the [Create Message](#DOCS_CHANNEL/create-message) endpoint.
+>If you only want to send messages, consider using a [Webhook](#DOCS_WEBHOOK) instead.
 
 ## Message Formatting
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -117,8 +117,8 @@ The HTTP API implements a process for limiting and preventing excessive requests
 Discord's Gateway API is used for maintaining persistent, stateful websocket connections between your client and our servers. These connections are used for sending and receiving real-time events your client can use to track and update local state. The Gateway API uses secure websocket connections as specified in [RFC 6455](https://tools.ietf.org/html/rfc6455). For information on opening Gateway connections, please see the [Gateway API](#DOCS_GATEWAY/gateways) section.
 
 >warn
->A bot must connect and identify to a gateway at least once before being able to use the [Create Message](#DOCS_CHANNEL/create-message) endpoint.
->If you only want to send messages and don't need to read them, consider using a [Webhook](#DOCS_WEBHOOK) instead.
+>A bot must connect to and identify with a gateway at least once it can use the [Create Message](#DOCS_CHANNEL/create-message) endpoint.
+>If your only requirement is to send messages to a channel, consider using a [Webhook](#DOCS_WEBHOOK) instead.
 
 ## Message Formatting
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -117,7 +117,7 @@ The HTTP API implements a process for limiting and preventing excessive requests
 Discord's Gateway API is used for maintaining persistent, stateful websocket connections between your client and our servers. These connections are used for sending and receiving real-time events your client can use to track and update local state. The Gateway API uses secure websocket connections as specified in [RFC 6455](https://tools.ietf.org/html/rfc6455). For information on opening Gateway connections, please see the [Gateway API](#DOCS_GATEWAY/gateways) section.
 
 >warn
->A bot must connect to and identify with a gateway at least once it can use the [Create Message](#DOCS_CHANNEL/create-message) endpoint.
+>A bot must connect to and identify with a gateway at least once before it can use the [Create Message](#DOCS_CHANNEL/create-message) endpoint.
 >If your only requirement is to send messages to a channel, consider using a [Webhook](#DOCS_WEBHOOK) instead.
 
 ## Message Formatting

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -112,12 +112,12 @@ Clients may append more information and metadata to the _end_ of this string as 
 
 The HTTP API implements a process for limiting and preventing excessive requests in accordance with [RFC 6585](https://tools.ietf.org/html/rfc6585#section-4). API users that regularly hit and ignore rate limits will have their API keys revoked, and be blocked from the platform. For more information on rate limiting of requests, please see the [Rate Limits](#DOCS_RATE_LIMITS/rate-limits) section.
 
->warn
->A bot account must connect and identify to a [Gateway](#DOCS_GATEWAY/connecting) at least once before being able to send messages.
-
 ## Gateway (WebSocket) API
 
 Discord's Gateway API is used for maintaining persistent, stateful websocket connections between your client and our servers. These connections are used for sending and receiving real-time events your client can use to track and update local state. The Gateway API uses secure websocket connections as specified in [RFC 6455](https://tools.ietf.org/html/rfc6455). For information on opening Gateway connections, please see the [Gateway API](#DOCS_GATEWAY/gateways) section.
+
+>warn
+>A bot must connect and identify to a gateway at least once before being able to use the [Create Message](#DOCS_CHANNEL/create-message) endpoint.
 
 ## Message Formatting
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -384,7 +384,7 @@ Returns a specific message in the channel. If operating on a guild channel, this
 ## Create Message % POST /channels/{channel.id#DOCS_CHANNEL/channel-object}/messages
 
 >warn
->Before being able to use this endpoint, you must [connect to the gateway](#DOCS_GATEWAY/connecting) at least once.
+>Before using this endpoint, you must [connect to the gateway](#DOCS_GATEWAY/connecting) at least once.
 
 Post a message to a guild text or DM channel. If operating on a guild channel, this endpoint requires the 'SEND_MESSAGES' permission to be present on the current user. Returns a [message](#DOCS_CHANNEL/message-object) object. Fires a [Message Create](#DOCS_GATEWAY/message-create) Gateway event. See [message formatting](#DOCS_REFERENCE/message-formatting) for more information on how to properly format messages.
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -384,7 +384,7 @@ Returns a specific message in the channel. If operating on a guild channel, this
 ## Create Message % POST /channels/{channel.id#DOCS_CHANNEL/channel-object}/messages
 
 >warn
->Before using this endpoint, you must [connect to the gateway](#DOCS_GATEWAY/connecting) at least once.
+>Before using this endpoint, you must connect to and identify with a [gateway](#DOCS_GATEWAY/gateways) at least once.
 
 Post a message to a guild text or DM channel. If operating on a guild channel, this endpoint requires the 'SEND_MESSAGES' permission to be present on the current user. Returns a [message](#DOCS_CHANNEL/message-object) object. Fires a [Message Create](#DOCS_GATEWAY/message-create) Gateway event. See [message formatting](#DOCS_REFERENCE/message-formatting) for more information on how to properly format messages.
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -383,6 +383,9 @@ Returns a specific message in the channel. If operating on a guild channel, this
 
 ## Create Message % POST /channels/{channel.id#DOCS_CHANNEL/channel-object}/messages
 
+>warn
+>Before being able to use this endpoint, you must [connect to the gateway](#DOCS_GATEWAY/connecting) at least once.
+
 Post a message to a guild text or DM channel. If operating on a guild channel, this endpoint requires the 'SEND_MESSAGES' permission to be present on the current user. Returns a [message](#DOCS_CHANNEL/message-object) object. Fires a [Message Create](#DOCS_GATEWAY/message-create) Gateway event. See [message formatting](#DOCS_REFERENCE/message-formatting) for more information on how to properly format messages.
 
 >warn


### PR DESCRIPTION
Documenting that bots have to identify at least once to send messages makes more sense in the documentation of the message create endpoint and the summary of the gateway in the reference, IMO.

I'm not sure whether having two separate 'warnings' in the message create endpoint documentation is a good idea though, but after [this was brought up](https://github.com/discordapp/discord-api-docs/pull/392#issuecomment-332591871) I felt it would be a good compromise so that we didn't have two blockquotes in a row, or one large blockquote.