### PR TITLE
Update Get Guild Roles and list Guild Emojis docs to reflect #581

### DIFF
--- a/docs/resources/Emoji.md
+++ b/docs/resources/Emoji.md
@@ -56,7 +56,7 @@
 
 ## List Guild Emojis % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/emojis
 
-Returns a list of [emoji](#DOCS_RESOURCES_EMOJI/emoji-object) objects for the given guild. Requires the `MANAGE_EMOJIS` permission.
+Returns a list of [emoji](#DOCS_RESOURCES_EMOJI/emoji-object) objects for the given guild.
 
 ## Get Guild Emoji % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/emojis/{emoji.id#DOCS_RESOURCES_EMOJI/emoji-object}
 

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -411,7 +411,7 @@ Remove the ban for a user. Requires the 'BAN_MEMBERS' permissions. Returns a 204
 
 ## Get Guild Roles % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/roles
 
-Returns a list of [role](#DOCS_TOPICS_PERMISSIONS/role-object) objects for the guild. Requires the 'MANAGE_ROLES' permission.
+Returns a list of [role](#DOCS_TOPICS_PERMISSIONS/role-object) objects for the guild.
 
 ## Create Guild Role % POST /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/roles
 


### PR DESCRIPTION
I removed the requires "permission `MANAGE_ROLES/EMOJIS`" clauses from the documentation for the `Get Guild Roles` and the `List Guild Emojis` endpoints