### PR TITLE
Add field clarifying transport compression url params

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -94,7 +94,7 @@ def on_websocket_message(msg):
 |-------|------|-------------|
 | v | integer | Gateway Version to use |
 | encoding | string | 'json' or 'etf' |
-| compress | string | 'zlib-stream' (optional) |
+| compress? | string | 'zlib-stream'|
 
 The first step in establishing connectivity to the gateway is requesting a valid websocket endpoint from the API. This can be done through either the [Get Gateway](#DOCS_GATEWAY/get-gateway) or the [Get Gateway Bot](#DOCS_GATEWAY/get-gateway-bot) endpoint.
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -94,6 +94,7 @@ def on_websocket_message(msg):
 |-------|------|-------------|
 | v | integer | Gateway Version to use |
 | encoding | string | 'json' or 'etf' |
+| compress | string | 'zlib-stream' (optional) |
 
 The first step in establishing connectivity to the gateway is requesting a valid websocket endpoint from the API. This can be done through either the [Get Gateway](#DOCS_GATEWAY/get-gateway) or the [Get Gateway Bot](#DOCS_GATEWAY/get-gateway-bot) endpoint.
 


### PR DESCRIPTION
Not sure if needed, but it might be an idea to also add a note in the Transport Compression section about where you can enable it (Similar to the note in Payload Compression)