### PR TITLE
Added channel_id parameter to "Modify Webhook"

### DIFF
--- a/docs/resources/Webhook.md
+++ b/docs/resources/Webhook.md
@@ -81,7 +81,7 @@ Modify a webhook. Returns the updated [webhook](#DOCS_WEBHOOK/webhook-object) ob
 
 ## Modify Webhook with Token % PATCH /webhooks/{webhook.id#DOCS_WEBHOOK/webhook-object}/{webhook.token#DOCS_WEBHOOK/webhook-object}
 
-Same as above, except this call does not require authentication and returns no user in the webhook object. Additionally, the `channel_id` parameter is not present in this endpoint.
+Same as above, except this call does not require authentication, does not accept a `channel_id` parameter in the body, and does not return a user in the webhook object.
 
 ## Delete Webhook % DELETE /webhooks/{webhook.id#DOCS_WEBHOOK/webhook-object}
 

--- a/docs/resources/Webhook.md
+++ b/docs/resources/Webhook.md
@@ -77,7 +77,7 @@ Modify a webhook. Returns the updated [webhook](#DOCS_WEBHOOK/webhook-object) ob
 |-------|------|-------------|
 | name | string | the default name of the webhook |
 | avatar | [avatar data](#DOCS_USER/avatar-data) string | image for the default webhook avatar |
-| channel_id | string | the new channel id this webhook is for |
+| channel_id | snowflake | the new channel id this webhook should be moved to |
 
 ## Modify Webhook with Token % PATCH /webhooks/{webhook.id#DOCS_WEBHOOK/webhook-object}/{webhook.token#DOCS_WEBHOOK/webhook-object}
 

--- a/docs/resources/Webhook.md
+++ b/docs/resources/Webhook.md
@@ -77,10 +77,11 @@ Modify a webhook. Returns the updated [webhook](#DOCS_WEBHOOK/webhook-object) ob
 |-------|------|-------------|
 | name | string | the default name of the webhook |
 | avatar | [avatar data](#DOCS_USER/avatar-data) string | image for the default webhook avatar |
+| channel_id | string | the new channel id this webhook is for |
 
 ## Modify Webhook with Token % PATCH /webhooks/{webhook.id#DOCS_WEBHOOK/webhook-object}/{webhook.token#DOCS_WEBHOOK/webhook-object}
 
-Same as above, except this call does not require authentication and returns no user in the webhook object.
+Same as above, except this call does not require authentication and returns no user in the webhook object. Additionally, the `channel_id` parameter is not present in this endpoint.
 
 ## Delete Webhook % DELETE /webhooks/{webhook.id#DOCS_WEBHOOK/webhook-object}
 


### PR DESCRIPTION
According to bwmarrin/discordgo#434, the "Modify Webhook" endpoint has an undocumented field named `channel_id` that updates the channel ID of the webhook, and in my testing, it seems to function as described. However, in my testing, the "Modify Webhook with Token" endpoint does **not** seem to use the field (even when the `name` field in the same request **does** function as intended), though the documentation for it originally expressed the two were the same with the exception of authentication and a return value. This PR adds documentation for the field.