### PR TITLE
Remove plans for 'prune messages' endpoint

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -515,7 +515,6 @@ Any message IDs given that do not exist or are invalid will count towards the mi
 
 >warn
 >This endpoint will not delete messages older than 2 weeks, and will fail if any message provided is older than that.
->An endpoint will be added in the future to prune messages older than 2 weeks from a channel.
 
 ###### JSON Params
 


### PR DESCRIPTION
The docs for [Bulk Delete Messages](https://discordapp.com/developers/docs/resources/channel#bulk-delete-messages) say that:
```
An endpoint will be added in the future to prune messages older than 2 weeks from a channel.
```

But in [#208](https://github.com/discordapp/discord-api-docs/issues/208#issuecomment-370077554), it was stated that this endpoint is no longer planned. Therefore, the sentence above should be removed from the docs.