### PR TITLE
Marked fields as optional in identify payload

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -295,7 +295,7 @@ Used to trigger the initial handshake with the gateway.
 | token | string | authentication token | - |
 | properties | object | [connection properties](#DOCS_GATEWAY/identify-identify-connection-properties) | - |
 | compress? | bool | whether this connection supports compression of packets | false |
-| large_threshold? | integer | value between 50 and 250, total number of members where the gateway will stop sending offline members in the guild member list | 100 |
+| large_threshold? | integer | value between 50 and 250, total number of members where the gateway will stop sending offline members in the guild member list | 50 |
 | shard? | array of two integers (shard_id, num_shards) | used for [Guild Sharding](#DOCS_GATEWAY/sharding) | - |
 | presence? | [update status](#DOCS_GATEWAY/update-status) object | presence structure for initial presence information | - |
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -294,18 +294,18 @@ Used to trigger the initial handshake with the gateway.
 |-------|------|-------------|
 | token | string | authentication token |
 | properties | object | [connection properties](#DOCS_GATEWAY/identify-identify-connection-properties) |
-| compress | bool | whether this connection supports compression of packets |
-| large_threshold | integer | value between 50 and 250, total number of members where the gateway will stop sending offline members in the guild member list |
-| shard | array of two integers (shard_id, num_shards) | used for [Guild Sharding](#DOCS_GATEWAY/sharding) |
-| presence | [update status](#DOCS_GATEWAY/update-status) object | presence structure for initial presence information |
+| compress? | bool | whether this connection supports compression of packets |
+| large_threshold? | integer | value between 50 and 250, total number of members where the gateway will stop sending offline members in the guild member list |
+| shard? | array of two integers (shard_id, num_shards) | used for [Guild Sharding](#DOCS_GATEWAY/sharding) |
+| presence? | [update status](#DOCS_GATEWAY/update-status) object | presence structure for initial presence information |
 
 ###### Identify Connection Properties
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| $os | string | your operating system |
-| $browser | string | your library name |
-| $device | string | your library name
+| $os? | string | your operating system |
+| $browser? | string | your library name |
+| $device? | string | your library name
 
 ###### Example Identify
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -290,22 +290,22 @@ Used to trigger the initial handshake with the gateway.
 
 ###### Identify Structure
 
-| Field | Type | Description |
-|-------|------|-------------|
-| token | string | authentication token |
-| properties | object | [connection properties](#DOCS_GATEWAY/identify-identify-connection-properties) |
-| compress? | bool | whether this connection supports compression of packets |
-| large_threshold? | integer | value between 50 and 250, total number of members where the gateway will stop sending offline members in the guild member list |
-| shard? | array of two integers (shard_id, num_shards) | used for [Guild Sharding](#DOCS_GATEWAY/sharding) |
-| presence? | [update status](#DOCS_GATEWAY/update-status) object | presence structure for initial presence information |
+| Field | Type | Description | Default |
+|-------|------|-------------|---------|
+| token | string | authentication token | - |
+| properties | object | [connection properties](#DOCS_GATEWAY/identify-identify-connection-properties) | - |
+| compress? | bool | whether this connection supports compression of packets | false |
+| large_threshold? | integer | value between 50 and 250, total number of members where the gateway will stop sending offline members in the guild member list | 100 |
+| shard? | array of two integers (shard_id, num_shards) | used for [Guild Sharding](#DOCS_GATEWAY/sharding) | - |
+| presence? | [update status](#DOCS_GATEWAY/update-status) object | presence structure for initial presence information | - |
 
 ###### Identify Connection Properties
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| $os? | string | your operating system |
-| $browser? | string | your library name |
-| $device? | string | your library name
+| $os | string | your operating system |
+| $browser | string | your library name |
+| $device | string | your library name |
 
 ###### Example Identify
 


### PR DESCRIPTION
I didn't check which fields could also be nullable, however this at least gives new library devs an easier time to make a first session.
`{"token": "my_token", "properties": {}}` is a valid identify payload.