### PR TITLE
Clarify the form of "emoji" in Create Reaction

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -463,7 +463,7 @@ For example:
 
 ## Create Reaction % PUT /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/messages/{message.id#DOCS_RESOURCES_CHANNEL/message-object}/reactions/{emoji#DOCS_RESOURCES_EMOJI/emoji-object}/@me
 
-Create a reaction for the message. This endpoint requires the 'READ\_MESSAGE\_HISTORY' permission to be present on the current user.  Additionally, if nobody else has reacted to the message using this emoji, this endpoint requires the 'ADD\_REACTIONS' permission to be present on the current user. Returns a 204 empty response on success.
+Create a reaction for the message. `emoji` takes the form of `name:id` for custom guild emoji, or Unicode characters. This endpoint requires the 'READ\_MESSAGE\_HISTORY' permission to be present on the current user.  Additionally, if nobody else has reacted to the message using this emoji, this endpoint requires the 'ADD\_REACTIONS' permission to be present on the current user. Returns a 204 empty response on success.
 
 ## Delete Own Reaction % DELETE /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/messages/{message.id#DOCS_RESOURCES_CHANNEL/message-object}/reactions/{emoji#DOCS_RESOURCES_EMOJI/emoji-object}/@me
 


### PR DESCRIPTION
The only string representations of an Emoji in the docs are [JSON](https://discordapp.com/developers/docs/resources/emoji#emoji-object-gateway-reaction-standard-emoji-example) (doesn't apply to a URL) and [Message Formatting](https://discordapp.com/developers/docs/reference#message-formatting-formats) - most beginners try to use the mention form of `:name:id` which will fail, as this endpoint does not expect the leading `:`-  rather I assume the parser sees `:` and expects an snowflake ID to follow, not a string, and fails with Unknown Emoji.

Another common uncertainty is whether the `a:` flag needs to be prefixed for animated emoji, as well as how to specify Unicode emoji, as the `{emoji}` hyperlink only links to the custom emoji page.

Hopefully this clarifies all of the above.

I considered changing the URL to read as `../{emoji.name}:{emoji.id}/..` but I figured it would make for a more complicated explanation in the documentation..