### PR TITLE
 Removed unnecessary follow-up instructions

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -37,9 +37,6 @@ Returns an object with the same information as [Get Gateway](#DOCS_GATEWAY/get-g
 
 The Discord Gateway has a versioning system which is separate from the core APIs. The documentation herein is only for the latest version in the following table, unless otherwise specified.
 
->danger
->Gateway versions below v6 will be discontinued on **October 16, 2017**.
-
 | Version | Status |
 |---------|----------------|
 | 6 | Available |


### PR DESCRIPTION
There was message like "v6 will be discontinued on October 16th", but it's still running..