### PR TITLE
Mark guild as optional on invites since group DMs have invites now

### DIFF
--- a/docs/resources/Invite.md
+++ b/docs/resources/Invite.md
@@ -2,14 +2,14 @@
 
 ### Invite Object
 
-Represents a code that when used, adds a user to a guild.
+Represents a code that when used, adds a user to a guild or group DM channel.
 
 ###### Invite Structure
 
 | Field | Type | Description |
 |-------|------|-------------|
 | code | string | the invite code (unique ID) |
-| guild | partial [guild](#DOCS_RESOURCES_GUILD/guild-object) object | the guild this invite is for |
+| guild? | partial [guild](#DOCS_RESOURCES_GUILD/guild-object) object | the guild this invite is for |
 | channel | partial [channel](#DOCS_RESOURCES_CHANNEL/channel-object) object | the channel this invite is for |
 | approximate_presence_count? | int | approximate count of online members |
 | approximate_member_count? | int | approximate count of total members |


### PR DESCRIPTION
Ref [this @discordapp tweet](https://twitter.com/discordapp/status/1007770364519186432) and some conversation we had in #js_eris on the API server the other day. Marked the guild of an invite as optional, as invites to a group DM won't return one since group DMs aren't guilds.