### PR TITLE
Document reason param for Create Guild Ban

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -402,6 +402,7 @@ Create a guild ban, and optionally delete previous messages sent by the banned u
 | Field | Type | Description |
 |-------|------|-------------|
 | delete-message-days | integer | number of days to delete messages for (0-7) |
+| reason | string | reason for the ban |
 
 ## Remove Guild Ban % DELETE /guilds/{guild.id#DOCS_GUILD/guild-object}/bans/{user.id#DOCS_USER/user-object}
 


### PR DESCRIPTION
This param has only been [mentioned briefly when discussing audit log bugs](https://github.com/discordapp/discord-api-docs/issues/265#issuecomment-306993317), but never actually documented.

Not sure if the special behavior of this param (sets both ban reason and audit log reason) should be noted in the description here.