### PR TITLE
Add Javacord as a compliant library

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -16,6 +16,7 @@ The Discord team curates the following list of officially vetted libraries that 
 | [dscord](https://github.com/b1naryth1ef/dscord) | D |
 | [DiscordGo](https://github.com/bwmarrin/discordgo) | Go |
 | [Discord4j](https://github.com/austinv11/Discord4J) | Java |
+| [Javacord](https://github.com/Javacord/Javacord) | Java |
 | [JDA](https://github.com/DV8FromTheWorld/JDA) | Java |
 | [discord.js](https://github.com/discordjs/discord.js) | JavaScript |
 | [Eris](https://github.com/abalabahaha/eris) | JavaScript |


### PR DESCRIPTION
This pull request (re)adds Javacord as a compliant library. The library got removed (commit https://github.com/discordapp/discord-api-docs/commit/c4a4783fbacf69289f3841dedc9658b3016bc5fd), because it didn't properly handle ratelimits (see #108) back then due to not being actively maintained.
The latest version is a complete rewrite which properly handles ratelimits (delay actions using the headers to not cause 429s) and is 100% feature-complete besides voice.
These are the ratelimit-relavant classes, if you want to check:
* [RatelimitManager.java](https://github.com/Javacord/Javacord/blob/master/javacord-core/src/main/java/org/javacord/core/util/ratelimit/RatelimitManager.java)
* [RatelimitBucket.java](https://github.com/Javacord/Javacord/blob/v_3/javacord-core/src/main/java/org/javacord/core/util/ratelimit/RatelimitBucket.java)
* [RestRequest.java](https://github.com/Javacord/Javacord/blob/v_3/javacord-core/src/main/java/org/javacord/core/util/rest/RestRequest.java)

The result would look like this without hitting any ratelimits:
```java
for (int i = 1; i <= 12; i++) {
    channel.sendMessage("Ratelimit Example #" + i);
}
```
![Example](https://i.imgur.com/ailPCdH.gif)