### PR TITLE
Game SDK V2 and Docs Reformatting

### DIFF
--- a/docs/game_sdk/Activities.md
+++ b/docs/game_sdk/Activities.md
@@ -182,14 +182,6 @@ Results a `Discord.Result` via callback.
 
 None
 
-###### Possible Results
-
-| error        | description              |
-| ------------ | ------------------------ |
-| OK           | success                  |
-| NotInstalled | Discord is not installed |
-| NotRunning   | Discord is not running   |
-
 ###### Example
 
 ```cs
@@ -217,14 +209,6 @@ Returns a `Discord.Result` via callback.
 | type    | ActivityActionType | marks the invite as an invitation to join or spectate |
 | content | string             | a message to send along with the invite               |
 
-###### Possible Results
-
-| error        | description              |
-| ------------ | ------------------------ |
-| OK           | success                  |
-| NotInstalled | Discord is not installed |
-| NotRunning   | Discord is not running   |
-
 ###### Example
 
 ```cs
@@ -249,14 +233,6 @@ Returns a `Discord.Result` via callback.
 | name   | type  | description                        |
 | ------ | ----- | ---------------------------------- |
 | userId | Int64 | the id of the user who invited you |
-
-###### Possible Results
-
-| error        | description              |
-| ------------ | ------------------------ |
-| OK           | success                  |
-| NotInstalled | Discord is not installed |
-| NotRunning   | Discord is not running   |
 
 ###### Example
 

--- a/docs/game_sdk/Activities.md
+++ b/docs/game_sdk/Activities.md
@@ -11,13 +11,13 @@ For more detailed information and documentation around the Rich Presence feature
 
 ###### User Struct
 
-| name          | type   | description                   |
-| ------------- | ------ | ----------------------------- |
-| Id            | Int32  | the user's id                 |
-| Username      | string | their name                    |
-| Discriminator | string | the user's unique discrim     |
-| Avatar        | string | the hash of the user's avatar |
-| Bot           | bool   | if the user is a bot user     |
+| name          | type             | description                   |
+| ------------- | ---------------- | ----------------------------- |
+| Id            | Int64            | the user's id                 |
+| Username      | string (256 len) | their name                    |
+| Discriminator | string (8 len)   | the user's unique discrim     |
+| Avatar        | string (128 len) | the hash of the user's avatar |
+| Bot           | bool             | if the user is a bot user     |
 
 ###### Activity Struct
 
@@ -42,19 +42,19 @@ For more detailed information and documentation around the Rich Presence feature
 
 ###### ActivityAssets Struct
 
-| name       | type   | description                    |
-| ---------- | ------ | ------------------------------ |
-| LargeImage | string | keyname of an asset to display |
-| LargeText  | string | hover text for the large image |
-| SmallImage | string | keyname of an asset to display |
-| SmallText  | string | hover text for the small image |
+| name       | type             | description                    |
+| ---------- | ---------------- | ------------------------------ |
+| LargeImage | string (128 len) | keyname of an asset to display |
+| LargeText  | string (128 len) | hover text for the large image |
+| SmallImage | string (128 len) | keyname of an asset to display |
+| SmallText  | string (128 len) | hover text for the small image |
 
 ###### ActivityParty Struct
 
-| name | type      | description                        |
-| ---- | --------- | ---------------------------------- |
-| Id   | string    | a unique identifier for this party |
-| Size | PartySize | info about the size of the party   |
+| name | type             | description                        |
+| ---- | ---------------- | ---------------------------------- |
+| Id   | string (128 len) | a unique identifier for this party |
+| Size | PartySize        | info about the size of the party   |
 
 ###### PartySize Struct
 
@@ -65,11 +65,11 @@ For more detailed information and documentation around the Rich Presence feature
 
 ###### ActivitySecrets Struct
 
-| name     | type   | description                                  |
-| -------- | ------ | -------------------------------------------- |
-| Match    | string | unique hash for the given match context      |
-| Join     | string | unique hash for chat invites and Ask to Join |
-| Spectate | string | unique hash for Spectate button              |
+| name     | type             | description                                  |
+| -------- | ---------------- | -------------------------------------------- |
+| Match    | string (128 len) | unique hash for the given match context      |
+| Join     | string (128 len) | unique hash for chat invites and Ask to Join |
+| Spectate | string (128 len) | unique hash for Spectate button              |
 
 ###### ActivityType Enum
 
@@ -247,7 +247,7 @@ activityManager.AcceptInvite(290926444748734466, Discord.Result result => {
 });
 ```
 
-## OnActivityJoin
+## OnJoin
 
 Fires when a user accepts a game chat invite or receives confirmation from Asking to Join.
 
@@ -257,7 +257,7 @@ Fires when a user accepts a game chat invite or receives confirmation from Askin
 | ---------- | ------ | ---------------------------------- |
 | joinSecret | string | the secret to join the user's game |
 
-## OnActivitySpectate
+## OnSpectate
 
 Fires when a user accepts a spectate chat invite or clicks the Spectate button on a user's profile.
 
@@ -267,7 +267,7 @@ Fires when a user accepts a spectate chat invite or clicks the Spectate button o
 | -------------- | ------ | ------------------------------------------------- |
 | spectateSecret | string | the secret to join the user's game as a spectator |
 
-## OnActivityJoinRequest
+## OnJoinRequest
 
 Fires when a user asks to join the current user's game.
 
@@ -277,7 +277,7 @@ Fires when a user asks to join the current user's game.
 | ---- | ---- | ----------------------- |
 | user | User | the user asking to join |
 
-## OnActivityInvite
+## OnInvite
 
 Fires when the user receives a join or spectate invite.
 

--- a/docs/game_sdk/Activities.md
+++ b/docs/game_sdk/Activities.md
@@ -327,14 +327,14 @@ var activity = new Discord.Activity
   Instance = true,
 };
 
-activitiesManager.UpdateActivity(activity, result =>
+ActivityManager.UpdateActivity(activity, result =>
 {
   Console.WriteLine("Update Activity {0}", result);
 
   // Send an invite to another user for this activity.
   // Receiver should see an invite in their DM.
   // Use a relationship user's ID for this.
-  activitiesManager
+  ActivityManager
     .InviteUser(
         364843917537050999,
         Discord.ActivityActionType.Join,

--- a/docs/game_sdk/Activities.md
+++ b/docs/game_sdk/Activities.md
@@ -7,7 +7,7 @@ Looking to integrate Rich Presence into your game? No need to manage multiple SD
 
 For more detailed information and documentation around the Rich Presence feature set and integration tips, check out our [Rich Presence Documentation](https://discordapp.com/developers/docs/rich-presence/how-to).
 
-### Data Models
+## Data Models
 
 ###### User Struct
 
@@ -95,11 +95,11 @@ For more detailed information and documentation around the Rich Presence feature
 | Join     | 1     |
 | Spectate | 2     |
 
-### Methods
+## Register
 
-`Register()`
+Registers a command by which Discord can launch your game. This might be a custom protocol, like `my-awesome-game://`, or a path to an executable. It also supports any lauch parameters that may be needed, like `game.exe --full-screen --no-hax`.
 
-Registers a command by which Discord can launch your game. This might be a custom protocol, like `my-awesome-game://`, or a path to an executable. It also supports any lauch parameters that may be needed, like `game.exe --full-screen --no-hax`. Returns `void`.
+Returns `void`.
 
 ###### Parameters
 
@@ -107,9 +107,17 @@ Registers a command by which Discord can launch your game. This might be a custo
 | ------- | ------ | ----------------------- |
 | command | string | the command to register |
 
-`RegisterSteam()`
+###### Example
 
-Used if you are distributing this SDK on Steam. Registers your game's Steam app id for the protocol `steam://run-game-id/<id>`. Returns `void`.
+```cs
+activitiesManager.Register("my-awesome-game://run --full-screen");
+```
+
+## RegisterSteam
+
+Used if you are distributing this SDK on Steam. Registers your game's Steam app id for the protocol `steam://run-game-id/<id>`.
+
+Returns `void`.
 
 ###### Parameters
 
@@ -117,9 +125,17 @@ Used if you are distributing this SDK on Steam. Registers your game's Steam app 
 | ------- | ------ | ------------------------ |
 | steamId | UInt32 | your game's Steam app id |
 
-`UpdateActivity()`
+###### Example
 
-Set's a user's presence in Discord to a new activity. Returns a `Discord.Result` via callback.
+```cs
+activitiesManager.RegisterSteam(1938123);
+```
+
+## UpdateActivity
+
+Set's a user's presence in Discord to a new activity.
+
+Returns a `Discord.Result` via callback.
 
 ###### Parameters
 
@@ -137,9 +153,30 @@ Set's a user's presence in Discord to a new activity. Returns a `Discord.Result`
 | NotInstalled   | Discord is not installed               |
 | NotRunning     | Discord is not running                 |
 
-`ClearActivity()`
+###### Example
 
-Clear's a user's presence in Discord to make it show nothing. Results a `Discord.Result` via callback.
+```cs
+var activity = new Discord.Activity();
+activity.State = "Hello!";
+activity.Details = "In Game";
+activity.Party.Size = 1;
+activity.Party.Max = 4;
+
+activitiesManager.UpdateActivity(activity, Discord.Result result => {
+    if (result == Discord.Result.OK) {
+        Console.WriteLine("Success!");
+    }
+    else {
+        Console.WriteLine("Failed");
+    }
+});
+```
+
+## ClearActivity
+
+Clear's a user's presence in Discord to make it show nothing.
+
+Results a `Discord.Result` via callback.
 
 ###### Parameters
 
@@ -153,9 +190,24 @@ None
 | NotInstalled | Discord is not installed |
 | NotRunning   | Discord is not running   |
 
-`InviteUser()`
+###### Example
 
-Sends a game invite to a given user. Returns a `Discord.Result` via callback.
+```cs
+activitiesManager.ClearActivity(Discord.Result result => {
+    if (result == Discord.Result.OK) {
+        Console.WriteLine("Success!");
+    }
+    else {
+        Console.WriteLine("Failed");
+    }
+});
+```
+
+## InviteUser
+
+Sends a game invite to a given user.
+
+Returns a `Discord.Result` via callback.
 
 ###### Parameters
 
@@ -173,9 +225,24 @@ Sends a game invite to a given user. Returns a `Discord.Result` via callback.
 | NotInstalled | Discord is not installed |
 | NotRunning   | Discord is not running   |
 
-`AcceptInvite()`
+###### Example
 
-Accepts a game invitation from a given userId. Returns a `Discord.Result` via callback.
+```cs
+activityManager.InviteUser(53908232506183689, Discord.ActivityActionType.Join, "Come play!", Discord.Result result => {
+    if (result == Discord.Result.OK) {
+        Console.WriteLine("Success!");
+    }
+    else {
+        Console.WriteLine("Failed");
+    }
+});
+```
+
+## AcceptInvite
+
+Accepts a game invitation from a given userId.
+
+Returns a `Discord.Result` via callback.
 
 ###### Parameters
 
@@ -191,9 +258,20 @@ Accepts a game invitation from a given userId. Returns a `Discord.Result` via ca
 | NotInstalled | Discord is not installed |
 | NotRunning   | Discord is not running   |
 
-### Callbacks
+###### Example
 
-`OnActivityJoin`
+```cs
+activityManager.AcceptInvite(290926444748734466, Discord.Result result => {
+    if (result == Discord.Result.OK) {
+        Console.WriteLine("Success!");
+    }
+    else {
+        Console.WriteLine("Failed");
+    }
+});
+```
+
+## OnActivityJoin
 
 Fires when a user accepts a game chat invite or receives confirmation from Asking to Join.
 
@@ -203,7 +281,7 @@ Fires when a user accepts a game chat invite or receives confirmation from Askin
 | ---------- | ------ | ---------------------------------- |
 | joinSecret | string | the secret to join the user's game |
 
-`OnActivitySpectate`
+## OnActivitySpectate
 
 Fires when a user accepts a spectate chat invite or clicks the Spectate button on a user's profile.
 
@@ -213,7 +291,7 @@ Fires when a user accepts a spectate chat invite or clicks the Spectate button o
 | -------------- | ------ | ------------------------------------------------- |
 | spectateSecret | string | the secret to join the user's game as a spectator |
 
-`OnActivityJoinRequest`
+## OnActivityJoinRequest
 
 Fires when a user asks to join the current user's game.
 
@@ -223,7 +301,7 @@ Fires when a user asks to join the current user's game.
 | ---- | ---- | ----------------------- |
 | user | User | the user asking to join |
 
-`OnActivityInvite`
+## OnActivityInvite
 
 Fires when the user receives a join or spectate invite.
 
@@ -235,7 +313,7 @@ Fires when the user receives a join or spectate invite.
 | user     | User               | the user sending the invite                |
 | activity | Activity           | the inviting user's current activity       |
 
-### Example: Inviting a User to a Game
+## Example: Inviting a User to a Game
 
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);

--- a/docs/game_sdk/Activities.md
+++ b/docs/game_sdk/Activities.md
@@ -11,13 +11,13 @@ For more detailed information and documentation around the Rich Presence feature
 
 ###### User Struct
 
-| name          | type             | description                   |
-| ------------- | ---------------- | ----------------------------- |
-| Id            | Int64            | the user's id                 |
-| Username      | string (256 len) | their name                    |
-| Discriminator | string (8 len)   | the user's unique discrim     |
-| Avatar        | string (128 len) | the hash of the user's avatar |
-| Bot           | bool             | if the user is a bot user     |
+| name          | type   | description                   |
+| ------------- | ------ | ----------------------------- |
+| Id            | Int64  | the user's id                 |
+| Username      | string | their name                    |
+| Discriminator | string | the user's unique discrim     |
+| Avatar        | string | the hash of the user's avatar |
+| Bot           | bool   | if the user is a bot user     |
 
 ###### Activity Struct
 
@@ -42,19 +42,19 @@ For more detailed information and documentation around the Rich Presence feature
 
 ###### ActivityAssets Struct
 
-| name       | type             | description                    |
-| ---------- | ---------------- | ------------------------------ |
-| LargeImage | string (128 len) | keyname of an asset to display |
-| LargeText  | string (128 len) | hover text for the large image |
-| SmallImage | string (128 len) | keyname of an asset to display |
-| SmallText  | string (128 len) | hover text for the small image |
+| name       | type   | description                    |
+| ---------- | ------ | ------------------------------ |
+| LargeImage | string | keyname of an asset to display |
+| LargeText  | string | hover text for the large image |
+| SmallImage | string | keyname of an asset to display |
+| SmallText  | string | hover text for the small image |
 
 ###### ActivityParty Struct
 
-| name | type             | description                        |
-| ---- | ---------------- | ---------------------------------- |
-| Id   | string (128 len) | a unique identifier for this party |
-| Size | PartySize        | info about the size of the party   |
+| name | type      | description                        |
+| ---- | --------- | ---------------------------------- |
+| Id   | string    | a unique identifier for this party |
+| Size | PartySize | info about the size of the party   |
 
 ###### PartySize Struct
 
@@ -65,11 +65,11 @@ For more detailed information and documentation around the Rich Presence feature
 
 ###### ActivitySecrets Struct
 
-| name     | type             | description                                  |
-| -------- | ---------------- | -------------------------------------------- |
-| Match    | string (128 len) | unique hash for the given match context      |
-| Join     | string (128 len) | unique hash for chat invites and Ask to Join |
-| Spectate | string (128 len) | unique hash for Spectate button              |
+| name     | type   | description                                  |
+| -------- | ------ | -------------------------------------------- |
+| Match    | string | unique hash for the given match context      |
+| Join     | string | unique hash for chat invites and Ask to Join |
+| Spectate | string | unique hash for Spectate button              |
 
 ###### ActivityType Enum
 

--- a/docs/game_sdk/Applications.md
+++ b/docs/game_sdk/Applications.md
@@ -103,7 +103,7 @@ void ValidateOrExit((Discord.Result result) =>
 
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);
-var appManager = new discord.CreateApplicationsManager();
+var appManager = new discord.CreateApplicationManager();
 
 // Retrieve the token
 appManager.GetOAuth2Token((OAuth2Token token) =>

--- a/docs/game_sdk/Applications.md
+++ b/docs/game_sdk/Applications.md
@@ -13,11 +13,11 @@ This manager also includes a couple useful helper functions, like getting the lo
 
 ## OAuth2Token Struct
 
-| name        | type   | description                                                                                     |
-| ----------- | ------ | ----------------------------------------------------------------------------------------------- |
-| AccessToken | string | a bearer token for the current user                                                             |
-| Scopes      | string | a list of oauth2 scopes as a single string, delineated by spaces like `"identify rpc gdm.join"` |
-| Expires     | Int64  | the timestamp at which the token expires                                                        |
+| name        | type              | description                                                                                     |
+| ----------- | ----------------- | ----------------------------------------------------------------------------------------------- |
+| AccessToken | string (128 len)  | a bearer token for the current user                                                             |
+| Scopes      | string (1024 len) | a list of oauth2 scopes as a single string, delineated by spaces like `"identify rpc gdm.join"` |
+| Expires     | Int64             | the timestamp at which the token expires                                                        |
 
 ## GetCurrentLocale
 
@@ -103,7 +103,7 @@ void ValidateOrExit((Discord.Result result) =>
 
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);
-var appManager = new discord.CreateApplicationManager();
+var appManager = new discord.GetApplicationManager();
 
 // Retrieve the token
 appManager.GetOAuth2Token((OAuth2Token token) =>

--- a/docs/game_sdk/Applications.md
+++ b/docs/game_sdk/Applications.md
@@ -11,43 +11,95 @@ These bearer tokens are good for seven days, after which they will expire. When 
 
 This manager also includes a couple useful helper functions, like getting the locale in which the user has chosen to use their Discord client, and knowing which game branch the game is running on. More about branches in the Dispatch CLI tool section of the documentation.
 
-### Models
+## OAuth2Token Struct
+
+| name        | type   | description                                                                                     |
+| ----------- | ------ | ----------------------------------------------------------------------------------------------- |
+| AccessToken | string | a bearer token for the current user                                                             |
+| Scopes      | string | a list of oauth2 scopes as a single string, delineated by spaces like `"identify rpc gdm.join"` |
+| Expires     | Int64  | the timestamp at which the token expires                                                        |
+
+## GetCurrentLocale
+
+Get's the locale the current user has Discord set to.
+
+Returns a `string`.
+
+###### Parameters
+
+None
+
+###### Example
 
 ```cs
-struct OAuth2Token
-{
-  string AccessToken;
-  string Scopes;
-  Int64 Expires;
+var locale = applicationManager.GetCurrentLocale();
+Console.WriteLine("This user's language is {0}", locale);
+```
+
+## GetCurrentBranch
+
+Get the name of pushed branch on which the game is running. These are branches that you created and pushed using Dispatch.
+
+###### Parameters
+
+None
+
+###### Example
+
+```cs
+var branch = applicationManager.GetCurrentBranch();
+if (branch !== MyBranches.Stable) {
+  Console.WriteLine("You are on a beta branch; expect bugs!");
 }
 ```
 
-### Methods
+## GetOAuth2Token
+
+Retrieve an oauth2 beare token for the current user. If your game was launched from Discord and you call this function, you will automatically receive the token. If the game was _not_ launched from Discord and this method is called, Discord will focus itself and prompt the user for authorization.
+
+Returns a `Discord.Result` and an `OAuth2Token` via callback.
+
+###### Parameters
+
+None
+
+###### Example
 
 ```cs
-string GetCurrentLocale();
-// Returns the locale the user chose in Discord as a string
-// See our Dispatch documentation for a list of valid values
-
-string GetCurrentBranch();
-// Returns the name as a string of your pushed branch the game is running on
-
-void GetOAuth2Token((Discord.Result result, OAuth2Token token) =>
+applicationManager.GetOAuth2Token((Discord.Result result, OAuth2Token token) =>
 {
-  // Returns the access token for the current user
-  // If call this function, and the game did was _not_ launched from Discord
-  // Discord will focus itself and pop an authorization modal for your application, and then return the token on accept
-  // If the game was launched from Discord, it will bypass the modal and return the token
-});
-
-void ValidateOrExit((Discord.Result result) =>
-{
-  // Entitlements check - does the user have the entitlement for this application?
-  // If so, good to go. If not, exit game
+  if (result == Discord.Result.OK) {
+    Console.WriteLine("Token for the user: {0}. Expires in {1}", token.AccessToken, token.Expires);
+    // You may now use this token against Discord's HTTP API
+  }
 });
 ```
 
-### Example: Get OAuth2 Token
+## ValidateOrExit
+
+Checks if the current user has the entitlement to run this game.
+
+Returns `void`.
+
+###### Parameters
+
+None
+
+###### Example
+
+```cs
+void ValidateOrExit((Discord.Result result) =>
+{
+  if (result !== Discord.Result.OK) {
+    Console.WriteLine("Something went wrong!");
+  }
+  if (result == Discord.Result.OK) {
+    // Game continues running
+  }
+});
+```
+
+## Example: Get OAuth2 Token
 
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);

--- a/docs/game_sdk/Applications.md
+++ b/docs/game_sdk/Applications.md
@@ -13,11 +13,11 @@ This manager also includes a couple useful helper functions, like getting the lo
 
 ## OAuth2Token Struct
 
-| name        | type              | description                                                                                     |
-| ----------- | ----------------- | ----------------------------------------------------------------------------------------------- |
-| AccessToken | string (128 len)  | a bearer token for the current user                                                             |
-| Scopes      | string (1024 len) | a list of oauth2 scopes as a single string, delineated by spaces like `"identify rpc gdm.join"` |
-| Expires     | Int64             | the timestamp at which the token expires                                                        |
+| name        | type   | description                                                                                     |
+| ----------- | ------ | ----------------------------------------------------------------------------------------------- |
+| AccessToken | string | a bearer token for the current user                                                             |
+| Scopes      | string | a list of oauth2 scopes as a single string, delineated by spaces like `"identify rpc gdm.join"` |
+| Expires     | Int64  | the timestamp at which the token expires                                                        |
 
 ## GetCurrentLocale
 
@@ -103,7 +103,7 @@ void ValidateOrExit((Discord.Result result) =>
 
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);
-var appManager = new discord.GetApplicationManager();
+var appManager = discord.GetApplicationManager();
 
 // Retrieve the token
 appManager.GetOAuth2Token((OAuth2Token token) =>

--- a/docs/game_sdk/Discord.md
+++ b/docs/game_sdk/Discord.md
@@ -32,7 +32,7 @@ Some functions behave with a normal return behavior; e.g. `RelationshipManager.C
 A quick example with our C# binding:
 
 ```c#
-var userManager = Discord.GetUserManager();
+var userManager = discord.GetUserManager();
 userManager.GetCurrentUser((result, currentUser) =>
 {
  Console.WriteLine(currentUser.username);
@@ -40,9 +40,9 @@ userManager.GetCurrentUser((result, currentUser) =>
 });
 ```
 
-## Discord
+## Core
 
-Discord is the interface through which your game talks to...Discord...obfuscating all the hard stuff and getting you to what you want quickly and easily.
+The Discord core is the interface through which your game talks to...Discord...obfuscating all the hard stuff and getting you to what you want quickly and easily.
 
 ## Error Handling
 
@@ -221,7 +221,7 @@ None
 ###### Example
 
 ```cs
-var activityManager = Discord.GetActivityManager();
+var activityManager = discord.GetActivityManager();
 ```
 
 ## GetRelationshipManager
@@ -237,7 +237,7 @@ None
 ###### Example
 
 ```cs
-var relationshipManager = Discord.GetRelationshipManager();
+var relationshipManager = discord.GetRelationshipManager();
 ```
 
 ## GetImageManager
@@ -253,7 +253,7 @@ None
 ###### Example
 
 ```cs
-var imageManager = Discord.GetImageManager();
+var imageManager = discord.GetImageManager();
 ```
 
 ## GetUserManager
@@ -269,7 +269,7 @@ None
 ###### Example
 
 ```cs
-var userManager = Discord.GetUserManager();
+var userManager = discord.GetUserManager();
 ```
 
 ## GetLobbyManager
@@ -285,7 +285,7 @@ None
 ###### Example
 
 ```cs
-var lobbyManager = Discord.GetLobbyManager();
+var lobbyManager = discord.GetLobbyManager();
 ```
 
 ## GetNetworkManager
@@ -301,7 +301,7 @@ None
 ###### Example
 
 ```cs
-var networkManager = Discord.GetNetworkManager();
+var networkManager = discord.GetNetworkManager();
 ```
 
 ## GetOverlayManager
@@ -317,7 +317,7 @@ None
 ###### Example
 
 ```cs
-var overlayManager = Discord.GetOverlayManager();
+var overlayManager = discord.GetOverlayManager();
 ```
 
 ## GetApplicationManager
@@ -333,7 +333,7 @@ None
 ###### Example
 
 ```cs
-var applicationManager = Discord.GetApplicationManager();
+var applicationManager = discord.GetApplicationManager();
 ```
 
 ## GetStorageManager
@@ -349,7 +349,7 @@ None
 ###### Example
 
 ```cs
-var storageManager = Discord.GetStorageManager();
+var storageManager = discord.GetStorageManager();
 ```
 
 ## OnReady

--- a/docs/game_sdk/Discord.md
+++ b/docs/game_sdk/Discord.md
@@ -71,41 +71,42 @@ SetLogHook(LogLevel level, LogProblemsFunction callback);
 
 You should begin your integration by setting up this callback to help you debug. Helpfully, if you put a breakpoint inside the callback function you register here, you'll be able to see the stack trace for errors you run into (as long as they fail synchronously). Take the guess work out of debugging, or hey, ignore any and all logging by setting a callback that does nothing. We're not here to judge.
 
-### Data Models
+## Models
+
+####### Result Enum
+
+| Value               | Description                                                                    |
+| ------------------- | ------------------------------------------------------------------------------ |
+| Ok                  | everything is good                                                             |
+| ServiceUnavailable  | Discord isn't working                                                          |
+| InvalidVersion      | the SDK version may be outdated                                                |
+| LockFailed          | an internal error on transactional operations                                  |
+| InternalError       | something on our side went wrong                                               |
+| InvalidPayload      | the data you sent didn't match what we expect                                  |
+| InvalidCommand      | that's not a thing you can do                                                  |
+| InvalidPermissions  | you aren't authorized to do that                                               |
+| NotFetched          | couldn't fetch what you wanted                                                 |
+| NotFound            | what you're looking for doesn't exist                                          |
+| Conflict            | ?                                                                              |
+| InvalidSecret       | activity secrets must be unique                                                |
+| InvalidJoinSecret   | the secret you're using to connect is wrong                                    |
+| NoEligibleActivity  | ?                                                                              |
+| InvalidInvite       | your game invite is no longer valid                                            |
+| NotAuthenticated    | the internal auth call failed for the user, and you can't do this              |
+| InvalidAccessToken  | the user's bearer token is invalid                                             |
+| ApplicationMismatch | ?                                                                              |
+| InvalidDataUrl      | ?                                                                              |
+| InvalidBase64       | ?                                                                              |
+| NotFiltered         | you're trying to access the list before creating a stable list with `Filter()` |
+| LobbyFull           | the lobby is full                                                              |
+| InvalidLobbySecret  | the secret you're using to connect is wrong                                    |
+| InvalidFilename     | ?                                                                              |
+| InvalidFileSize     | ?                                                                              |
+| InvalidEntitlement  | the user does not have the right entitlement for this game                     |
+| NotInstalled        | Discord is not installed                                                       |
+| NotRunning          | Discord is not running                                                         |
 
 ```cs
-enum Result
-{
-  Ok,
-  ServiceUnavailable,
-  InvalidVersion,
-  LockFailed,
-  InternalError,
-  InvalidPaylaod,
-  InvalidCommand,
-  InvalidPermissions,
-  NotFetched,
-  NotFound,
-  Conflict,
-  InvalidSecret,
-  InvalidJoinSecret,
-  NoEligibleActivity,
-  InvalidInvite,
-  NotAuthenticated,
-  InvalidAccessToken,
-  ApplicationMismatch,
-  InvalidDataUrl,
-  InvalidBase64,
-  NotFiltered,
-  LobbyFull,
-  InvalidLobbySecret,
-  InvalidFilename,
-  InvalidFileSize,
-  InvalidEntitlement,
-  NotInstalled,
-  NotRunning
-};
-
 enum LogLevel
 {
   Error = 1,

--- a/docs/game_sdk/Discord.md
+++ b/docs/game_sdk/Discord.md
@@ -106,71 +106,265 @@ You should begin your integration by setting up this callback to help you debug.
 | NotInstalled        | Discord is not installed                                                       |
 | NotRunning          | Discord is not running                                                         |
 
-```cs
-enum LogLevel
-{
-  Error = 1,
-  Warning,
-  Info,
-  Debug
-};
+###### LogLevel Enum
 
-// CreateFlags are a set of flags that tell Discord to do different things on initialization
-// Each flag below has been documented with what it tells Discord to do
-enum CreateFlags
-{
-  // Keep it simple and default. Default values:
-  // DRM: Require Discord to be running to play. SDK will close the game, open Discord, and then relaunch the game
-  Default = 0,
+| Value   | Description                    |
+| ------- | ------------------------------ |
+| Error   | Log only errors                |
+| Warning | Log warnings and errors        |
+| Info    | Log info, warnings, and errors |
+| Debug   | Log _all_ the things!          |
 
-  // Tells the SDK not to close the game if Discord is not running
-  // You probably want to ship with this flag on other platforms
-  NoRequireDiscord
-};
+###### CreateFlags Enum
+
+| Value            | Description                                                         |
+| ---------------- | ------------------------------------------------------------------- |
+| Default          | Requires Discord to be running to play the game                     |
+| NoRequireDiscord | Does not require Discord to be running, use this on other platforms |
+
+## Create
+
+Creates an instance of Discord to initialize the SDK. This is the overlord of all things Discord. We like to call her Nelly.
+
+Returns a new `Discord`.
+
+###### Parameters
+
+| name     | type        | description                                         |
+| -------- | ----------- | --------------------------------------------------- |
+| clientId | Int64       | your application's client id                        |
+| flags    | CreateFlags | the creation parameters for the SDK, outlined above |
+
+###### Example
+
+```cpp
+Discord.Core core;
+core->Create(53908232506183680, Discord.CreateFlags.Default, &core);
 ```
 
-### Methods
-
 ```cs
-Discord.Core Create(Int64 clientId, CreateFlags flags);
-// Creates an instance of Discord with your client id
-// This is the overlord of all things Discord. We like to call her Nelly
-// In C# land, you can just `new` up an instance of the Discord class with these parameters
-
-void Destroy();
-// Destroys the instance. Wave goodbye, Nelly!
-// You monster.
-// Called Dispose() in C# land
-
-void SetLogHook(LogLevel level, MyCallbackFunction callback);
-// Registers a logging callback function with a minimum level of message to receive
-// The callback function has a signature of void MyCallbackFunction(LogLevel level, string message)
-
-void RunCallbacks();
-// Runs all pending callbacks
-// Put this in your game's main event loop, like Update() in Unity
-// That way the first thing your game does is check for any new info from Discord
+var discord = new Discord(53908232506183680, Discord.CreateFlags.Default);
 ```
 
-There are also methods to create managers, which control the data that pertain to their respective names. For brevity's sake, these managers all have a `Destroy()` (`Dispose()` in C# land) function that kills the instance. Now I won't have to repeat myself:
+## Destroy
 
-```cs
-var ActivityManager = Discord.CreateActivityManager();
-var RelationshipManager = Discord.CreateRelationshipManager();
-var ImageManager = Discord.CreateImageManager();
-var UserManager = Discord.CreateUserManager();
-var LobbyManager = Discord.CreateLobbyManager();
-var NetworkManager = Discord.CreateNetworkManager();
-var OverlayManager = Discord.CreateOverlayManager();
-var ApplicationManager = Discord.CreateApplicationManager();
-var StorageManager = Discord.CreateStorageMaager();
+Destroys the instance. Wave goodbye, Nelly! You monster. In C# land, this is `Dispose()`.
+
+Returns `void`.
+
+###### Parameters
+
+None
+
+###### Example
+
+```cpp
+core->Destroy();
 ```
 
-### Callbacks
+```cs
+discord.Dispose();
+```
+
+## SetLogHook
+
+Registers a logging callback function with the minimum level of message to receive. The callback function should have a signature of:
+
+```
+MyCallbackFunction(LogLevel level, string message);
+```
+
+Returns `void`.
+
+###### Parameters
+
+| name     | type     | description                                 |
+| -------- | -------- | ------------------------------------------- |
+| level    | LogLevel | the minimum level of event to log           |
+| callback | function | the callback function to catch the messages |
+
+###### Example
+
+```cs
+public void LogProblemsFunction(LogLevel level, string message);
+SetLogHook(LogLevel level, LogProblemsFunction callback);
+```
+
+## RunCallbacks
+
+Runs all pending SDK callbacks. Put this in your game's main event loop, like `Update()` in Unity. That way, the first thing your game does is check for any new info from Discord.
+
+Returns `void`.
+
+###### Parameters
+
+None
+
+###### Example
+
+```cs
+void Update() {
+  discord.RunCallbacks();
+}
+```
+
+## CreateActivityManager
+
+Creates the manager for interfacing with activities in the SDK.
+
+Returns an `ActivityManager`.
+
+###### Parameters
+
+None
+
+###### Example
+
+```cs
+var activityManager = Discord.CreateActivityManager();
+```
+
+## CreateRelationshipManager
+
+Creates the manager for interfacing with relationships in the SDK.
+
+Returns a `RelationshipManager`.
+
+###### Parameters
+
+None
+
+###### Example
+
+```cs
+var relationshipManager = Discord.CreateRelationshipManager();
+```
+
+## CreateImageManager
+
+Creates the manager for interfacing with images in the SDK.
+
+Returns an `ImageManager`.
+
+###### Parameters
+
+None
+
+###### Example
+
+```cs
+var imageManager = Discord.CreateImageManager();
+```
+
+## CreateUserManager
+
+Creates the manager for interfacing with users in the SDK.
+
+Returns an `UserManager`.
+
+###### Parameters
+
+None
+
+###### Example
+
+```cs
+var userManager = Discord.CreateUserManager();
+```
+
+## CreateLobbyManager
+
+Creates the manager for interfacing with lobbies in the SDK.
+
+Returns a `LobbyManager`.
+
+###### Parameters
+
+None
+
+###### Example
+
+```cs
+var lobbyManager = Discord.CreateLobbyManager();
+```
+
+## CreateNetworkManager
+
+Creates the manager for interfacing with networking in the SDK.
+
+Returns an `NetworkManager`.
+
+###### Parameters
+
+None
+
+###### Example
+
+```cs
+var networkManager = Discord.CreateNetworkManager();
+```
+
+## CreateOverlayManager
+
+Creates the manager for interfacing with the overlay in the SDK.
+
+Returns an `OverlayManager`.
+
+###### Parameters
+
+None
+
+###### Example
+
+```cs
+var overlayManager = Discord.CreateOverlayManager();
+```
+
+## CreateApplicationManager
+
+Creates the manager for interfacing with applications in the SDK.
+
+Returns an `ApplicationManager`.
+
+###### Parameters
+
+None
+
+###### Example
+
+```cs
+var applicationManager = Discord.CreateApplicationManager();
+```
+
+## CreateStorageManager
+
+Creates the manager for interfacing with storage in the SDK.
+
+Returns an `StorageManager`.
+
+###### Parameters
+
+None
+
+###### Example
+
+```cs
+var storageManager = Discord.CreateStorageManager();
+```
+
+## OnReady
+
+Fires when Discord is connected and ready to roll!
+
+###### Parameters
+
+None
+
+###### Example
 
 ```cs
 OnReady += () =>
 {
-  // Fires when Discord is connected and ready to roll!
+  Console.WriteLine("Let's do this!");
 };
 ```

--- a/docs/game_sdk/Discord.md
+++ b/docs/game_sdk/Discord.md
@@ -11,28 +11,28 @@ OK, cool, so how's it work?
 
 At a high level, the Discord GameSDK has a class, `Discord`. This class is in charge of the creation of a few "manager" sub-classes. They are:
 
-- `ActivitiesManager` - for Rich Presence and game invites
-- `RelationshipsManager` - for users' social relationships across Discord, including friends list
-- `ImagesManager` - for getting data about images on Discord, like user avatars or chat images
-- `UsersManager` - for fetching user data for a given id and the current user
-- `LobbiesManager` - for multiplayer lobbies
+- `ActivityManager` - for Rich Presence and game invites
+- `RelationshipManager` - for users' social relationships across Discord, including friends list
+- `ImageManager` - for getting data about images on Discord, like user avatars or chat images
+- `UserManager` - for fetching user data for a given id and the current user
+- `LobbyManager` - for multiplayer lobbies
 - `NetworkManager` - for all your networking layer needs
 - `ApplicationManager` - for retrieving a user's OAuth2 bearer token, locale, and current game branch
 - `StorageManager` - for saving game data to the disk and the cloud
 - `OverlayManager` - for interacting with Discord's built-in overlay
 
-Each one of these managers contain a number of methods and events used to interact with Discord in the context of the manager. For example, `RelationshipsManager` has a function called `filter()`, which lets you pare down a user's inter-Discord relationships based on a boolean condition, like being friends!
+Each one of these managers contain a number of methods and events used to interact with Discord in the context of the manager. For example, `RelationshipManager` has a function called `filter()`, which lets you pare down a user's inter-Discord relationships based on a boolean condition, like being friends!
 
 ## Functions in the SDK
 
 Most functions in the Discord GameSDK, uh, _function_ in a similar way. They take whatever parameters are required for the function to do its job—a user id, the requested size for an image, etc.—and a callback by means of a function pointer. That callback is fired when the function completes its work, letting you handle events without worrying about piping asynchronously-returned data to the right context.
 
-Some functions behave with a normal return behavior; e.g. `RelationshipsManager.Count()` just returns the number directly. Don't worry, it's outlined in the docs.
+Some functions behave with a normal return behavior; e.g. `RelationshipManager.Count()` just returns the number directly. Don't worry, it's outlined in the docs.
 
 A quick example with our C# binding:
 
 ```c#
-var userManager = Discord.CreateUsersManager();
+var userManager = Discord.CreateUserManager();
 userManager.GetCurrentUser((Discord.Result result, ref Discord.User currentUser) =>
 {
  Console.WriteLine(currentUser.username);
@@ -155,14 +155,14 @@ void RunCallbacks();
 There are also methods to create managers, which control the data that pertain to their respective names. For brevity's sake, these managers all have a `Destroy()` (`Dispose()` in C# land) function that kills the instance. Now I won't have to repeat myself:
 
 ```cs
-var ActivitiesManager = Discord.CreateActivitiesManager();
-var RelationshipsManager = Discord.CreateRelationshipsManager();
-var ImagesManager = Discord.CreateImagesManager();
-var UsersManager = Discord.CreateUsersManager();
-var LobbiesManager = Discord.CreateLobbiesManager();
+var ActivityManager = Discord.CreateActivityManager();
+var RelationshipManager = Discord.CreateRelationshipManager();
+var ImageManager = Discord.CreateImageManager();
+var UserManager = Discord.CreateUserManager();
+var LobbyManager = Discord.CreateLobbyManager();
 var NetworkManager = Discord.CreateNetworkManager();
 var OverlayManager = Discord.CreateOverlayManager();
-var ApplicationsManager = Discord.CreateApplicationsManager();
+var ApplicationManager = Discord.CreateApplicationManager();
 var StorageManager = Discord.CreateStorageMaager();
 ```
 

--- a/docs/game_sdk/Discord.md
+++ b/docs/game_sdk/Discord.md
@@ -21,7 +21,7 @@ At a high level, the Discord GameSDK has a class, `Discord`. This class is in ch
 - `StorageManager` - for saving game data to the disk and the cloud
 - `OverlayManager` - for interacting with Discord's built-in overlay
 
-Each one of these managers contain a number of methods and events used to interact with Discord in the context of the manager. For example, `RelationshipManager` has a function called `filter()`, which lets you pare down a user's inter-Discord relationships based on a boolean condition, like being friends!
+Each one of these managers contain a number of methods and events used to interact with Discord in the context of the manager. For example, `RelationshipManager` has a function called `Filter()`, which lets you pare down a user's inter-Discord relationships based on a boolean condition, like being friends!
 
 ## Functions in the SDK
 
@@ -32,8 +32,8 @@ Some functions behave with a normal return behavior; e.g. `RelationshipManager.C
 A quick example with our C# binding:
 
 ```c#
-var userManager = Discord.CreateUserManager();
-userManager.GetCurrentUser((Discord.Result result, ref Discord.User currentUser) =>
+var userManager = Discord.GetUserManager();
+userManager.GetCurrentUser((result, currentUser) =>
 {
  Console.WriteLine(currentUser.username);
  Console.WriteLine(currentUser.ID);
@@ -208,9 +208,9 @@ void Update() {
 }
 ```
 
-## CreateActivityManager
+## GetActivityManager
 
-Creates the manager for interfacing with activities in the SDK.
+Fetches an instance of the manager for interfacing with activities in the SDK.
 
 Returns an `ActivityManager`.
 
@@ -221,12 +221,12 @@ None
 ###### Example
 
 ```cs
-var activityManager = Discord.CreateActivityManager();
+var activityManager = Discord.GetActivityManager();
 ```
 
-## CreateRelationshipManager
+## GetRelationshipManager
 
-Creates the manager for interfacing with relationships in the SDK.
+Fetches an instance of the manager for interfacing with relationships in the SDK.
 
 Returns a `RelationshipManager`.
 
@@ -237,12 +237,12 @@ None
 ###### Example
 
 ```cs
-var relationshipManager = Discord.CreateRelationshipManager();
+var relationshipManager = Discord.GetRelationshipManager();
 ```
 
-## CreateImageManager
+## GetImageManager
 
-Creates the manager for interfacing with images in the SDK.
+Fetches an instance of the manager for interfacing with images in the SDK.
 
 Returns an `ImageManager`.
 
@@ -253,12 +253,12 @@ None
 ###### Example
 
 ```cs
-var imageManager = Discord.CreateImageManager();
+var imageManager = Discord.GetImageManager();
 ```
 
-## CreateUserManager
+## GetUserManager
 
-Creates the manager for interfacing with users in the SDK.
+Fetches an instance of the manager for interfacing with users in the SDK.
 
 Returns an `UserManager`.
 
@@ -269,12 +269,12 @@ None
 ###### Example
 
 ```cs
-var userManager = Discord.CreateUserManager();
+var userManager = Discord.GetUserManager();
 ```
 
-## CreateLobbyManager
+## GetLobbyManager
 
-Creates the manager for interfacing with lobbies in the SDK.
+Fetches an instance of the manager for interfacing with lobbies in the SDK.
 
 Returns a `LobbyManager`.
 
@@ -285,12 +285,12 @@ None
 ###### Example
 
 ```cs
-var lobbyManager = Discord.CreateLobbyManager();
+var lobbyManager = Discord.GetLobbyManager();
 ```
 
-## CreateNetworkManager
+## GetNetworkManager
 
-Creates the manager for interfacing with networking in the SDK.
+Fetches an instance of the manager for interfacing with networking in the SDK.
 
 Returns an `NetworkManager`.
 
@@ -301,12 +301,12 @@ None
 ###### Example
 
 ```cs
-var networkManager = Discord.CreateNetworkManager();
+var networkManager = Discord.GetNetworkManager();
 ```
 
-## CreateOverlayManager
+## GetOverlayManager
 
-Creates the manager for interfacing with the overlay in the SDK.
+Fetches an instance of the manager for interfacing with the overlay in the SDK.
 
 Returns an `OverlayManager`.
 
@@ -317,12 +317,12 @@ None
 ###### Example
 
 ```cs
-var overlayManager = Discord.CreateOverlayManager();
+var overlayManager = Discord.GetOverlayManager();
 ```
 
-## CreateApplicationManager
+## GetApplicationManager
 
-Creates the manager for interfacing with applications in the SDK.
+Fetches an instance of the manager for interfacing with applications in the SDK.
 
 Returns an `ApplicationManager`.
 
@@ -333,12 +333,12 @@ None
 ###### Example
 
 ```cs
-var applicationManager = Discord.CreateApplicationManager();
+var applicationManager = Discord.GetApplicationManager();
 ```
 
-## CreateStorageManager
+## GetStorageManager
 
-Creates the manager for interfacing with storage in the SDK.
+Fetches an instance of the manager for interfacing with storage in the SDK.
 
 Returns an `StorageManager`.
 
@@ -349,7 +349,7 @@ None
 ###### Example
 
 ```cs
-var storageManager = Discord.CreateStorageManager();
+var storageManager = Discord.GetStorageManager();
 ```
 
 ## OnReady

--- a/docs/game_sdk/Images.md
+++ b/docs/game_sdk/Images.md
@@ -5,47 +5,113 @@
 
 Discord is like a book; it's better with pictures. The image manager helps you fetch image data for images in Discord, including user's avatars. They worked hard to pick out those photos and gifs. Show them you care, too.
 
-### Data Models
+## Models
+
+###### ImageDimensions Struct
+
+| name   | type   | description             |
+| ------ | ------ | ----------------------- |
+| Height | UInt32 | the height of the image |
+| Width  | UInt32 | the width of the image  |
+
+###### ImageType Enum
+
+| value | description              |
+| ----- | ------------------------ |
+| User  | image is a user's avatar |
+
+###### ImageHandle Struct
+
+| name | type      | description                                     |
+| ---- | --------- | ----------------------------------------------- |
+| Type | ImageType | the source of the image                         |
+| Id   | Int64     | the id of the user whose avatar you want to get |
+| Size | UInt32    | the resolution at which you want the image      |
+
+## Fetch
+
+Prepare's an image to later retrieve data about it.
+
+Returns a `Discord.Result` and `ImageHandle` via callback.
+
+###### Parameters
+
+| name    | type        | description                                                 |
+| ------- | ----------- | ----------------------------------------------------------- |
+| handle  | ImageHandle | contains the desired userId and size for the returned image |
+| refresh | bool        | whether to use cached data for fetch anew                   |
+
+###### Example
 
 ```cs
-struct ImageDimensions
-{
-  UInt32 Height;
-  UInt32 Width;
+var handle = new Discord.ImageHandle() {
+  Id = 53908232506183680,
+  Size = 1024
 };
 
-struct ImageHandle
+imageManager.Fetch(ImageHandle handle, bool refresh (Discord.Result result, ImageHandle handle) =>
 {
-  ImageType Type;
-  Int64 Id;
-  UInt32 Size;
-};
-
-enum ImageType
-{
-  User
-};
+  if (result == Discord.Result.OK) {
+    imageManager.GetData(handle, (Discord.Result result, byte[] data) => {
+      // Do stuff with the byte[]
+    });
+  }
+});
 ```
 
-### Methods
+## GetDimensions
+
+Get's the dimensions for the given user's avatar's source image.
+
+Returns `ImageDimensions`.
+
+###### Parameters
+
+| name   | type        | description                                                 |
+| ------ | ----------- | ----------------------------------------------------------- |
+| handle | ImageHandle | contains the desired userId and size for the returned image |
+
+###### Example
 
 ```cs
-void Fetch(ImageHandle handle, bool refresh (Discord.Result result, ImageHandle handle) =>
-{
-  // Prepares user avatar data for getting
-  // Refresh tells Discord whether or not to use cached data or fetch anew
-});
+var handle = new Discord.ImageHandle() {
+  Id = 53908232506183680,
+  Size = 1024
+};
+var dimensions =  imageManager.GetDimentions(ImageHandle handle);
+```
 
-ImageDimensions GetDimentions(ImageHandle handle);
-// Gets dimensions for current user's avatar
+## GetData
 
-void GetData(ImageHandle handle, (Discord.Result result, byte[] data) =>
+Gets the image data for a given user's avatar.
+
+Returns `Discord.Result` and `byte[]` via callback.
+
+###### Parameters
+
+| name   | type        | description                                  |
+| ------ | ----------- | -------------------------------------------- |
+| handle | ImageHandle | the image handle from the `Fetch()` callback |
+
+###### Example
+
+```cs
+var handle = new Discord.ImageHandle() {
+  Id = 53908232506183680,
+  Size = 1024
+};
+
+imageManager.Fetch(ImageHandle handle, bool refresh (Discord.Result result, ImageHandle handle) =>
 {
-  // Gets image data for current user's avatar
+  if (result == Discord.Result.OK) {
+    imageManager.GetData(handle, (Discord.Result result, byte[] data) => {
+      // Do stuff with the byte[]
+    });
+  }
 });
 ```
 
-### Example: A Helper Method for Getting a User's Avatar Data
+## Example: A Helper Method for Getting a User's Avatar Data
 
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);
@@ -60,8 +126,9 @@ static void FetchAvatar(Discord.ImageManager ImageManager, Int64 userID)
       {
         // You can also use GetTexture2D within Unity.
         // These return raw RGBA.
-        var data = ImageManager.GetData(handle);
-        Console.WriteLine("image updated {0} {1}", handle.Id, data.Length);
+        ImageManager.GetData(handle, (result2, data) => {
+          Console.WriteLine("image updated {0} {1}", handle.Id, data.Length);
+        });
       }
       else
       {

--- a/docs/game_sdk/Images.md
+++ b/docs/game_sdk/Images.md
@@ -51,16 +51,16 @@ void GetData(ImageHandle handle, (Discord.Result result, byte[] data) =>
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);
 
 // Request user's avatar data. Sizes can be powers of 2 between 16 and 2048
-static void FetchAvatar(Discord.ImagesManager imagesManager, Int64 userID)
+static void FetchAvatar(Discord.ImageManager ImageManager, Int64 userID)
 {
-  imagesManager.Fetch(Discord.ImageHandle.User(userID), (result, handle) =>
+  ImageManager.Fetch(Discord.ImageHandle.User(userID), (result, handle) =>
   {
     {
       if (result == Discord.Result.Ok)
       {
         // You can also use GetTexture2D within Unity.
         // These return raw RGBA.
-        var data = imagesManager.GetData(handle);
+        var data = ImageManager.GetData(handle);
         Console.WriteLine("image updated {0} {1}", handle.Id, data.Length);
       }
       else

--- a/docs/game_sdk/Lobbies.md
+++ b/docs/game_sdk/Lobbies.md
@@ -60,13 +60,13 @@ LobbyManager.CreateLobby(txn, (Discord.Result result, ref Discord.Lobby lobby) =
 
 ###### Lobby Struct
 
-| name     | type             | description                       |
-| -------- | ---------------- | --------------------------------- |
-| Id       | Int64            | the unique id of the lobby        |
-| Type     | LobbyType        | if the lobby is public or private |
-| OwnerId  | Int64            | the userId of the lobby owner     |
-| Secret   | string (128 len) | the password to the lobby         |
-| Capacity | UInt32           | the max capacity of the lobby     |
+| name     | type      | description                       |
+| -------- | --------- | --------------------------------- |
+| Id       | Int64     | the unique id of the lobby        |
+| Type     | LobbyType | if the lobby is public or private |
+| OwnerId  | Int64     | the userId of the lobby owner     |
+| Secret   | string    | the password to the lobby         |
+| Capacity | UInt32    | the max capacity of the lobby     |
 
 ###### LobbySearchComparison Enum
 
@@ -161,10 +161,10 @@ Returns `void`.
 
 ###### Parameters
 
-| name  | type             | description      |
-| ----- | ---------------- | ---------------- |
-| key   | string (128 len) | key for the data |
-| value | string (128 len) | data value       |
+| name  | type   | description      |
+| ----- | ------ | ---------------- |
+| key   | string | key for the data |
+| value | string | data value       |
 
 ###### Example
 
@@ -181,9 +181,9 @@ Returns `void`.
 
 ###### Parameters
 
-| name | type             | description      |
-| ---- | ---------------- | ---------------- |
-| key  | string (128 len) | key for the data |
+| name | type   | description      |
+| ---- | ------ | ---------------- |
+| key  | string | key for the data |
 
 ###### Example
 
@@ -200,10 +200,10 @@ Returns `void`.
 
 ###### Parameters
 
-| name  | type             | description      |
-| ----- | ---------------- | ---------------- |
-| key   | string (128 len) | key for the data |
-| value | string (128 len) | data value       |
+| name  | type   | description      |
+| ----- | ------ | ---------------- |
+| key   | string | key for the data |
+| value | string | data value       |
 
 ###### Example
 
@@ -220,9 +220,9 @@ Returns `void`.
 
 ###### Parameters
 
-| name | type             | description      |
-| ---- | ---------------- | ---------------- |
-| key  | string (128 len) | key for the data |
+| name | type   | description      |
+| ---- | ------ | ---------------- |
+| key  | string | key for the data |
 
 ###### Example
 
@@ -241,10 +241,10 @@ Returns `void`.
 
 | name  | type                  | description                                                                |
 | ----- | --------------------- | -------------------------------------------------------------------------- |
-| key   | string (128 len)      | key to search for filter data                                              |
+| key   | string                | key to search for filter data                                              |
 | comp  | LobbySearchComparison | how the value on the lobby metadata should be compared to the search value |
 | cast  | LobbySearchCast       | should the search value be cast as a string or a number                    |
-| value | string (128 len)      | the value to filter against                                                |
+| value | string                | the value to filter against                                                |
 
 ###### Example
 
@@ -261,11 +261,11 @@ Returns `void`.
 
 ###### Parameters
 
-| name  | type             | description                                             |
-| ----- | ---------------- | ------------------------------------------------------- |
-| key   | string (128 len) | key for the data                                        |
-| cast  | LobbySearchCast  | should the search value be cast as a string or a number |
-| value | string (128 len) | the value to sort by                                    |
+| name  | type            | description                                             |
+| ----- | --------------- | ------------------------------------------------------- |
+| key   | string          | key for the data                                        |
+| cast  | LobbySearchCast | should the search value be cast as a string or a number |
+| value | string          | the value to sort by                                    |
 
 ###### Example
 
@@ -424,10 +424,10 @@ Returns `Discord.Result` and `ref Discord.Lobby` via callback.
 
 ###### Parameters
 
-| name        | type                                       | description                      |
-| ----------- | ------------------------------------------ | -------------------------------- |
-| lobbyId     | Int64                                      | the lobby you want to connect to |
-| lobbySecret | string(128 len) the password for the lobby |
+| name        | type                             | description                      |
+| ----------- | -------------------------------- | -------------------------------- |
+| lobbyId     | Int64                            | the lobby you want to connect to |
+| lobbySecret | stringthe password for the lobby |
 
 ###### Example
 
@@ -592,10 +592,10 @@ Returns lobby metadata value for a given key and id. Can be used with iteration,
 
 ###### Parameters
 
-| name    | type             | description                            |
-| ------- | ---------------- | -------------------------------------- |
-| lobbyId | Int64            | the lobby you want to get metadata for |
-| key     | string (128 len) | the key name to access                 |
+| name    | type   | description                            |
+| ------- | ------ | -------------------------------------- |
+| lobbyId | Int64  | the lobby you want to get metadata for |
+| key     | string | the key name to access                 |
 
 ####### Example
 
@@ -723,11 +723,11 @@ Returns `string`.
 
 ####### Parameters
 
-| name    | type             | description                            |
-| ------- | ---------------- | -------------------------------------- |
-| lobbyId | Int64            | the lobby the member belongs to        |
-| userId  | Int64            | the id of the user to get metadata for |
-| key     | string (128 len) | the metadata key to access             |
+| name    | type   | description                            |
+| ------- | ------ | -------------------------------------- |
+| lobbyId | Int64  | the lobby the member belongs to        |
+| userId  | Int64  | the id of the user to get metadata for |
+| key     | string | the metadata key to access             |
 
 ###### Example
 

--- a/docs/game_sdk/Lobbies.md
+++ b/docs/game_sdk/Lobbies.md
@@ -22,7 +22,7 @@ To update a user or a lobby, create or get a transaction for that resource, call
 ### Example: Creating a Lobby
 
 ```cs
-var LobbyManager = Discord.GetLobbyManager();
+var LobbyManager = discord.GetLobbyManager();
 
 // Create the transaction
 var txn = LobbyManager.CreateLobbyTransaction();
@@ -999,8 +999,8 @@ If you are creating lobbies for users in the game client, and not on a backend s
 
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);
-var LobbyManager = Discord.GetLobbyManager();
-var ActivityManager = Discord.GetActivityManager();
+var LobbyManager = discord.GetLobbyManager();
+var ActivityManager = discord.GetActivityManager();
 
 // Create a lobby
 var txn = LobbyManager.CreateLobbyTransaction();

--- a/docs/game_sdk/Lobbies.md
+++ b/docs/game_sdk/Lobbies.md
@@ -22,7 +22,7 @@ To update a user or a lobby, create or get a transaction for that resource, call
 ### Example: Creating a Lobby
 
 ```cs
-var LobbyManager = Discord.CreateLobbyManager();
+var LobbyManager = Discord.GetLobbyManager();
 
 // Create the transaction
 var txn = LobbyManager.CreateLobbyTransaction();
@@ -53,20 +53,20 @@ LobbyManager.CreateLobby(txn, (Discord.Result result, ref Discord.Lobby lobby) =
 
 ###### LobbyType Enum
 
-| value   |
-| ------- |
-| Private |
-| Public  |
+| name    | value |
+| ------- | ----- |
+| Private | 1     |
+| Public  | 2     |
 
 ###### Lobby Struct
 
-| name     | type      | description                       |
-| -------- | --------- | --------------------------------- |
-| Id       | Int64     | the unique id of the lobby        |
-| Type     | LobbyType | if the lobby is public or private |
-| OwnerId  | Int64     | the userId of the lobby owner     |
-| Secret   | string    | the password to the lobby         |
-| Capacity | UInt32    | the max capacity of the lobby     |
+| name     | type             | description                       |
+| -------- | ---------------- | --------------------------------- |
+| Id       | Int64            | the unique id of the lobby        |
+| Type     | LobbyType        | if the lobby is public or private |
+| OwnerId  | Int64            | the userId of the lobby owner     |
+| Secret   | string (128 len) | the password to the lobby         |
+| Capacity | UInt32           | the max capacity of the lobby     |
 
 ###### LobbySearchComparison Enum
 
@@ -161,10 +161,10 @@ Returns `void`.
 
 ###### Parameters
 
-| name  | type   | description      |
-| ----- | ------ | ---------------- |
-| key   | string | key for the data |
-| value | string | data value       |
+| name  | type             | description      |
+| ----- | ---------------- | ---------------- |
+| key   | string (128 len) | key for the data |
+| value | string (128 len) | data value       |
 
 ###### Example
 
@@ -181,9 +181,9 @@ Returns `void`.
 
 ###### Parameters
 
-| name | type   | description      |
-| ---- | ------ | ---------------- |
-| key  | string | key for the data |
+| name | type             | description      |
+| ---- | ---------------- | ---------------- |
+| key  | string (128 len) | key for the data |
 
 ###### Example
 
@@ -200,10 +200,10 @@ Returns `void`.
 
 ###### Parameters
 
-| name  | type   | description      |
-| ----- | ------ | ---------------- |
-| key   | string | key for the data |
-| value | string | data value       |
+| name  | type             | description      |
+| ----- | ---------------- | ---------------- |
+| key   | string (128 len) | key for the data |
+| value | string (128 len) | data value       |
 
 ###### Example
 
@@ -220,9 +220,9 @@ Returns `void`.
 
 ###### Parameters
 
-| name | type   | description      |
-| ---- | ------ | ---------------- |
-| key  | string | key for the data |
+| name | type             | description      |
+| ---- | ---------------- | ---------------- |
+| key  | string (128 len) | key for the data |
 
 ###### Example
 
@@ -241,10 +241,10 @@ Returns `void`.
 
 | name  | type                  | description                                                                |
 | ----- | --------------------- | -------------------------------------------------------------------------- |
-| key   | string                | key to search for filter data                                              |
+| key   | string (128 len)      | key to search for filter data                                              |
 | comp  | LobbySearchComparison | how the value on the lobby metadata should be compared to the search value |
 | cast  | LobbySearchCast       | should the search value be cast as a string or a number                    |
-| value | string                | the value to filter against                                                |
+| value | string (128 len)      | the value to filter against                                                |
 
 ###### Example
 
@@ -261,11 +261,11 @@ Returns `void`.
 
 ###### Parameters
 
-| name  | type            | description                                             |
-| ----- | --------------- | ------------------------------------------------------- |
-| key   | string          | key for the data                                        |
-| cast  | LobbySearchCast | should the search value be cast as a string or a number |
-| value | string          | the value to sort by                                    |
+| name  | type             | description                                             |
+| ----- | ---------------- | ------------------------------------------------------- |
+| key   | string (128 len) | key for the data                                        |
+| cast  | LobbySearchCast  | should the search value be cast as a string or a number |
+| value | string (128 len) | the value to sort by                                    |
 
 ###### Example
 
@@ -424,10 +424,10 @@ Returns `Discord.Result` and `ref Discord.Lobby` via callback.
 
 ###### Parameters
 
-| name        | type   | description                      |
-| ----------- | ------ | -------------------------------- |
-| lobbyId     | Int64  | the lobby you want to connect to |
-| lobbySecret | string | the password for the lobby       |
+| name        | type                                       | description                      |
+| ----------- | ------------------------------------------ | -------------------------------- |
+| lobbyId     | Int64                                      | the lobby you want to connect to |
+| lobbySecret | string(128 len) the password for the lobby |
 
 ###### Example
 
@@ -592,10 +592,10 @@ Returns lobby metadata value for a given key and id. Can be used with iteration,
 
 ###### Parameters
 
-| name    | type   | description                            |
-| ------- | ------ | -------------------------------------- |
-| lobbyId | Int64  | the lobby you want to get metadata for |
-| key     | string | the key name to access                 |
+| name    | type             | description                            |
+| ------- | ---------------- | -------------------------------------- |
+| lobbyId | Int64            | the lobby you want to get metadata for |
+| key     | string (128 len) | the key name to access                 |
 
 ####### Example
 
@@ -723,11 +723,11 @@ Returns `string`.
 
 ####### Parameters
 
-| name    | type   | description                            |
-| ------- | ------ | -------------------------------------- |
-| lobbyId | Int64  | the lobby the member belongs to        |
-| userId  | Int64  | the id of the user to get metadata for |
-| key     | string | the metadata key to access             |
+| name    | type             | description                            |
+| ------- | ---------------- | -------------------------------------- |
+| lobbyId | Int64            | the lobby the member belongs to        |
+| userId  | Int64            | the id of the user to get metadata for |
+| key     | string (128 len) | the metadata key to access             |
 
 ###### Example
 
@@ -766,7 +766,7 @@ lobbyManager.UpdateMember(290926798626357250, 53908232506183680, txn, (result) =
 });
 ```
 
-## Send
+## SendMessage
 
 Sends a message to the lobby on behalf of the current user. You must be connected to the lobby you are messaging.
 
@@ -782,7 +782,7 @@ Returns `void`.
 ###### Example
 
 ```cs
-lobbyManager.Send(290926798626357250, Encoding.UTF8.GetBytes("hey."));
+lobbyManager.SendMessage(290926798626357250, Encoding.UTF8.GetBytes("hey."));
 ```
 
 ## CreateLobbySearch
@@ -913,7 +913,7 @@ lobbyManager.VoiceDisconnect(290926798626357250, (result) =>
 });
 ```
 
-## OnLobbyUpdate
+## OnUpdate
 
 Fires when a lobby is updated.
 
@@ -923,7 +923,7 @@ Fires when a lobby is updated.
 | ------- | ----- | ------------------ |
 | lobbyId | Int64 | lobby that updated |
 
-## OnLobbyDelete
+## OnDelete
 
 Fired when a lobby is deleted.
 
@@ -934,7 +934,7 @@ Fired when a lobby is deleted.
 | lobbyId | Int64  | lobby that was deleted                         |
 | reason  | string | reason for deletion - this is a system message |
 
-## OnLobbyMemberJoin
+## OnMemberConnect
 
 Fires when a new member joins the lobby.
 
@@ -945,7 +945,7 @@ Fires when a new member joins the lobby.
 | lobbyId | Int64 | lobby the user joined |
 | userId  | Int64 | user that joined      |
 
-## OnLobbyMemberUpdate
+## OnMemberUpdate
 
 Fires when data for a lobby member is updated.
 
@@ -956,7 +956,7 @@ Fires when data for a lobby member is updated.
 | lobbyId | Int64 | lobby the user is a member of |
 | userId  | Int64 | user that was updated         |
 
-## OnLobbyMemberDisconnect
+## OnMemberDisconnect
 
 Fires when a member leaves the lobby.
 
@@ -967,7 +967,7 @@ Fires when a member leaves the lobby.
 | lobbyId | Int64 | lobby the user was a member of |
 | userId  | Int64 | user that left                 |
 
-## OnLobbyMessage
+## OnMessage
 
 Fires when a message is sent to the lobby.
 
@@ -979,7 +979,7 @@ Fires when a message is sent to the lobby.
 | userId  | Int64  | user that sent the message   |
 | data    | byte[] | the message contents         |
 
-## OnLobbySpeaking
+## OnSpeaking
 
 Fires when a user connected to voice starts or stops speaking.
 
@@ -999,8 +999,8 @@ If you are creating lobbies for users in the game client, and not on a backend s
 
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);
-var LobbyManager = Discord.CreateLobbyManager();
-var ActivityManager = Discord.CreateActivityManager();
+var LobbyManager = Discord.GetLobbyManager();
+var ActivityManager = Discord.GetActivityManager();
 
 // Create a lobby
 var txn = LobbyManager.CreateLobbyTransaction();

--- a/docs/game_sdk/Lobbies.md
+++ b/docs/game_sdk/Lobbies.md
@@ -740,83 +740,258 @@ for (int i = 0; i < count; i++) {
 }
 ```
 
+## UpdateMember
+
+Updates lobby member info for a given member of the lobby.
+
+Returns `Discord.Result` via callback.
+
+###### Parameters
+
+| name        | type                   | description                       |
+| ----------- | ---------------------- | --------------------------------- |
+| lobbyId     | Int64                  | lobby the member belongs to       |
+| userId      | Int64                  | id of the user                    |
+| transaction | LobbyMemberTransaction | transaction with the changed data |
+
+###### Example
+
 ```cs
-void UpdateMember(Int64 lobbyId, Int64 userId, MemberTransaction transaction, (Discord.Result result) =>
-{
-  // Updates info for a lobby member
-});
-
-void Send(int lobbyId, byte[] data);
-// Sends a message to the lobby on behalf of the current user
-// You must be connected to the lobby you are sending a message to
-
-LobbySearch CreateLobbySearch();
-// Creates a search object to search available lobbies
-
-void Search(LobbySearch search, () =>
-{
-  // Searches available lobbies based on the search criteria
-  // Lobbies that meet criteria are available within the context of the callback
-});
-
-Int32 GetLobbyCount();
-// Returns the number of lobbies that match the search
-
-Int64 GetLobbyId(Int32 index);
-// Returns the id for the lobby at the given index
-
-void VoiceConnect(Int64 lobbyId, (Discord.Result result) =>
-{
-  // Connect to the voice channel of the current lobby
-});
-
-void VoiceDisconnect(Int64 lobbyId, (Discord.Result result) =>
-{
-  // Disconnect from the voice channel of the current lobby
+var txn = lobbyManager.GetLobbyMemberTransaction(290926798626357250, 53908232506183680);
+txn.SetMetadata("my_mmr", "9999");
+lobbyManager.UpdateMember(290926798626357250, 53908232506183680, txn, (result) => {
+  if (result == Discord.Result.OK) {
+    Console.WriteLine("Lobby member updated!");
+  }
 });
 ```
 
-### Callbacks
+## Send
+
+Sends a message to the lobby on behalf of the current user. You must be connected to the lobby you are messaging.
+
+Returns `void`.
+
+###### Parameters
+
+| name    | type   | description                 |
+| ------- | ------ | --------------------------- |
+| lobbyId | Int64  | lobby the member belongs to |
+| data    | byte[] | the data to send            |
+
+###### Example
 
 ```cs
-OnLobbyUpdate+= (Int64 lobbyId) =>
-{
-  // Fired when the lobby is updated
-};
-
-OnLobbyDelete+= (Int64 lobbyId, string reason) =>
-{
-  // Fired when the lobby is deleted
-};
-
-OnLobbyMemberJoin+= (Int64 lobbyId, int userId) =>
-{
-  // Fires when a new member joins the lobby
-};
-
-OnLobbyMemberUpdate += (Int64 lobbyId, Int64 userId) =>
-{
-  // Fires when data for a lobby member is updated
-};
-
-OnLobbyMemberDisconnect += (Int64 lobbyId, Int64 userId) =>
-{
-  // Fires when a member leaves the lobby
-};
-
-OnLobbyMessage += (Int64 lobbyId, Int64 userId, byte[] data) =>
-{
-  // Fires when a message is sent to the lobby
-  // Turn back into a string with something like Encoding.UTF8.GetString(data);
-};
-
-OnLobbySpeaking += (Int64 lobbyId, Int64 userId, bool speaking) =>
-{
-  // Fires when a user connected to voice starts speaking (true) or stops (false)
-};
+lobbyManager.Send(290926798626357250, Encoding.UTF8.GetBytes("hey."));
 ```
 
-### Connecting to Lobbies
+## CreateLobbySearch
+
+Creates a search object to search available lobbies.
+
+Returns `Discord.LobbySearch`.
+
+###### Parameters
+
+None
+
+###### Example
+
+```cs
+var search = lobbyManager.CreateLobbySearch();
+```
+
+## Search
+
+Searches available lobbies based on the search criteria chosen in the `Discord.LobbySearch` member functions. Lobbies that meet the criteria are available within the context of the callback.
+
+Returns `void`, and a parameter-less function callback.
+
+###### Parameters
+
+| name   | type        | description         |
+| ------ | ----------- | ------------------- |
+| search | LobbySearch | the search criteria |
+
+###### Example
+
+```cs
+var search = lobbyManger.CreateLobbySearch();
+search.Filter("metadata.matchmaking_rating", LobbySearchComparison.GreaterThan, LobbySearchCast.Number, "455");
+search.Sort("metadata.matchmaking_rating", LobbySearchCast.Number, "456");
+search.Limit(10);
+lobbyManger.Search(search, () => {
+  var count = lobbyManager.GetLobbyCount();
+  Console.WriteLine("There are {0} lobbies that match your search criteria", count);
+});
+```
+
+## GetLobbyCount
+
+Get the number of lobbies that match the search.
+
+Returns `Int32`.
+
+###### Parameters
+
+None
+
+###### Example
+
+```cs
+lobbyManger.Search(search, () => {
+  var count = lobbyManager.GetLobbyCount();
+  Console.WriteLine("There are {0} lobbies that match your search criteria", count);
+});
+```
+
+## GetLobbyId
+
+Returns the id for the lobby at the given index.
+
+Returns `Int64`.
+
+###### Parameters
+
+| name  | type  | description                                      |
+| ----- | ----- | ------------------------------------------------ |
+| index | Int32 | the index at which to access the list of lobbies |
+
+###### Example
+
+```cs
+lobbyManger.Search(search, () => {
+  var count = lobbyManager.GetLobbyCount();
+  for (int i = 0; i < count; i++) {
+    var id = lobbyManager.GetLobbyId(i);
+    Console.WriteLine("Found lobby {0}", id);
+  }
+});
+```
+
+## VoiceConnect
+
+Connects to the voice channel of the current lobby.
+
+Returns `Discord.Result` via callback.
+
+###### Parameters
+
+| name    | type  | description               |
+| ------- | ----- | ------------------------- |
+| lobbyId | Int64 | lobby to voice connect to |
+
+###### Example
+
+```cs
+lobbyManager.VoiceConnect(290926798626357250, (result) =>
+{
+  if (result == Discord.Result.OK) {
+    Console.WriteLine("Voice connected!");
+  }
+});
+```
+
+## VoiceDisconnect
+
+Disconnects from the voice channel of a given lobby.
+
+###### Parameters
+
+| name    | type  | description                    |
+| ------- | ----- | ------------------------------ |
+| lobbyId | Int64 | lobby to voice disconnect from |
+
+###### Example
+
+```cs
+lobbyManager.VoiceDisconnect(290926798626357250, (result) =>
+{
+  if (result == Discord.Result.OK) {
+    Console.WriteLine("Voice disconnected!");
+  }
+});
+```
+
+## OnLobbyUpdate
+
+Fires when a lobby is updated.
+
+###### Parameters
+
+| name    | type  | description        |
+| ------- | ----- | ------------------ |
+| lobbyId | Int64 | lobby that updated |
+
+## OnLobbyDelete
+
+Fired when a lobby is deleted.
+
+###### Parameters
+
+| name    | type   | description                                    |
+| ------- | ------ | ---------------------------------------------- |
+| lobbyId | Int64  | lobby that was deleted                         |
+| reason  | string | reason for deletion - this is a system message |
+
+## OnLobbyMemberJoin
+
+Fires when a new member joins the lobby.
+
+###### Parameters
+
+| name    | type  | description           |
+| ------- | ----- | --------------------- |
+| lobbyId | Int64 | lobby the user joined |
+| userId  | Int64 | user that joined      |
+
+## OnLobbyMemberUpdate
+
+Fires when data for a lobby member is updated.
+
+###### Parameters
+
+| name    | type  | description                   |
+| ------- | ----- | ----------------------------- |
+| lobbyId | Int64 | lobby the user is a member of |
+| userId  | Int64 | user that was updated         |
+
+## OnLobbyMemberDisconnect
+
+Fires when a member leaves the lobby.
+
+###### Parameters
+
+| name    | type  | description                    |
+| ------- | ----- | ------------------------------ |
+| lobbyId | Int64 | lobby the user was a member of |
+| userId  | Int64 | user that left                 |
+
+## OnLobbyMessage
+
+Fires when a message is sent to the lobby.
+
+###### Parameters
+
+| name    | type   | description                  |
+| ------- | ------ | ---------------------------- |
+| lobbyId | Int64  | lobby the message is sent to |
+| userId  | Int64  | user that sent the message   |
+| data    | byte[] | the message contents         |
+
+## OnLobbySpeaking
+
+Fires when a user connected to voice starts or stops speaking.
+
+###### Parameters
+
+| name     | type  | description                                             |
+| -------- | ----- | ------------------------------------------------------- |
+| lobbyId  | Int64 | lobby the user is connceted to                          |
+| userId   | Int64 | user in voice                                           |
+| speaking | bool  | `true` == started speaking, `false` == stopped speaking |
+
+## Connecting to Lobbies
 
 In the preceding section, you probably noticed there are a couple different methods for connecting to a lobby: `Connect()` and `ConnectWithActivitySecret()`. Lobbies in Discord are even more useful when hooked together with Activities/Rich Presence functionality; they give you everything you need to create an awesome game invite system.
 

--- a/docs/game_sdk/Lobbies.md
+++ b/docs/game_sdk/Lobbies.md
@@ -49,177 +49,698 @@ LobbyManager.CreateLobby(txn, (Discord.Result result, ref Discord.Lobby lobby) =
 });
 ```
 
-### Data Models
+## Models
+
+###### LobbyType Enum
+
+| value   |
+| ------- |
+| Private |
+| Public  |
+
+###### Lobby Struct
+
+| name     | type      | description                       |
+| -------- | --------- | --------------------------------- |
+| Id       | Int64     | the unique id of the lobby        |
+| Type     | LobbyType | if the lobby is public or private |
+| OwnerId  | Int64     | the userId of the lobby owner     |
+| Secret   | string    | the password to the lobby         |
+| Capacity | UInt32    | the max capacity of the lobby     |
+
+###### LobbySearchComparison Enum
+
+| name               | value |
+| ------------------ | ----- |
+| LessThanOrEqual    | -2    |
+| LessThan           | -1    |
+| Equal              | 0     |
+| GreaterThan        | 1     |
+| GreaterThanOrEqual | 2     |
+| NotEqual           | 3     |
+
+###### LobbySearchCast Enum
+
+| name   | value |
+| ------ | ----- |
+| String | 1     |
+| Number | 2     |
+
+###### LobbyTransaction Struct
+
+Has no values, but has member functions, outlined later.
+
+###### LobbyMemberTransaction Struct
+
+Has no values, but has member functions, outlined later.
+
+###### LobbySearch Struct
+
+Has no values, but has member functions, outlined later.
+
+## LobbyTransaction.SetType
+
+Marks a lobby as private or public
+
+###### Parameters
+
+| name | type      | description       |
+| ---- | --------- | ----------------- |
+| type | LobbyType | private or public |
+
+###### Example
 
 ```cs
-enum LobbyType
+var txn = new Discord.LobbyTransaction();
+txn.SetType(Discord.LobbyType.Public);
+```
+
+## LobbyTransaction.SetOwner
+
+Sets a new owner for the lobby.
+
+Returns `void`;
+
+###### Parameters
+
+| name   | type  | description             |
+| ------ | ----- | ----------------------- |
+| userId | Int64 | the new owner's user id |
+
+###### Example
+
+```cs
+var txn = new Discord.LobbyTransaction();
+txn.SetOwner(53908232506183680);
+```
+
+## LobbyTransaction.SetCapacity
+
+Sets a new capacity for the lobby.
+
+Returns `void`.
+
+###### Parameters
+
+| name     | type   | description            |
+| -------- | ------ | ---------------------- |
+| capacity | UInt32 | the new max lobby size |
+
+###### Example
+
+```cs
+var txn = new Discord.LobbyTransaction();
+txn.SetCapacity(10);
+```
+
+## LobbyTransaction.SetMetadata
+
+Sets metadata value under a given key name for the lobby.
+
+Returns `void`.
+
+###### Parameters
+
+| name  | type   | description      |
+| ----- | ------ | ---------------- |
+| key   | string | key for the data |
+| value | string | data value       |
+
+###### Example
+
+```cs
+var txn = new Discord.LobbyTransaction();
+txn.SetMetadata("average_mmr", "4500");
+```
+
+## LobbyTransaction.DeleteMetadata
+
+Delete's the lobby metadata for a key.
+
+Returns `void`.
+
+###### Parameters
+
+| name | type   | description      |
+| ---- | ------ | ---------------- |
+| key  | string | key for the data |
+
+###### Example
+
+```cs
+var txn = new Discord.LobbyTransaction();
+txn.DeleteMetadata("average_mmr");
+```
+
+## LobbyMemberTransaction.SetMetadata
+
+Sets metadata value under a given key name for the current user.
+
+Returns `void`.
+
+###### Parameters
+
+| name  | type   | description      |
+| ----- | ------ | ---------------- |
+| key   | string | key for the data |
+| value | string | data value       |
+
+###### Example
+
+```cs
+var txn = new Discord.LobbyTransaction();
+txn.SetMetadata("current_mmr", "4267");
+```
+
+## LobbyMemberTransaction.DeleteMetadata
+
+Sets metadata value under a given key name for the current user.
+
+Returns `void`.
+
+###### Parameters
+
+| name | type   | description      |
+| ---- | ------ | ---------------- |
+| key  | string | key for the data |
+
+###### Example
+
+```cs
+var txn = new Discord.LobbyTransaction();
+txn.DeleteMetadata("current_mmr");
+```
+
+## LobbySearch.Filter
+
+Filters lobbies based on metadata comparison. Available filter values are `owner_id`, `capacity`, `slots`, and `metadata`. If you are filtering based on metadata, make sure you prepend your key with `"metadata."` For example, filtering on matchmaking rating would be `"metadata.matchmaking_rating"`.
+
+Returns `void`.
+
+###### Parameters
+
+| name  | type                  | description                                                                |
+| ----- | --------------------- | -------------------------------------------------------------------------- |
+| key   | string                | key to search for filter data                                              |
+| comp  | LobbySearchComparison | how the value on the lobby metadata should be compared to the search value |
+| cast  | LobbySearchCast       | should the search value be cast as a string or a number                    |
+| value | string                | the value to filter against                                                |
+
+###### Example
+
+```cs
+var query = new LobbyManager.CreateLobbySearch();
+query.LobbySearchFilter("metadata.matchmaking_rating", LobbySearchComparison.GreaterThan, LobbySearchCast.Number, "455");
+```
+
+## LobbySearch.Sort
+
+Sorts the filtered lobbies based on "near-ness" to a given value.
+
+Returns `void`.
+
+###### Parameters
+
+| name  | type            | description                                             |
+| ----- | --------------- | ------------------------------------------------------- |
+| key   | string          | key for the data                                        |
+| cast  | LobbySearchCast | should the search value be cast as a string or a number |
+| value | string          | the value to sort by                                    |
+
+###### Example
+
+```cs
+var query = new LobbyManager.CreateLobbySearch();
+query.LobbySearchSort("metadata.ELO", LobbySearchCast.Number, "1337");
+```
+
+## LobbySearch.Limit
+
+Limits the number of lobbies returned in a search.
+
+Returns `void`.
+
+###### Parameters
+
+| name  | type   | description                            |
+| ----- | ------ | -------------------------------------- |
+| limit | UInt32 | the number of lobbies to return at max |
+
+###### Example
+
+```cs
+var query = new LobbyManager.CreateLobbySearch();
+query.Limit(10);
+```
+
+## CreateLobbyTransaction
+
+Creates a new lobby transaction; used when creating a new lobby.
+
+Returns a `Discord.LobbyTransaction`.
+
+###### Parameters
+
+None
+
+###### Example
+
+```cs
+var txn = lobbyManager.CreateLobbyTransaction();
+```
+
+## GetLobbyTransaction
+
+Gets a new lobby transaction for an existing lobby.
+
+Returns a `Discord.LobbyTransaction`.
+
+###### Parameters
+
+| name    | type  | description                  |
+| ------- | ----- | ---------------------------- |
+| lobbyId | Int64 | the lobby you want to change |
+
+###### Example
+
+```cs
+var txn = lobbyManager.GetLobbyTransaction(290926798626357250);
+```
+
+## GetMemberTransaction
+
+Gets a new member transaction for a lobby member in a given lobby.
+
+Returns a `Discord.LobbyMemberTransaction`.
+
+###### Parameters
+
+| name    | type  | description                  |
+| ------- | ----- | ---------------------------- |
+| lobbyId | Int64 | the lobby you want to change |
+| userId  | Int64 | the user you wish to change  |
+
+###### Example
+
+```cs
+var txn = lobbyManager.GetMemberTransaction(290926798626357250, 53908232506183680);
+```
+
+## CreateLobby
+
+Creates a lobby. Creating a lobby auto-joins the connected user to it. **Do not call `SetOwner()` in the transaction for this method.**
+
+Returns `Discord.Result` and `ref Lobby` via callback.
+
+###### Parameters
+
+| name        | type             | description                                           |
+| ----------- | ---------------- | ----------------------------------------------------- |
+| transaction | LobbyTransaction | a lobby transaction with set properties like capacity |
+
+###### Example
+
+```cs
+lobbyManager.CreateLobby(txn, (Discord.Result result, Lobby lobby) =>
 {
-  Private = 1,
-  Public = 2,
+  if (result == Discord.Result.OK) {
+    Console.WriteLine("Created lobby {0}", lobby.Id);
+  }
+});
+```
+
+## UpdateLobby
+
+Updates a lobby with data from the given transaction. You _can_ call `SetOwner()` in this transaction.
+
+Returns `Discord.Result` via callback.
+
+###### Parameters
+
+| name        | type             | description                         |
+| ----------- | ---------------- | ----------------------------------- |
+| lobbyId     | Int64            | the lobby you want to change        |
+| transaction | LobbyTransaction | the transaction with wanted changes |
+
+###### Example
+
+```cs
+lobbymanager.UpdateLobby(290926798626357250, transaction, (result) =>
+{
+  if (result == Discord.Result.OK) {
+    Console.WriteLine("Lobby updated!");
+  }
+});
+```
+
+## DeleteLobby
+
+Deletes a given lobby.
+
+Returns `Discord.Result` via callback.
+
+###### Parameters
+
+| name    | type  | description                  |
+| ------- | ----- | ---------------------------- |
+| lobbyId | Int64 | the lobby you want to delete |
+
+###### Example
+
+```cs
+lobbymanager.DeleteLobby(290926798626357250, (result) =>
+{
+  if (result == Discord.Result.OK) {
+    Console.WriteLine("Lobby deleted!");
+  }
+});
+```
+
+## Connect
+
+Connects the current user to a given lobby. You can be connected to up to five lobbies at a time.
+
+Returns `Discord.Result` and `ref Discord.Lobby` via callback.
+
+###### Parameters
+
+| name        | type   | description                      |
+| ----------- | ------ | -------------------------------- |
+| lobbyId     | Int64  | the lobby you want to connect to |
+| lobbySecret | string | the password for the lobby       |
+
+###### Example
+
+```cs
+lobbyManager.Connect(290926798626357250, "363446008341987328:123123", (result, lobby) =>
+{
+  if (result == Discord.Result.OK) {
+    Console.WriteLine("Connected to lobby {0}!", lobby.Id);
+  }
+});
+```
+
+## ConnectWithActivitySecret
+
+Connects the current user to a lobby; requires the special activity secret from the lobby which is a concatenated lobbyId and secret.
+
+Returns `Discord.Result` and `ref Discord.Lobby` via callback.
+
+###### Parameters
+
+| name           | type   | description                               |
+| -------------- | ------ | ----------------------------------------- |
+| activitySecret | string | the special activity secret for the lobby |
+
+###### Example
+
+```cs
+lobbyManager.ConnectWithActivitySecret("363446008341987328:123123", (result, lobby) =>
+{
+  if (result == Discord.Result.OK) {
+    Console.WriteLine("Connected to lobby {0}!", lobby.Id);
+  }
+});
+```
+
+## GetLobbyActivitySecret
+
+Gets the special activity secret for a given lobby. If you are creating lobbies from game clients, use this to easily interact with Rich Presence invites. Set the returned secret to your activity's `JoinSecret`.
+
+Returns `string`.
+
+###### Parameters
+
+| name    | type  | description                              |
+| ------- | ----- | ---------------------------------------- |
+| lobbyId | Int64 | the lobby you want to get the secret for |
+
+###### Example
+
+```cs
+var activitySecret = lobbyManager.GetLobbyActivitySecret(290926798626357250);
+var activity = new Discord.Activity
+{
+  State = "olleh",
+  Details = "foo details",
+    Party = {
+      Id = "foo partyID",
+      Size = {
+          CurrentSize = 1,
+          MaxSize = 4,
+      },
+  },
+  Secrets = {
+      Join = activitySecret,
+  },
+  Instance = true,
 };
 
-struct Lobby
+ActivityManager.UpdateActivity(activity, result =>
 {
-  Int64 Id;
-  LobbyType Type;
-  Int64 OwnerId;
-  string Secret;
-  UInt32 Capacity;
-};
+  Console.WriteLine("Update Activity {0}", result);
+});
+```
 
-enum LobbySearchComparison
+## Disconnect
+
+Disconnects the current user from a lobby.
+
+Returns `Discord.Result`.
+
+###### Parameters
+
+| name    | type  | description                 |
+| ------- | ----- | --------------------------- |
+| lobbyId | Int64 | the lobby you want to leave |
+
+###### Example
+
+```cs
+lobbyManager.Disconnect(290926798626357250, result) =>
 {
-  LessThanOrEqual = -2,
-  LessThan = -1,
-  Equal = 0,
-  GreaterThan = 1,
-  GreaterThanOrEqual = 2,
-  NotEqual = 3
-};
+  if (result == Discord.Result.OK) {
+    Console.WriteLine("Left lobby!");
+  }
+});
+```
 
-enum LobbySearchCast
-{
-  String = 1,
-  Number
-};
+## GetLobby
 
-struct LobbyTransaction
-{
-  void SetType(LobbyType type);
-  // Marks a lobby private or public
+Gets the lobby object for a given lobby id.
 
-  void SetOwner(Int64 userId);
-  // Marks a new user as the lobby owner
+Returns a `Discord.Lobby`.
 
-  void SetCapacity(UInt32 capacity);
-  // Sets the maximum lobby size
+###### Parameters
 
-  void SetMetadata(string key, string value);
-  // Sets arbitrary metadata on the lobby
+| name    | type  | description               |
+| ------- | ----- | ------------------------- |
+| lobbyId | Int64 | the lobby you want to get |
 
-  void DeleteMetadata(string key);
-  // Deletes lobby metadata by key
-};
+###### Example
 
-struct LobbyMemberTransaction
-{
-  void SetMetadata(string key, string value);
-  // Sets arbitrary metadata on a user
+```cs
+var lobby = lobbyManager.GetLobby(Int64 lobbyId);
+```
 
-  void DeleteMetadata(string key);
-  // Deletes user metadata by key
-};
+## GetLobbyMetadataCount
 
-struct LobbySearch
-{
-  void Filter(string key, LobbySearchComparison comp, LobbySearchCast cast, string value);
-  // Filters lobbies based on metadata comparison
-  // Available filter values are owner_id, capacity, slots, and metadata
-  // If you are filtering based on metadata, make sure you prepend your key with "metadata."
-  // For example, filtering on matchmaking rating would be "metadata.matchmaking_rating"
-  // Example:
-  // var query = LobbyManager.create_lobby_search();
-  // query.LobbySearchFilter("metadata.matchmaking_rating", LobbySearchComparison.GreaterThan, LobbySearchCast.Number, "455");
+Returns the number of metadata key/value pairs on a given lobby. Used for accessing metadata by iterating over the list.
 
-  void Sort(string key, LobbySearchCast cast, string value);
-  // Sorts available lobbies based on metadata "near-ness" to a given value
-  // Example: query.LobbySearchSort("metadata.ELO", LobbySearchCast.Number, "1337");
+Returns `Int32`.
 
-  void Limit(UInt32 limit);
-  // Limits the number of lobbies returned in a search
+###### Parameters
+
+| name    | type  | description                            |
+| ------- | ----- | -------------------------------------- |
+| lobbyId | Int64 | the lobby you want to get metadata for |
+
+###### Example
+
+```cs
+var count = lobbyManger.GetLobbyMetadataCount(290926798626357250);
+for (int i = 0; i < count; i++) {
+  var value = lobbyManager.GetLobbyMetadataKey(290926798626357250, i);
 }
 ```
 
-### Methods
+## GetLobbyMetadataKey
+
+Returns the key for the lobby metadata at the given index.
+
+Returns `string`.
+
+###### Parameters
+
+| name    | type  | description                            |
+| ------- | ----- | -------------------------------------- |
+| lobbyId | Int64 | the lobby you want to get metadata for |
+| index   | Int32 | the index of lobby metadata to access  |
+
+###### Example
 
 ```cs
-LobbyTransaction CreateLobbyTransaction();
-// Returns a new lobby transaction
+var count = lobbyManger.GetLobbyMetadataCount(290926798626357250);
+for (int i = 0; i < count; i++) {
+  var value = lobbyManager.GetLobbyMetadataKey(290926798626357250, i);
+}
+```
 
-LobbyTransaction GetLobbyTransaction(int lobbyId);
-// Returns the transaction for a given lobby
+## GetLobbyMetadataValue
 
-LobbyMemberTransaction GetMemberTransaction(Int64 lobbyId, Int64 userId);
-// Returns a new member transaction for a user
+Returns lobby metadata value for a given key and id. Can be used with iteration, or direct access by keyname.
 
-void CreateLobby(LobbyTransaction transaction, (Discord.Result result, Lobby lobby) =>
-{
-  // Creates a lobby
-  // Note that creating a lobby auto-joins the connected member to it
-  // Remember - no SetOwner in this transaction!
-});
+###### Parameters
 
-void UpdateLobby(Int64 lobbyId, LobbyTransaction transaction, (Discord.Result result) =>
-{
-  // Updates a lobby
-  // You can safely SetOwner in here, though
-});
+| name    | type   | description                            |
+| ------- | ------ | -------------------------------------- |
+| lobbyId | Int64  | the lobby you want to get metadata for |
+| key     | string | the key name to access                 |
 
-void DeleteLobby(int lobbyId, (Discord.Result result) =>
-{
-  // Deletes a lobby
-});
+####### Example
 
-void Connect(Int64 lobbyId, string lobbySecret, (Discord.Result result, Lobby lobby) =>
-{
-  // Connects the current user to a lobby
-  // Requires both the secret and the lobby ID
-  // You can be connected to up to 5 lobbies at a time
-});
+```cs
+var averageMmr = lobbyManger.GetLobbyMetadataValue(290926798626357250, "metadata.average_mmr");
+```
 
-void ConnectWithActivitySecret(string activitySecret, (Discord.Result result, ref Lobby Lobby) =>
-{
-  // Connects the current user to a lobby
-  // Requires the special activity secret
-  // Retrieved from GetLobbyActivitySecret()
-});
+## GetMemberCount
 
-string GetLobbyActivitySecret(Int64 lobbyId);
-// Returns a unique secret for the given lobby concatenated with the lobby id
-// If you are creating lobbies from game clients, use this to easily interact with Rich Presence invites
-// Set the returned secret to your activity's JoinSecret
+Get the number of members in a lobby.
 
-void Disconnect(Int64 lobbyId, (Discord.Result result) =>
-{
-  // Disconnects the current user from a lobby
-});
+Returns `Int32`.
 
-Lobby GetLobby(Int64 lobbyId);
-// Returns the lobby object for the given id
+####### Parameters
 
-Int32 GetLobbyMetadataCount(Int64 lobbyid);
-// Returns the number of metadata pairs on the given lobby
-// Used for accessing metadata by iterating over a list
+| name    | type  | description                           |
+| ------- | ----- | ------------------------------------- |
+| lobbyId | Int64 | the lobby you want to get members for |
 
-string GetLobbyMetadataKey(Int64 lobbyId, Int32 index);
-// Returns the key for the lobby metadata at the given index
+###### Example
 
-string GetLobbyMetadataValue(Int64 lobbyId, string key);
-// Returns lobby metadata value for a key
-// Can be used in conjunction with the count and get key functions if you're iterating over metadata
-// Or you can access the metadata directly by keyname
+```cs
+var count = lobbyManager.GetMemberCount(290926798626357250);
+for (int i = 0; i < count; i++) {
+  var id = lobbyManager.GetMemberUserId(290926798626357250, i);
+}
+```
 
-Int32 GetMemberCount(Int64 lobbyId);
-// Returns the number of members in a lobby
+## GetMemberUserId
 
-Int64 GetMemberUserId(Int64 lobbyId, Int32 index);
-// Returns the userId for a member at the index
+Gets the user id of the lobby member at the given index.
 
-User GetMemberUser(Int64 lobbyId, Int64 userId);
-// Returns the user info for a userId
+Returns `Int64`.
 
-Int32 GetMemberMetadataCount(Int64 lobbyid, Int64 userId);
-// Returns the number of metadata pairs on the given lobby member
-// Used for accessing metadata by iterating over a list
+###### Parameters
 
-string GetMemberMetadataKey(Int64 lobbyId, Int64 userId Int32 index);
-// Returns the key for the lobby metadata at the given index
+| name    | type  | description                           |
+| ------- | ----- | ------------------------------------- |
+| lobbyId | Int64 | the lobby you want to get members for |
+| index   | Int32 | the index of lobby member to access   |
 
-string GetMemberMetadataValue(Int64 lobbyId, Int64 userId, string key);
-// Returns user metadata for a given key
-// Can be used in conjunction with the count and get key functions if you're iterating over metadata
-// Or you can access the metadata directly by keyname
+###### Example
 
+```cs
+var count = lobbyManager.GetMemberCount(290926798626357250);
+for (int i = 0; i < count; i++) {
+  var id = lobbyManager.GetMemberUserId(290926798626357250, i);
+}
+```
+
+## GetMemberUser
+
+Gets the user object for a given user id.
+
+Returns `Discord.User`.
+
+###### Parameters
+
+| name    | type  | description                           |
+| ------- | ----- | ------------------------------------- |
+| lobbyId | Int64 | the lobby you want to get members for |
+| userId  | Int64 | the user's userId                     |
+
+###### Example
+
+```cs
+var count = lobbyManager.GetMemberCount(290926798626357250);
+for (int i = 0; i < count; i++) {
+  var id = lobbyManager.GetMemberUserId(290926798626357250, i);
+  var user = lobbyManager.GetMemberUser(290926798626357250, id);
+  Console.WriteLine("Got user {0}", user.Id);
+}
+```
+
+## GetMemberMetadataCount
+
+Gets the number of metadata key/value pairs for the given lobby member. Used for accessing metadata by iterating over a list.
+
+Returns `Int32`.
+
+###### Parameters
+
+| name    | type  | description                            |
+| ------- | ----- | -------------------------------------- |
+| lobbyId | Int64 | the lobby the member belongs to        |
+| userId  | Int64 | the id of the user to get metadata for |
+
+###### Example
+
+```cs
+var count = lobbyManager.GetMemberMetadataCount(290926798626357250, 53908232506183680);
+for (int i = 0; i < count; i++) {
+  var key = lobbyManager.GetMemberMetadataKey(290926798626357250, 53908232506183680, i);
+}
+```
+
+## GetMemberMetadataKey
+
+Gets the key for the lobby metadata at the given index on a lobby member.
+
+Returns `string`.
+
+####### Parameters
+
+| name    | type  | description                            |
+| ------- | ----- | -------------------------------------- |
+| lobbyId | Int64 | the lobby the member belongs to        |
+| userId  | Int64 | the id of the user to get metadata for |
+| index   | Int32 | the index of metadata to access        |
+
+###### Example
+
+```cs
+var count = lobbyManager.GetMemberMetadataCount(290926798626357250, 53908232506183680);
+for (int i = 0; i < count; i++) {
+  var key = lobbyManager.GetMemberMetadataKey(290926798626357250, 53908232506183680, i);
+}
+```
+
+## GetMemberMetadataValue
+
+Returns user metadata for a given key. Can be used in conjunction with the count and get key functions if you're iterating over metadata. Or you can access the metadata directly by keyname
+
+Returns `string`.
+
+####### Parameters
+
+| name    | type   | description                            |
+| ------- | ------ | -------------------------------------- |
+| lobbyId | Int64  | the lobby the member belongs to        |
+| userId  | Int64  | the id of the user to get metadata for |
+| key     | string | the metadata key to access             |
+
+###### Example
+
+```cs
+var count = lobbyManager.GetMemberMetadataCount(290926798626357250, 53908232506183680);
+for (int i = 0; i < count; i++) {
+  var key = lobbyManager.GetMemberMetadataKey(290926798626357250, 53908232506183680, i);
+  var value = lobbyManager.GetMemberMetadataValue(290926798626357250, 53908232506183680, key);
+  Console.WriteLine("Value: {0}", value);
+}
+```
+
+```cs
 void UpdateMember(Int64 lobbyId, Int64 userId, MemberTransaction transaction, (Discord.Result result) =>
 {
   // Updates info for a lobby member
@@ -376,9 +897,9 @@ LobbyManager.Search(query, (_) =>
 });
 ```
 
-### Example: Crossplay? In my SDK!?
+## Example: Crossplayish
 
-It's more likely than you think. So, an explanation. Because the DLL that you ship with your game is a stub that calls out to the local Discord client for actual operations, the SDK does not necessarily care if the game was launched from Discord. As long as the player launching the game:
+So, an explanation. Because the DLL that you ship with your game is a stub that calls out to the local Discord client for actual operations, the SDK does not necessarily care if the game was launched from Discord. As long as the player launching the game:
 
 1.  Has Discord installed
 2.  Has a Discord account

--- a/docs/game_sdk/Networking.md
+++ b/docs/game_sdk/Networking.md
@@ -90,7 +90,7 @@ var playerARemoteSessionId = 1234;
 networkManager.OpenReliableChannel(playerARemoteSessionId, 1);
 ```
 
-## Send
+## SendMessage
 
 Sends data to a given sessionid through the given channel.
 
@@ -111,7 +111,7 @@ Returns `void`.
 var playerARemoteSessionId = 1234;
 
 byte[] lootDrops = GameEngine.GetLootData();
-networkManager.Send(playerARemoteSessionId, 1, lootDrops);
+networkManager.SendMessage(playerARemoteSessionId, 1, lootDrops);
 ```
 
 ## CloseChannel
@@ -160,7 +160,7 @@ OnMessage += (UInt64 senderSessionId, byte channel, byte[] data) =>
 
 ## Connecting to Each Other
 
-This manager is built around the concept of channels between players. Player A opens a channel to Player B, and then Player B does the same to Player A. These two users can now send data back and forth to each other with `Send()` and receive it with `OnMessage`.
+This manager is built around the concept of channels between players. Player A opens a channel to Player B, and then Player B does the same to Player A. These two users can now send data back and forth to each other with `SendMessage()` and receive it with `OnMessage`.
 
 In order to properly send and receive data between A and B, both users need to have **the same type of channel** open to each other **on the same channel number**. If A has Reliable Channel 4 open to B, B also needs Reliable Channel 4 open to A. There are many ways to keep track of this; utilizing metadata on the lobby is one great way.
 
@@ -213,9 +213,9 @@ var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);
 // Join a lobby with another user in it
 // Get their session id, and connect to them
 
-var networkManager = Discord.CreateNetworkManager();
-var lobbyManager = Discord.CreateLobbyManager();
-var authManager = Discord.CreateAuthManager();
+var networkManager = Discord.GetNetworkManager();
+var lobbyManager = Discord.GetLobbyManager();
+var authManager = Discord.GetAuthManager();
 
 var me;
 var otherUserSessionId;
@@ -258,13 +258,13 @@ if (isDataAboutPlayerLootDrops(data))
 {
   // This is important and has to get there
   // Send over reliable channel
-  networkManager.Send(otherUserSessionId, 1, data);
+  networkManager.SendMessage(otherUserSessionId, 1, data);
 }
 else
 {
     // This is eventually consistent data, like the player's position in the world
     // It can be sent over the unreliable channel
-    networkManager.Send(otherUserSessionId, 0, data);
+    networkManager.SendMessage(otherUserSessionId, 0, data);
 }
 
 // Done; ship it!

--- a/docs/game_sdk/Networking.md
+++ b/docs/game_sdk/Networking.md
@@ -213,9 +213,9 @@ var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);
 // Join a lobby with another user in it
 // Get their session id, and connect to them
 
-var networkManager = Discord.GetNetworkManager();
-var lobbyManager = Discord.GetLobbyManager();
-var authManager = Discord.GetAuthManager();
+var networkManager = discord.GetNetworkManager();
+var lobbyManager = discord.GetLobbyManager();
+var authManager = discord.GetAuthManager();
 
 var me;
 var otherUserSessionId;

--- a/docs/game_sdk/Networking.md
+++ b/docs/game_sdk/Networking.md
@@ -14,46 +14,151 @@ Need a networking layer? Have a networking layer! This manager handles all thing
 
 An important note to make here is that our networking layer **is not peer-to-peer**. Discord has always promised that we will not leak your IP, and we promise to keep it that way. Though it seems like you are connected directly to another user, it routes through Discord's servers in the middle, ensuring both security and robust networking thanks to our servers.
 
-### Methods
+## GetSessionId
+
+Get the unique networking session id for the current user. Each user has a unique id for that session, used for connecting to that user.
+
+Returns a `UInt64`.
+
+###### Parameters
+
+None
+
+###### Example
 
 ```cs
-UInt64 GetSessionId();
-// Returns the session id for the connected user
-// Each user has a unique id for that session, used for connecting to that user
-
-void Flush();
-// This writes the packets out to the network
-// Run this at the end of your game's loop, once you've finished sending all you need to send
-// In Unity, for example, stick it in LateUpdate()
-
-void OpenChannel(UInt64 remoteSessionId, byte channel);
-// Opens an unreliable channel to the given session id on the given channel number
-// Use this type of channel for loss-agnostic data, like player positioning in a world
-
-void OpenReliableChannel(UInt64 remoteSessionId, byte channel);
-// Opens a reliable channel to a given session id on the given channel number
-// You can open a reliable and unreliable channel to the same user, on different channel numbers
-// Use this type of channel for data that must get there, like loot drops!
-
-void Send(UInt64 remoteSessionId, byte channel, byte[] data);
-// Send data to an open channel
-
-void CloseChannel(UInt64 remoteSessionId, byte channel);
-// Wave goodbye!
+var sid = networkManager.GetSessionId();
 ```
 
-### Callbacks
+## Flush
+
+Flushes the network. Run this at the end of your game's loop, once you've finished sending all you need to send. In Unity, for example, stick this in `LateUpdate()`.
+
+Returns `void`.
+
+###### Parameters
+
+None
+
+###### Example
+
+```cs
+OnLateUpdate() {
+  networkManager.Flush();
+}
+```
+
+## OpenChannel
+
+Opens an unreliable channel to the given session id on the given channel number. Use this type of channel for loss-tolerant data, like player positioning in the world.
+
+Returns `void`.
+
+###### Parameters
+
+| name            | type   | description                     |
+| --------------- | ------ | ------------------------------- |
+| remoteSessionId | UInt64 | the session id to connect to    |
+| channel         | byte   | the channel on which to connect |
+
+###### Example
+
+```cs
+// In reality, you'd fetch this from their lobby metadata
+var playerARemoteSessionId = 1234;
+networkManager.OpenChannel(playerARemoteSessionId, 0);
+```
+
+## OpenReliableChannel
+
+Opens a reliable channel to the given session id on the given channel number. Use this type of channel for data that _must_ get to the user, like loot drops!
+
+Returns `void`.
+
+###### Parameters
+
+| name            | type   | description                     |
+| --------------- | ------ | ------------------------------- |
+| remoteSessionId | UInt64 | the session id to connect to    |
+| channel         | byte   | the channel on which to connect |
+
+###### Example
+
+```cs
+// In reality, you'd fetch this from their lobby metadata
+var playerARemoteSessionId = 1234;
+networkManager.OpenReliableChannel(playerARemoteSessionId, 1);
+```
+
+## Send
+
+Sends data to a given sessionid through the given channel.
+
+Returns `void`.
+
+###### Parameters
+
+| name            | type   | description                     |
+| --------------- | ------ | ------------------------------- |
+| remoteSessionId | UInt64 | the session id to connect to    |
+| channel         | byte   | the channel on which to connect |
+| data            | byte[] | the data to send                |
+
+###### Example
+
+```cs
+// In reality, you'd fetch this from their lobby metadata
+var playerARemoteSessionId = 1234;
+
+byte[] lootDrops = GameEngine.GetLootData();
+networkManager.Send(playerARemoteSessionId, 1, lootDrops);
+```
+
+## CloseChannel
+
+Close the connection to a given remote seesion id on the given channel.
+
+Returns `void`.
+
+###### Parameters
+
+| name            | type   | description                               |
+| --------------- | ------ | ----------------------------------------- |
+| remoteSessionId | UInt64 | the session id of the connection to close |
+| channel         | byte   | the channel to close                      |
+
+###### Example
+
+```cs
+// In reality, you'd fetch this from their lobby metadata
+var playerARemoteSessionId = 1234;
+void CloseChannel(UInt64 playerARemoteSessionId, byte channel);
+Console.WriteLine("Connection to {0} closed", playerARemoteSessionId);
+```
+
+## OnMessage
+
+Fires when you receive data from another user. This callback will only fire if you already have an open channel with the user sending you data. Make sure you're running `RunCallbacks()` in your game loop, or you'll never get data!
+
+###### Parameters
+
+| name            | type   | description                  |
+| --------------- | ------ | ---------------------------- |
+| senderSessionId | UInt64 | the session id of the sender |
+| channel         | byte   | the channel it was sent on   |
+| data            | byte[] | the data sent                |
+
+###### Example
 
 ```cs
 OnMessage += (UInt64 senderSessionId, byte channel, byte[] data) =>
 {
-  // Fires when you receive data from another user
-  // This callback will only fire if you already have an open channel with the user sending you data
-  // Make sure you're running RunCallbacks() in your game loop, or you'll never get a thing!
+  var stringData = Encoding.UTF8.GetString(data);
+  Console.WriteLine("Message from {0}: {1}", senderSessionId, stringData)
 }
 ```
 
-### Connecting to Each Other
+## Connecting to Each Other
 
 This manager is built around the concept of channels between players. Player A opens a channel to Player B, and then Player B does the same to Player A. These two users can now send data back and forth to each other with `Send()` and receive it with `OnMessage`.
 
@@ -94,13 +199,13 @@ lobbyManager.UpdateLobby(lobby.id, txn, Discord.Result result =>
 // Player A can now listen for the OnLobbyUpdate callback and read the metadata
 ```
 
-### Flush() vs. RunCallbacks()
+## Flush vs RunCallbacks
 
 A quick note here may be helpful for the two functions that should be called continuously in your game loop: `discord.RunCallbacks()` and `networkManager.Flush()`. `RunCallbacks()` pumps the SDK's event loop, sending any newly-received data down the SDK tubes to your game. For this reason, you should call it at the beginning of your game loop; that way, any new data is handled immediately by callbacks you've registered. In Unity, for example, this goes in `Update()`.
 
 `Flush()` is specific to the network manager. It actually _writes_ the packets out to the stream. You should call this at the _end_ of your game loop as a way of saying "OK, I'm done with networking stuff, go send all the stuff to people who need it". In Unity, for example, this goes in `LateUpdate()`.
 
-### Example: Connecting to Another Player in a Lobby
+## Example: Connecting to Another Player in a Lobby
 
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);

--- a/docs/game_sdk/Overlay.md
+++ b/docs/game_sdk/Overlay.md
@@ -9,46 +9,109 @@ Discord comes with an awesome built-in overlay, and you may want to make use of 
   - Locked, enabled, unlocked, open, closed, etc.
 - Allows you to change that state
 
-### Data Models
+## Data Models
+
+###### ActivityActionType Enum
+
+| value    |
+| -------- |
+| Join     |
+| Spectate |
+
+## Methods
+
+## IsEnabled
+
+Check whether the user has the overlay enabled or disabled. You probably want to make this check before attempting to interact with the overlay.
+
+Returns a `bool`.
+
+###### Parameters
+
+None
+
+###### Example
 
 ```cs
-enum ActivityActionType
-{
-  Join = 1,
-  Spectate
-};
+if (!overlaymanager.IsEnabled()) {
+  Console.WriteLine("Could not complete operation. Please enable the overlay and relaunch the game.");
+}
+
+else {
+  DoTheThing();
+}
 ```
 
-### Methods
+## IsLocked
+
+Check if the overlay is currently locked or unlocked
+
+###### Parameters
+
+None
+
+###### Example
 
 ```cs
-bool IsEnabled();
-// Returns if the user currently has the overlay enabled or disabled
+if (overlayManager.IsLocked()) {
+  overlayManager.SetLocked(false);
+}
+```
 
-bool IsLocked();
-// Returns if the overlay is currently locked or unlocked
+## SetLocked
 
-void SetLocked(bool locked);
-// Toggles the overlay to be locked (true) or unlocked (false)
+Locks or unlocks the overlay.
 
-void OpenActivityInvite(ActivityActionType type, (Discord.Result result) =>
+Returns `void`.
+
+###### Parameters
+
+| name   | type | description                |
+| ------ | ---- | -------------------------- |
+| locked | bool | lock or unlock the overlay |
+
+###### Example
+
+```cs
+if (overlayManager.IsLocked()) {
+  overlayManager.SetLocked(false);
+}
+```
+
+## OpenActivityInvite
+
+Opens the overlay modal for sending game invitations to users, channels, and servers.
+
+Returns a `Discord.Result` via callback.
+
+###### Parameters
+
+| name | type               | description                 |
+| ---- | ------------------ | --------------------------- |
+| type | ActivityActionType | what type of invite to send |
+
+###### Example
+
+```cs
+overlayManager.OpenActivityInvite(Discord.ActivityActionType.Join, (Discord.Result result) =>
 {
-  // Opens the overlay modal for game invitations
-  // Invite users to Join to Spectate your game based on the action type
-  // The user receiving the invite will receive an `ActivityManager.OnActivityInvite` callback
+  if (result == Discord.Result.OK) {
+    Console.WriteLine("User is now inviting others to play!");
+  }
 });
 ```
 
-### Callbacks
+## OnOverlayLocked
 
-```cs
-OnOverlayLocked += (bool locked) =>
-{
-  // Fires when the overlay is locked/unlocked
-};
-```
+Fires when the overlay is locked or unlocked
 
-### Example: Unlock the Overlay
+###### Parameters
+
+| name   | type | description                           |
+| ------ | ---- | ------------------------------------- |
+| locked | bool | is the overlay now locked or unlocked |
+
+## Example: Unlock the Overlay
 
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);
@@ -61,7 +124,7 @@ overlayManager.OnOverlayLocked += locked => {
 overlayManager.SetLocked(false);
 ```
 
-### Example: Activate Overlay Invite Modal
+## Example: Activate Overlay Invite Modal
 
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);

--- a/docs/game_sdk/Overlay.md
+++ b/docs/game_sdk/Overlay.md
@@ -101,7 +101,7 @@ overlayManager.OpenActivityInvite(Discord.ActivityActionType.Join, (Discord.Resu
 });
 ```
 
-## OnOverlayLocked
+## OnLocked
 
 Fires when the overlay is locked or unlocked
 
@@ -116,9 +116,9 @@ Fires when the overlay is locked or unlocked
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);
 
-var overlayManager = discord.CreateOverlayManager();
+var overlayManager = discord.GetOverlayManager();
 
-overlayManager.OnOverlayLocked += locked => {
+overlayManager.OnLocked += locked => {
   Console.WriteLine("Overlay Locked: {0}", locked);
 };
 overlayManager.SetLocked(false);
@@ -128,7 +128,7 @@ overlayManager.SetLocked(false);
 
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);
-var overlayManager = discord.CreateOverlayManager();
+var overlayManager = discord.GetOverlayManager();
 
 // Invite users to join your game
 overlayManager.OpenActivityInvite(ActivityActionType.Join, result => {

--- a/docs/game_sdk/Relationships.md
+++ b/docs/game_sdk/Relationships.md
@@ -39,12 +39,12 @@ This manager helps you access the relationships your players have made on Discor
 
 ###### Status Enum
 
-| value        |
-| ------------ |
-| Offline      |
-| Online       |
-| Idle         |
-| DoNotDisturn |
+| name         | value |
+| ------------ | ----- |
+| Offline      | 0     |
+| Online       | 1     |
+| Idle         | 2     |
+| DoNotDisturn | 4     |
 
 ## Filter
 
@@ -124,7 +124,7 @@ for (int i = 0; i < relationshipsManager.Count(); i++) {
 }
 ```
 
-## OnRelationshipsUpdate
+## OnUpdateAll
 
 Fires in response to `Filter()` when relationships have been filtered and the list is stable and ready for access.
 
@@ -132,7 +132,7 @@ Fires in response to `Filter()` when relationships have been filtered and the li
 
 None
 
-## OnRelationshipUpdate
+## OnUpdate
 
 Fires when a relationship in the filtered list changes, like an updated presence or user attribute.
 
@@ -145,7 +145,7 @@ Fires when a relationship in the filtered list changes, like an updated presence
 ###### Example
 
 ```cs
-OnRelationshipUpdate += (Relationship relationship) =>
+OnUpdate += (Relationship relationship) =>
 {
   Console.WriteLine("Who changed? {0}", relationship.User.Id);
 };
@@ -155,11 +155,11 @@ OnRelationshipUpdate += (Relationship relationship) =>
 
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);
-var RelationshipManager = discord.CreateRelationshipManager();
+var RelationshipManager = discord.GetRelationshipManager();
 
 // Assign this handle right away to get the initial relationships update.
 // This callback will only be fired when the whole list is initially loaded or was reset
-RelationshipManager.OnRelationshipsUpdate += () =>
+RelationshipManager.OnUpdateAll += () =>
 {
   // Filter a user's relationship list to be just friends
   RelationshipManager.Filter((ref Discord.Relationship relationship) =>
@@ -186,8 +186,8 @@ RelationshipManager.OnRelationshipsUpdate += () =>
 
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);
-var RelationshipManager = discord.CreateRelationshipManager();
-var ActivityManager = discord.CreateActivityManager();
+var RelationshipManager = discord.GetRelationshipManager();
+var ActivityManager = discord.GetActivityManager();
 
 RelationshipManager.Filter((ref Discord.Relationship relationship) =>
 {

--- a/docs/game_sdk/Relationships.md
+++ b/docs/game_sdk/Relationships.md
@@ -155,29 +155,29 @@ OnRelationshipUpdate += (Relationship relationship) =>
 
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);
-var relationshipsManager = discord.CreateRelationshipsManager();
+var RelationshipManager = discord.CreateRelationshipManager();
 
 // Assign this handle right away to get the initial relationships update.
 // This callback will only be fired when the whole list is initially loaded or was reset
-relationshipsManager.OnRelationshipsUpdate += () =>
+RelationshipManager.OnRelationshipsUpdate += () =>
 {
   // Filter a user's relationship list to be just friends
-  relationshipsManager.Filter((ref Discord.Relationship relationship) =>
+  RelationshipManager.Filter((ref Discord.Relationship relationship) =>
   {
     return relationship.Type == Discord.RelationshipType.Friend;
   });
 
   // Loop over all friends a user has.
-  Console.WriteLine("relationships updated: {0}", relationshipsManager.Count());
+  Console.WriteLine("relationships updated: {0}", RelationshipManager.Count());
 
-  for (var i = 0; i < Math.Min(relationshipsManager.Count(), 10); i++)
+  for (var i = 0; i < Math.Min(RelationshipManager.Count(), 10); i++)
   {
       // Get an individual relationship from the list
-      var r = relationshipsManager.At((uint)i);
+      var r = RelationshipManager.At((uint)i);
       Console.WriteLine("relationships: {0} {1}", r.Type, r.User.Username);
 
       // Request relationship's avatar data.
-      FetchAvatar(imagesManager, r.User.Id);
+      FetchAvatar(ImageManager, r.User.Id);
   }
 };
 ```
@@ -186,24 +186,24 @@ relationshipsManager.OnRelationshipsUpdate += () =>
 
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);
-var relationshipsManager = discord.CreateRelationshipsManager();
-var activitiesManager = discord.CreateActivitiesManager();
+var RelationshipManager = discord.CreateRelationshipManager();
+var ActivityManager = discord.CreateActivityManager();
 
-relationshipsManager.Filter((ref Discord.Relationship relationship) =>
+RelationshipManager.Filter((ref Discord.Relationship relationship) =>
 {
   // Filter for users who are playing the same game as the current user
   // Is their activity application id the same as my client id?
   return relationship.Presence.Activity.ApplicationId == clientId;
 });
 
-for (var i = 0; i < Math.Min(relationshipsManager.Count(); i++)
+for (var i = 0; i < Math.Min(RelationshipManager.Count(); i++)
 {
     // Get an individual relationship from the list
-    var r = relationshipsManager.At((uint)i);
+    var r = RelationshipManager.At((uint)i);
     Console.WriteLine("relationships: {0} {1}", r.Type, r.User.Username);
 
     // Send them a game invite!
-    activitiesManager.InviteUser(r.User.Id, Discord.ActivityActionType.Join, "Come play with me!", result =>
+    ActivityManager.InviteUser(r.User.Id, Discord.ActivityActionType.Join, "Come play with me!", result =>
     {
       Console.WriteLine("Invited user {0} to play with you", r.User.Username);
     });

--- a/docs/game_sdk/SDK_Starter_Guide.md
+++ b/docs/game_sdk/SDK_Starter_Guide.md
@@ -64,7 +64,7 @@ And now you know, and knowing is half the battle.
 
 ## Step 1 - Get the Thing
 
-I know you're already convinced, so let's begin. First, get the SDK. The latest version can always be found in the `#resources` channel of our server.
+I know you're already convinced, so let's begin. First, get the SDK. Right now, the SDK is not publically available. If you are one of our developer partners, you'll have access to it; if not, feel free to keep reading for the sake of learning! And hey, if you've got an awesome game, and _want_ to be one of our developer partners, [drop us a message](https://dis.gdi/devstoreform).
 
 There's a few things in there, but let's quickly talk about what the SDK actually _is_. Inside the `lib/` folder, you'll see `x86/` and `x86_64/` that have some `.lib`, `.bundle`, and `.dll` files. You'll also notice that those files are _really_ small, just a couple hundred kilobytes. What these are are stubs for the Discord SDK. These are the things you want to distribute with your game. When you initialize the SDK, these stubs will call back to the locally installed Discord app to actually do the things your game needs. That means that the SDK will launch Discord if it's not already launched, or give you an error if Discord is not installed.
 
@@ -76,8 +76,6 @@ You'll also notice that there is a `runtime/` folder. Inside that folder are _ac
 - **macOS/Linux**: `~/.discord_game_sdk/`
 
 The SDK will prioritize these DLLs instead of using the stub to call out to the Discord client. That way, if we've got a new build of the SDK you want to test locally, or we gave you a debug build for debugging help, you can stick it in those folders and use it temporarily.
-
-> For the beginning of Discord's Store Beta Test period, you will need to have these DLLs in the above folders for local testing. We will let you know when you no longer need to rely on them.
 
 ## Get Set Up
 

--- a/docs/game_sdk/Storage.md
+++ b/docs/game_sdk/Storage.md
@@ -13,67 +13,218 @@ Discord's storage manager lets you save data mapped to a key for easy reading, w
 
 Creating this manager will also spawn an IO thread for async reads and writes, so unless you really want to be blocking, you don't need to be!
 
-### Data Models
+## Data Models
+
+###### FileStat Struct
+
+| name         | type   | description                                  |
+| ------------ | ------ | -------------------------------------------- |
+| Filename     | string | the name of the file                         |
+| Size         | UInt64 | the size of the file                         |
+| LastModified | UInt64 | timestamp of when the file was last modified |
+
+## Read
+
+Reads data synchronously from the game's allocated save file into a buffer. The file is mapped by key value pairs, and this function will read data that exists for the given key name.
+
+Returns a `UInt32`.
+
+###### Parameters
+
+| name | type   | description                        |
+| ---- | ------ | ---------------------------------- |
+| name | string | the key name to read from the file |
+| data | byte[] | the buffer to read into            |
+
+## ReadAsync
+
+Reads data asynchronously from the game's allocated save file into a buffer.
+
+Returns a `Discord.Result` and a `byte[]` containing the data via callback.
+
+###### Parameters
+
+| name | type   | description                        |
+| ---- | ------ | ---------------------------------- |
+| name | string | the key name to read from the file |
+
+###### Example
 
 ```cs
-struct FileStat
+storeManager.ReadAsync("high_score", (Discord.Result result, byte[] data) =>
 {
-  string Filename;
-  UInt64 Size;
-  UInt64 LastModified;
-};
+  if (result == Discord.Result.OK) {
+    LoadHighScore(data);
+  }
+});
 ```
 
-### Methods
+## ReadAsyncPartial
+
+Reads data asynchronously from the game's allocated save file into a buffer, starting at a given offset and up to a given length.
+
+Returns a `Discord.Result` and `byte[]` containing the data via callback.
+
+###### Parameters
+
+| name   | type   | description                          |
+| ------ | ------ | ------------------------------------ |
+| name   | string | the key name to read from the file   |
+| offset | UInt64 | the offset at which to start reading |
+| length | UInt64 | the length to read                   |
+
+###### Example
 
 ```cs
-UInt32 Read(string name, byte[] data);
-// Reads data synchronously from disk into the buffer
-// Looks for data mapped under given key name
-
-void ReadAsync(string name, (Discord.Result result, byte[] data) =>
+storeManager.ReadAsyncPartial("high_score", 10, 8, (Discord.Result result, byte[] data) =>
 {
-  // Reads data asynchronously from disk into the buffer
-  // Looks for data mapped under given key name
+  if (result == Discord.Result.OK) {
+    LoadHighScore(data);
+  }
 });
-
-void ReadAsyncPartial(string name, UInt64 offset, UInt64 length, (Discord.Result result, byte[] data) =>
-{
-  // Reads data asynchronously from disk into the buffer
-  // Starts at the given offset and reads up to length
-  // Looks for data mapped under given key name
-});
-
-void Write(string name, byte[] data);
-// Writes data synchronously to disk
-// Mapped to the given key name
-
-void WriteAsync(string name, byte[] data, (Discord.Result result) =>
-{
-  // Writes data asynchronously to disk
-  // Mapped to the given key name
-});
-
-void Delete(string name);
-// Deletes the data for the given key name
-
-bool Exists(string name);
-// Checks if data exists under the given key name
-// Returns a boolean
-
-FileStat Stat(string name);
-// Returns file info for the given key name
-// In the form of a File struct
-
-Int32 Count();
-// Returns the count of files returned for iteration
-
-FileStat StatIndex(int index);
-// Returns file info for the given index
-// In the form of a FIle struct
 ```
 
-### Example: Saving, Reading, Deleting, and Checking Data
+## Write
+
+Writes data synchronously to disk, under the given key name.
+
+Returns `void`.
+
+###### Parameters
+
+| name | type   | description                 |
+| ---- | ------ | --------------------------- |
+| name | string | the key name to write under |
+| data | byte[] | the data to write           |
+
+###### Example
+
+```cs
+storageManager.Write("high_score", Encoding.UTF8.GetBytes("9999"));
+```
+
+## WriteAsync
+
+Writes data asynchronously to disk under the given keyname.
+
+###### Parameters
+
+| name | type   | description                 |
+| ---- | ------ | --------------------------- |
+| name | string | the key name to write under |
+| data | byte[] | the data to write           |
+
+###### Example
+
+```cs
+storageManager.WriteAsync("high_score", Encoding.UTF8.GetBytes("9999"), Discord.Result result => {
+  if (result == Discord.Result.OK) {
+    Console.WriteLine("Wrote data");
+  }
+});
+```
+
+## Delete
+
+Deletes written data for the given key name.
+
+Returns `void`.
+
+###### Parameters
+
+| name | type   | description            |
+| ---- | ------ | ---------------------- |
+| name | string | the key name to delete |
+
+###### Example
+
+```cs
+storageManager.Delete("high_score");
+// Because you cheated. Jerk.
+```
+
+## Exists
+
+Checks if data exists for a given key name.
+
+Returns `bool`.
+
+###### Parameters
+
+| name | type   | description           |
+| ---- | ------ | --------------------- |
+| name | string | the key name to check |
+
+###### Example
+
+```cs
+var highScore = storageManager.Exists("high_score");
+if (!highScore) {
+  Console.WriteLine("Couldn't find any highscore for you. Did you cheat? Jerk.");
+}
+```
+
+## Stat
+
+Returns file info for the given key name.
+
+Returns a `Filestat`.
+
+###### Parameters
+
+| name | type   | description                    |
+| ---- | ------ | ------------------------------ |
+| name | string | the key name get file data for |
+
+###### Example
+
+```cs
+var file = storageManager.Stat("high_score");
+Console.WriteLine("File {0} is {1} in size and was last edited at {2}", file.Name, file.Size, file.LastModified);
+```
+
+## Count
+
+Returns the count of files, for iteration.
+
+Returns an `Int32`.
+
+###### Parameters
+
+None
+
+###### Example
+
+```cs
+var numFiles = storageManager.Count();
+for (int i = 0; i < numFiles; i++) {
+  Console.WriteLine("We're at file {0}", i);
+}
+```
+
+## StatIndex
+
+Returns file info for the given index when iterating over files.
+
+Returns a `FileStat`.
+
+###### Parameters
+
+| name  | type  | description                    |
+| ----- | ----- | ------------------------------ |
+| index | Int32 | the index to get file data for |
+
+###### Example
+
+```cs
+var numFiles = storageManager.Count();
+for (int i = 0; i < numFiles; i++) {
+  var file = storageManager.StatIndex(i);
+  Console.WriteLine("File is {0}", file.Name);
+}
+```
+
+## Example: Saving, Reading, Deleting, and Checking Data
 
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);

--- a/docs/game_sdk/Storage.md
+++ b/docs/game_sdk/Storage.md
@@ -17,11 +17,11 @@ Creating this manager will also spawn an IO thread for async reads and writes, s
 
 ###### FileStat Struct
 
-| name         | type   | description                                  |
-| ------------ | ------ | -------------------------------------------- |
-| Filename     | string | the name of the file                         |
-| Size         | UInt64 | the size of the file                         |
-| LastModified | UInt64 | timestamp of when the file was last modified |
+| name         | type             | description                                  |
+| ------------ | ---------------- | -------------------------------------------- |
+| Filename     | string (260 len) | the name of the file                         |
+| Size         | UInt64           | the size of the file                         |
+| LastModified | UInt64           | timestamp of when the file was last modified |
 
 ## Read
 
@@ -228,7 +228,7 @@ for (int i = 0; i < numFiles; i++) {
 
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);
-var storageManager = discord.CreateStorageManager();
+var storageManager = discord.GetStorageManager();
 
 // Create some nonsense data
 var contents = new byte[20000];

--- a/docs/game_sdk/Storage.md
+++ b/docs/game_sdk/Storage.md
@@ -17,11 +17,11 @@ Creating this manager will also spawn an IO thread for async reads and writes, s
 
 ###### FileStat Struct
 
-| name         | type             | description                                  |
-| ------------ | ---------------- | -------------------------------------------- |
-| Filename     | string (260 len) | the name of the file                         |
-| Size         | UInt64           | the size of the file                         |
-| LastModified | UInt64           | timestamp of when the file was last modified |
+| name         | type   | description                                  |
+| ------------ | ------ | -------------------------------------------- |
+| Filename     | string | the name of the file                         |
+| Size         | UInt64 | the size of the file                         |
+| LastModified | UInt64 | timestamp of when the file was last modified |
 
 ## Read
 

--- a/docs/game_sdk/Users.md
+++ b/docs/game_sdk/Users.md
@@ -71,8 +71,8 @@ Fires when the `User` struct of the currently connected user changes. They may h
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);
 
-var usersManager = discord.CreateUsersManager();
-usersManager.Fetch(450795363658366976, (Discord.Result result, ref Discord.User user) =>
+var UserManager = discord.CreateUserManager();
+UserManager.Fetch(450795363658366976, (Discord.Result result, ref Discord.User user) =>
 {
   if (result == Discord.Result.Ok)
   {
@@ -80,7 +80,7 @@ usersManager.Fetch(450795363658366976, (Discord.Result result, ref Discord.User 
 
     // Request users's avatar data.
     // This can only be done after a user is successfully fetched.
-    FetchAvatar(imagesManager, user.Id);
+    FetchAvatar(ImageManager, user.Id);
   }
   else
   {

--- a/docs/game_sdk/Users.md
+++ b/docs/game_sdk/Users.md
@@ -9,13 +9,13 @@ This manager helps retrieve basic user information for any user on Discord.
 
 ###### User Struct
 
-| name          | type             | description                   |
-| ------------- | ---------------- | ----------------------------- |
-| Id            | Int64            | the user's id                 |
-| Username      | string (256 len) | their name                    |
-| Discriminator | string (8 len)   | the user's unique discrim     |
-| Avatar        | string (128 len) | the hash of the user's avatar |
-| Bot           | bool             | if the user is a bot user     |
+| name          | type   | description                   |
+| ------------- | ------ | ----------------------------- |
+| Id            | Int64  | the user's id                 |
+| Username      | string | their name                    |
+| Discriminator | string | the user's unique discrim     |
+| Avatar        | string | the hash of the user's avatar |
+| Bot           | bool   | if the user is a bot user     |
 
 ## GetCurrentUser
 

--- a/docs/game_sdk/Users.md
+++ b/docs/game_sdk/Users.md
@@ -9,12 +9,13 @@ This manager helps retrieve basic user information for any user on Discord.
 
 ###### User Struct
 
-| name          | type   | description                        |
-| ------------- | ------ | ---------------------------------- |
-| Id            | Int64  | unique Discord id                  |
-| Username      | string | user's name                        |
-| Discriminator | string | the four digits after the username |
-| Avatar        | string | hash of user's avatar              |
+| name          | type             | description                   |
+| ------------- | ---------------- | ----------------------------- |
+| Id            | Int64            | the user's id                 |
+| Username      | string (256 len) | their name                    |
+| Discriminator | string (8 len)   | the user's unique discrim     |
+| Avatar        | string (128 len) | the hash of the user's avatar |
+| Bot           | bool             | if the user is a bot user     |
 
 ## GetCurrentUser
 
@@ -71,7 +72,7 @@ Fires when the `User` struct of the currently connected user changes. They may h
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);
 
-var UserManager = discord.CreateUserManager();
+var UserManager = discord.GetUserManager();
 UserManager.Fetch(450795363658366976, (Discord.Result result, ref Discord.User user) =>
 {
   if (result == Discord.Result.Ok)

--- a/docs/game_sdk/Users.md
+++ b/docs/game_sdk/Users.md
@@ -5,40 +5,68 @@
 
 This manager helps retrieve basic user information for any user on Discord.
 
-### Data Models
+## Data Models
+
+###### User Struct
+
+| name          | type   | description                        |
+| ------------- | ------ | ---------------------------------- |
+| Id            | Int64  | unique Discord id                  |
+| Username      | string | user's name                        |
+| Discriminator | string | the four digits after the username |
+| Avatar        | string | hash of user's avatar              |
+
+## GetCurrentUser
+
+Fetch information about the currently connected user account.
+
+Returns a `User`.
+
+###### Parameters
+
+None
+
+###### Example
 
 ```cs
-struct User
-{
-  Int64 Id;
-  string Username;
-  string Discriminator;
-  string Avatar;
-  bool Bot;
-};
+var user = userManager.GetCurrentUser();
+Console.WriteLine("Connected to user {0}", user.Id);
 ```
 
-### Methods
+## Fetch
+
+Fetch user information for a given id.
+
+Returns a `Discord.Result` and `User` via callback.
+
+###### Parameters
+
+| name   | type  | description                 |
+| ------ | ----- | --------------------------- |
+| userId | Int64 | the id of the user to fetch |
+
+###### Example
 
 ```cs
-User GetCurrentUser();
-// Returns information about the currently connected user account
-
 void Fetch(Int64 userId, (Discord.Result result, User user) =>
 {
-  // Returns information about a user given their id
+  if (result == Discord.Result.OK) {
+    Console.WriteLine("User {0} is {1}", user.Id, user.Username);
+  }
 });
 ```
 
-### Callbacks
+## OnCurrentUserUpdate
 
-````cs
-OnCurrentUserUpdate =+ User user =>
-{
-  // Fires when the User object of the currently connected user changes
-}
+Fires when the `User` struct of the currently connected user changes. They may have changed their avatar, username, or something else.
 
-### Example: Fetching Data About a Discord User
+###### Parameters
+
+| name | type | description                            |
+| ---- | ---- | -------------------------------------- |
+| user | User | a new User struct for the current user |
+
+## Example: Fetching Data About a Discord User
 
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);
@@ -59,4 +87,4 @@ usersManager.Fetch(450795363658366976, (Discord.Result result, ref Discord.User 
     Console.WriteLine("user fetch error: {0}", result);
   }
 });
-````
+```


### PR DESCRIPTION
This PR reformats the Game SDK docs to be consistent with the broader Discord API documentation. That is to say, using tables/proper headers and anchor tags.

It also includes the changes for V2 of the Game SDK. It does not yet include error documentation around the functions, e.g. what sort of `Discord.Result`s the functions can return. That will be done in the next pass.