### PR TITLE
Fix Audit Log Entry field types

### DIFF
--- a/docs/resources/Audit_Log.md
+++ b/docs/resources/Audit_Log.md
@@ -20,13 +20,13 @@ Whenever an admin action is performed on the API, an entry is added to the respe
 
 | Field | Type | Description |
 |-------|------|-------------|
-| target_id | string | id of the affected entity (webhook, user, role, etc.) |
-| changes | array of [audit log change](#DOCS_AUDIT_LOG/audit-log-change-object) objects | changes made to the target_id |
+| target_id | ?string | id of the affected entity (webhook, user, role, etc.) |
+| changes? | array of [audit log change](#DOCS_AUDIT_LOG/audit-log-change-object) objects | changes made to the target_id |
 | user_id | snowflake | the user who made the changes
 | id | snowflake | id of the entry
 | action_type | [audit log event](#DOCS_AUDIT_LOG/audit-log-entry-object-audit-log-events) | type of action that occured |
-| options | [optional audit entry info](#DOCS_AUDIT_LOG/audit-log-entry-object-optional-audit-entry-info) |  additional info for certain action types |
-| reason | string | the reason for the change |
+| options? | [optional audit entry info](#DOCS_AUDIT_LOG/audit-log-entry-object-optional-audit-entry-info) |  additional info for certain action types |
+| reason? | string | the reason for the change |
 
 ###### Audit Log Events
 

--- a/docs/resources/Audit_Log.md
+++ b/docs/resources/Audit_Log.md
@@ -25,7 +25,7 @@ Whenever an admin action is performed on the API, an entry is added to the respe
 | user_id | snowflake | the user who made the changes
 | id | snowflake | id of the entry
 | action_type | [audit log event](#DOCS_AUDIT_LOG/audit-log-entry-object-audit-log-events) | type of action that occured |
-| options | array of [optional audit entry info](#DOCS_AUDIT_LOG/audit-log-entry-object-optional-audit-entry-info) objects |  additional info for certain action types |
+| options | [optional audit entry info](#DOCS_AUDIT_LOG/audit-log-entry-object-optional-audit-entry-info) |  additional info for certain action types |
 | reason | string | the reason for the change |
 
 ###### Audit Log Events


### PR DESCRIPTION
* The `options` field is not an array
* The `reason`, `options`, and `changes` fields are optional
* The `target_id` field is nullable