### PR TITLE
Update guild.join to point to current resource

### DIFF
--- a/docs/resources/Invite.md
+++ b/docs/resources/Invite.md
@@ -74,10 +74,3 @@ Returns an [invite](#DOCS_RESOURCES_INVITE/invite-object) object for the given c
 ## Delete Invite % DELETE /invites/{invite.code#DOCS_RESOURCES_INVITE/invite-object}
 
 Delete an invite. Requires the `MANAGE_CHANNELS` permission. Returns an [invite](#DOCS_RESOURCES_INVITE/invite-object) object on success.
-
-## Accept Invite % POST /invites/{invite.code#DOCS_RESOURCES_INVITE/invite-object}
-
->danger
->This endpoint is deprecated and will be discontinued on March 23, 2018. [Add Guild Member](#DOCS_RESOURCES_GUILD/add-guild-member) should be used in its place.
-
-Accept an invite. This requires the `guilds.join` OAuth2 scope to be able to accept invites on behalf of normal users (via an OAuth2 Bearer token). Bot users are disallowed. Returns an [invite](#DOCS_RESOURCES_INVITE/invite-object) object on success.

--- a/docs/topics/OAuth2.md
+++ b/docs/topics/OAuth2.md
@@ -26,7 +26,7 @@ The first step in implementing OAuth2 is [registering a developer application](#
 | email | enables [/users/@me](#DOCS_RESOURCES_USER/get-current-user) to return an `email` |
 | identify | allows [/users/@me](#DOCS_RESOURCES_USER/get-current-user) without `email` |
 | guilds | allows [/users/@me/guilds](#DOCS_RESOURCES_USER/get-current-user-guilds) to return basic information about all of a user's guilds |
-| guilds.join | allows [/invites/{invite.id}](#DOCS_RESOURCES_INVITE/accept-invite) to be used for joining users to a guild |
+| guilds.join | allows [/guilds/{guild.id}/members/{user.id}](#DOCS_RESOURCES_GUILD/add-guild-member) to be used for joining users to a guild |
 | gdm.join | allows your app to [join users to a group dm](#DOCS_RESOURCES_CHANNEL/group-dm-add-recipient) |
 | messages.read | for local rpc server api access, this allows you to read messages from all client channels (otherwise restricted to channels/guilds your app creates) |
 | rpc | for local rpc server access, this allows you to control a user's local Discord client |


### PR DESCRIPTION
The endpoint previously linked points to [/invites/{invite.id}](https://discordapp.com/developers/docs/resources/invite#accept-invite), which was deprecated and discontinued on the 23 of March. I did not remove the discontinued item from the docs, but I can if requested.