### PR TITLE
Clarification & typo fixes for Rich Presence docs

### DIFF
--- a/docs/rich_presence/Best_Practices.md
+++ b/docs/rich_presence/Best_Practices.md
@@ -75,7 +75,7 @@ For a great real world example, check out [Holodrive](https://store.steampowered
 - The large image should be consistent for all players in a party.
 - The small image is where you can customize on a per-player basis.
 - Use high resolution artwork so your art looks great on fancy, high DPI screens.
-- We strongly recommend image sizes of 1024x1024.
+- We strongly recommend image sizes of 1024x1024 pixels.
 
 ###### Examples
 

--- a/docs/rich_presence/Getting_Approved.md
+++ b/docs/rich_presence/Getting_Approved.md
@@ -62,6 +62,6 @@ To be approved for Spectate, submit a video of your game’s Spectate flow that 
 - Game client launches
 - Begin spectating friend
 
-In the case of spectating, your players should not be able to join the game directly via spectating. If you want players to be able to join a game session, use our Ask to Join feature instead. Discord’s Spectate feature is limited to a “true spectate” experience—that means no joining on.
+In the case of spectating, your players should not be able to join the game directly. If you want players to be able to join a game session, use our Ask to Join feature instead. Discord’s Spectate feature is limited to a “true spectate” experience—that means no joining on.
 
 To test Spectate for your game, you can add whitelisted users on [your app's developer dashboard](https://discordapp.com/developers/applications/me) who will then have the feature enabled on their profile.

--- a/docs/rich_presence/Launch_Checklist.md
+++ b/docs/rich_presence/Launch_Checklist.md
@@ -18,7 +18,7 @@ Ready to launch a Rich Presence integration for your game? Did you read our [Bes
 #### Artwork
 
 - Is your artwork high resolution?
-- Are your image sizes at least 1024x1024?
+- Are your images at least 1024x1024 pixels?
 - Is it clean, interesting, and descriptive without being too highly detailed?
 - Do you have artwork for every different state? Don't forget your default state/main menu!
 - Did you make use of tooltips and the small image where appropriate?
@@ -26,7 +26,7 @@ Ready to launch a Rich Presence integration for your game? Did you read our [Bes
 #### Joining
 
 >warn
->If you want the Ask to Join button on users' profiles, check out [Getting Aproved](#DOCS_GETTING_APPROVED/) for more information!
+>If you want the Ask to Join button on users' profiles, check out [Getting Approved](#DOCS_GETTING_APPROVED/) for more information!
 
 - Have you successfully implemented join invites for your game if applicable?
 - Does the state of the invite properly represent the party/group in-game with regards to:


### PR DESCRIPTION
Noticed a few points that could do with extra clarification (e.g image sizes), a line that had a redundant "via spectating" in there despite already starting with "in the case of spectating", and fixed a minor typo.