### PR TITLE
Add 50025 Invalid OAuth 2 access token error

### DIFF
--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -144,6 +144,7 @@ Along with the HTTP error code, our API can also return more detailed error code
 | 50016 | Provided too few or too many messages to delete. Must provide at least 2 and fewer than 100 messages to delete. |
 | 50019 | A message can only be pinned to the channel it was sent in |
 | 50021 | Cannot execute action on a system message |
+| 50025 | Invalid OAuth2 access token |
 | 50034 | A message provided was too old to bulk delete |
 | 50035 | Invalid Form Body |
 | 50036 | An invite was accepted to a guild the application's bot is not in |


### PR DESCRIPTION
Occurs when authorization token is expired / has been refreshed and a stale copy is being used, or authorization token and bot token do not match when calling this endpoint https://discordapp.com/developers/docs/resources/guild#add-guild-member