### PR TITLE
Create Guild Emoji: clarify size limit

### DIFF
--- a/docs/resources/Emoji.md
+++ b/docs/resources/Emoji.md
@@ -67,7 +67,7 @@ Returns an [emoji](#DOCS_RESOURCES_EMOJI/emoji-object) object for the given guil
 Create a new emoji for the guild. Requires the 'MANAGE_EMOJIS' permission. Returns the new [emoji](#DOCS_RESOURCES_EMOJI/emoji-object) object on success. Fires a [Guild Emojis Update](#DOCS_TOPICS_GATEWAY/guild-emojis-update) Gateway event.
 
 >warn
->Emojis and animated emojis have a maximum file size of 256kb. Attempting to upload an emoji larger than this limit will fail and return 400 Bad Request and an error message, but not a [JSON status code](#DOCS_TOPICS_OPCODES_AND_STATUS_CODES/json).
+>Emojis and animated emojis have a maximum file size of 256KiB. Attempting to upload an emoji larger than this limit will fail and return 400 Bad Request and an error message, but not a [JSON status code](#DOCS_TOPICS_OPCODES_AND_STATUS_CODES/json).
 
 ###### JSON Params
 


### PR DESCRIPTION
"kb" can mean 1024 bytes or 1000 bytes.
In my experience, the limit is actually 1024 bytes, which is unambiguously called "KiB".

For consistency, this should be changed in the HTTP error response as well. It's currently

400 Bad Request
Invalid Form Body
In image: File cannot be larger than 256 **kb**