### PR TITLE
Mark channel_id as nullable in Guild Embed Object

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -122,7 +122,7 @@ A partial [guild](#DOCS_RESOURCES_GUILD/guild-object) object. Represents an Offl
 | Field | Type | Description |
 |-------|------|-------------|
 | enabled | bool | if the embed is enabled |
-| channel_id | snowflake | the embed channel id |
+| channel_id | ?snowflake | the embed channel id |
 
 ###### Example Guild Embed
 


### PR DESCRIPTION
It is possible for an embed to have no instant invite channel set.
```json
{"channel_id": null, "enabled": true}
```