### PR TITLE
Reword private_channels field from READY docs

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -491,7 +491,7 @@ The ready event is dispatched when a client has completed the initial handshake 
 >`guilds` are the guilds of which your bot is a member. They start out as unavailable when you connect to the gateway. As they become available to your bot, you will be notified via [Guild Create](#DOCS_GATEWAY/guild-create) events.
 
 >warn
->`private_channels` will be an empty array for bot accounts. As bots receive messages, you will receive [Channel Create](#DOCS_GATEWAY/channel-create) payloads before the [Message Create](#DOCS_GATEWAY/message-create) ones.
+>`private_channels` will be an empty array for bot accounts. As bots receive private messages, you will receive a [Channel Create](#DOCS_GATEWAY/channel-create) payload before the [Message Create](#DOCS_GATEWAY/message-create) one.
 
 #### Resumed
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -476,6 +476,8 @@ Sent on connection to the websocket. Defines the heartbeat interval that the cli
 
 The ready event is dispatched when a client has completed the initial handshake with the gateway (for new sessions). The ready event can be the largest and most complex event the gateway will send, as it contains all the state required for a client to begin interacting with the rest of the platform.
 
+For bots, `guilds` are the guilds of which your bot is a member. They start out as unavailable when you connect to the gateway. As they become available to your bot, you will be notified via [Guild Create](#DOCS_GATEWAY/guild-create) events. Also for bots, `private_channels` will be an empty array. As bots receive private messages, they will receive [Channel Create](#DOCS_GATEWAY/channel-create) payloads before the [Message Create](#DOCS_GATEWAY/message-create) ones.
+
 ###### Ready Event Fields
 
 | Field | Type | Description |
@@ -486,12 +488,6 @@ The ready event is dispatched when a client has completed the initial handshake 
 | guilds | array of [Unavailable Guild](#DOCS_GUILD/unavailable-guild-object) objects | the guilds the user is in |
 | session_id | string | used for resuming connections |
 | \_trace | array of strings | used for debugging - the guilds the user is in |
-
->warn
->`guilds` are the guilds of which your bot is a member. They start out as unavailable when you connect to the gateway. As they become available to your bot, you will be notified via [Guild Create](#DOCS_GATEWAY/guild-create) events.
-
->warn
->`private_channels` will be an empty array for bot accounts. As bots receive private messages, you will receive [Channel Create](#DOCS_GATEWAY/channel-create) payloads before the [Message Create](#DOCS_GATEWAY/message-create) ones.
 
 #### Resumed
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -491,7 +491,7 @@ The ready event is dispatched when a client has completed the initial handshake 
 >`guilds` are the guilds of which your bot is a member. They start out as unavailable when you connect to the gateway. As they become available to your bot, you will be notified via [Guild Create](#DOCS_GATEWAY/guild-create) events.
 
 >warn
->`private_channels` will be an empty array for bot accounts. As bots receive private messages, you will receive a [Channel Create](#DOCS_GATEWAY/channel-create) payload before the [Message Create](#DOCS_GATEWAY/message-create) one.
+>`private_channels` will be an empty array for bot accounts. As bots receive private messages, you will receive [Channel Create](#DOCS_GATEWAY/channel-create) payloads before the [Message Create](#DOCS_GATEWAY/message-create) ones.
 
 #### Resumed
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -482,7 +482,6 @@ The ready event is dispatched when a client has completed the initial handshake 
 |-------|------|-------------|
 | v | integer | [gateway protocol version](#DOCS_GATEWAY/gateway-protocol-versions) |
 | user | [user](#DOCS_USER/user-object) object | information about the user including email |
-| private_channels | array of [DM channel](#DOCS_CHANNEL/channel-object) objects | the direct messages the user is in |
 | guilds | array of [Unavailable Guild](#DOCS_GUILD/unavailable-guild-object) objects | the guilds the user is in |
 | session_id | string | used for resuming connections |
 | \_trace | array of strings | used for debugging - the guilds the user is in |

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -476,7 +476,7 @@ Sent on connection to the websocket. Defines the heartbeat interval that the cli
 
 The ready event is dispatched when a client has completed the initial handshake with the gateway (for new sessions). The ready event can be the largest and most complex event the gateway will send, as it contains all the state required for a client to begin interacting with the rest of the platform.
 
-For bots, `guilds` are the guilds of which your bot is a member. They start out as unavailable when you connect to the gateway. As they become available to your bot, you will be notified via [Guild Create](#DOCS_GATEWAY/guild-create) events. Also for bots, `private_channels` will be an empty array. As bots receive private messages, they will receive [Channel Create](#DOCS_GATEWAY/channel-create) payloads before the [Message Create](#DOCS_GATEWAY/message-create) ones.
+`guilds` are the guilds of which your bot is a member. They start out as unavailable when you connect to the gateway. As they become available, your bot will be notified via [Guild Create](#DOCS_GATEWAY/guild-create) events. `private_channels` will be an empty array. As bots receive private messages, they will be notified via [Channel Create](#DOCS_GATEWAY/channel-create) events.
 
 ###### Ready Event Fields
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -482,12 +482,16 @@ The ready event is dispatched when a client has completed the initial handshake 
 |-------|------|-------------|
 | v | integer | [gateway protocol version](#DOCS_GATEWAY/gateway-protocol-versions) |
 | user | [user](#DOCS_USER/user-object) object | information about the user including email |
+| private_channels | array of [DM channel](#DOCS_CHANNEL/channel-object) objects | the direct message channels the user is in |
 | guilds | array of [Unavailable Guild](#DOCS_GUILD/unavailable-guild-object) objects | the guilds the user is in |
 | session_id | string | used for resuming connections |
 | \_trace | array of strings | used for debugging - the guilds the user is in |
 
 >warn
 >`guilds` are the guilds of which your bot is a member. They start out as unavailable when you connect to the gateway. As they become available to your bot, you will be notified via [Guild Create](#DOCS_GATEWAY/guild-create) events.
+
+>warn
+>`private_channels` will be an empty array for bot accounts. As bots receive messages, you will receive [Channel Create](#DOCS_GATEWAY/channel-create) payloads before the [Message Create](#DOCS_GATEWAY/message-create) ones.
 
 #### Resumed
 


### PR DESCRIPTION
As of #184, the READY event doesn't return any private channels anymore for bot accounts but rather CHANNEL_CREATEs get dispatched as new messages are received.

This PR rewords the `private_channels` field from the READY payload