### PR TITLE
Add permission info for more endpoints

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -389,7 +389,7 @@ Returns a specific message in the channel. If operating on a guild channel, this
 >warn
 >Before using this endpoint, you must connect to and identify with a [gateway](#DOCS_GATEWAY/gateways) at least once.
 
-Post a message to a guild text or DM channel. If operating on a guild channel, this endpoint requires the 'SEND_MESSAGES' permission to be present on the current user. Returns a [message](#DOCS_CHANNEL/message-object) object. Fires a [Message Create](#DOCS_GATEWAY/message-create) Gateway event. See [message formatting](#DOCS_REFERENCE/message-formatting) for more information on how to properly format messages.
+Post a message to a guild text or DM channel. If operating on a guild channel, this endpoint requires the 'SEND_MESSAGES' permission to be present on the current user. If the `tts` field is set to `true`, the SEND_TTS_MESSAGES permission is required for the message to be spoken. Returns a [message](#DOCS_CHANNEL/message-object) object. Fires a [Message Create](#DOCS_GATEWAY/message-create) Gateway event. See [message formatting](#DOCS_REFERENCE/message-formatting) for more information on how to properly format messages.
 
 The maximum request size when sending a message is 8MB.
 

--- a/docs/resources/Emoji.md
+++ b/docs/resources/Emoji.md
@@ -26,7 +26,7 @@ Returns an [emoji](#DOCS_EMOJI/emoji-object) object for the given guild and emoj
 
 ## Create Guild Emoji % POST /guilds/{guild.id#DOCS_GUILD/guild-object}/emojis
 
-Create a new emoji for the guild. Returns the new [emoji](#DOCS_EMOJI/emoji-object) object on success. Fires a [Guild Emojis Update](#DOCS_GATEWAY/guild-emojis-update) Gateway event.
+Create a new emoji for the guild. Requires the 'MANAGE_EMOJIS' permission. Returns the new [emoji](#DOCS_EMOJI/emoji-object) object on success. Fires a [Guild Emojis Update](#DOCS_GATEWAY/guild-emojis-update) Gateway event.
 
 >info
 >Passing the roles field will be ignored unless the application is whitelisted as an emoji provider. For more information and to request whitelisting please contact support@discordapp.com
@@ -41,7 +41,7 @@ Create a new emoji for the guild. Returns the new [emoji](#DOCS_EMOJI/emoji-obje
 
 ## Modify Guild Emoji % PATCH /guilds/{guild.id#DOCS_GUILD/guild-object}/emojis/{emoji.id#DOCS_EMOJI/emoji-object}
 
-Modify the given emoji. Returns the updated [emoji](#DOCS_EMOJI/emoji-object) object on success. Fires a [Guild Emojis Update](#DOCS_GATEWAY/guild-emojis-update) Gateway event.
+Modify the given emoji. Requires the 'MANAGE_EMOJIS' permission. Returns the updated [emoji](#DOCS_EMOJI/emoji-object) object on success. Fires a [Guild Emojis Update](#DOCS_GATEWAY/guild-emojis-update) Gateway event.
 
 >info
 >Passing the roles field will be ignored unless the application is whitelisted as an emoji provider. For more information and to request whitelisting please contact support@discordapp.com
@@ -55,4 +55,4 @@ Modify the given emoji. Returns the updated [emoji](#DOCS_EMOJI/emoji-object) ob
 
 ## Delete Guild Emoji % DELETE /guilds/{guild.id#DOCS_GUILD/guild-object}/emojis/{emoji.id#DOCS_EMOJI/emoji-object}
 
-Delete the given emoji. Returns `204 No Content` on success. Fires a [Guild Emojis Update](#DOCS_GATEWAY/guild-emojis-update) Gateway event.
+Delete the given emoji. Requires the 'MANAGE_EMOJIS' permission. Returns `204 No Content` on success. Fires a [Guild Emojis Update](#DOCS_GATEWAY/guild-emojis-update) Gateway event.

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -247,7 +247,7 @@ Returns the [guild](#DOCS_GUILD/guild-object) object for the given id.
 
 ## Modify Guild % PATCH /guilds/{guild.id#DOCS_GUILD/guild-object}
 
-Modify a guild's settings. Returns the updated [guild](#DOCS_GUILD/guild-object) object on success. Fires a [Guild Update](#DOCS_GATEWAY/guild-update) Gateway event.
+Modify a guild's settings. Requires the 'MANAGE_GUILD' permission. Returns the updated [guild](#DOCS_GUILD/guild-object) object on success. Fires a [Guild Update](#DOCS_GATEWAY/guild-update) Gateway event.
 
 >info
 >All parameters to this endpoint are optional

--- a/docs/resources/Webhook.md
+++ b/docs/resources/Webhook.md
@@ -39,7 +39,7 @@ Used to represent a webhook.
 
 ## Create Webhook % POST /channels/{channel.id#DOCS_CHANNEL/channel-object}/webhooks
 
-Create a new webhook. Returns a [webhook](#DOCS_WEBHOOK/webhook-object) object on success.
+Create a new webhook. Requres the 'MANAGE_WEBHOOKS' permission. Returns a [webhook](#DOCS_WEBHOOK/webhook-object) object on success.
 
 ###### JSON Params
 
@@ -50,11 +50,11 @@ Create a new webhook. Returns a [webhook](#DOCS_WEBHOOK/webhook-object) object o
 
 ## Get Channel Webhooks % GET /channels/{channel.id#DOCS_CHANNEL/channel-object}/webhooks
 
-Returns a list of channel [webhook](#DOCS_WEBHOOK/webhook-object) objects.
+Returns a list of channel [webhook](#DOCS_WEBHOOK/webhook-object) objects. Requres the 'MANAGE_WEBHOOKS' permission.
 
 ## Get Guild Webhooks % GET /guilds/{guild.id#DOCS_GUILD/guild-object}/webhooks
 
-Returns a list of guild [webhook](#DOCS_WEBHOOK/webhook-object) objects.
+Returns a list of guild [webhook](#DOCS_WEBHOOK/webhook-object) objects. Requres the 'MANAGE_WEBHOOKS' permission.
 
 ## Get Webhook % GET /webhooks/{webhook.id#DOCS_WEBHOOK/webhook-object}
 
@@ -66,7 +66,7 @@ Same as above, except this call does not require authentication and returns no u
 
 ## Modify Webhook % PATCH /webhooks/{webhook.id#DOCS_WEBHOOK/webhook-object}
 
-Modify a webhook. Returns the updated [webhook](#DOCS_WEBHOOK/webhook-object) object on success.
+Modify a webhook. Requres the 'MANAGE_WEBHOOKS' permission. Returns the updated [webhook](#DOCS_WEBHOOK/webhook-object) object on success.
 
 >info
 >All parameters to this endpoint are optional


### PR DESCRIPTION
Adds required permission info for some endpoints where I noticed it was missing. A bit unsure about the webhooks, but I assume that's the correct ones.