### PR TITLE
Document additional G250K fields

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -140,13 +140,15 @@ Represents a message sent in a channel within Discord.
 |-------|------|-------------|
 | id | snowflake | id of the message |
 | channel\_id | snowflake | id of the channel the message was sent in |
+| guild\_id? | snowflake | id of the guild the message was sent in |
 | author* | [user](#DOCS_RESOURCES_USER/user-object) object | the author of this message (not guaranteed to be a valid user, see below) |
+| member? | partial [member object](#DOCS_RESOURCES_GUILD/member-object) | member properties for this message's author |
 | content | string | contents of the message |
 | timestamp | ISO8601 timestamp | when this message was sent |
 | edited\_timestamp | ?ISO8601 timestamp | when this message was edited (or null if never) |
 | tts | bool | whether this was a TTS message |
 | mention\_everyone | bool | whether this message mentions everyone |
-| mentions | array of [user](#DOCS_RESOURCES_USER/user-object) objects | users specifically mentioned in the message |
+| mentions | array of [user](#DOCS_RESOURCES_USER/user-object) objects, with an additional partial [member](#DOCS_RESOURCES_GUILD/member-object) field | users specifically mentioned in the message |
 | mention\_roles | array of [role](#DOCS_TOPICS_PERMISSIONS/role-object) object ids | roles specifically mentioned in this message |
 | attachments | array of [attachment](#DOCS_RESOURCES_CHANNEL/attachment-object) objects | any attached files |
 | embeds | array of [embed](#DOCS_RESOURCES_CHANNEL/embed-object) objects | any embedded content |

--- a/docs/resources/Voice.md
+++ b/docs/resources/Voice.md
@@ -11,6 +11,7 @@ Used to represent a user's voice connection status.
 | guild_id? | snowflake | the guild id this voice state is for |
 | channel_id | ?snowflake | the channel id this user is connected to |
 | user_id | snowflake | the user id this voice state is for |
+| member? | [member object](#DOCS_RESOURCES_GUILD/member-object) | the guild member this voice state is for |
 | session_id | string | the session id for this voice state |
 | deaf | bool | whether this user is deafened by the server |
 | mute | bool | whether this user is muted by the server |

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -706,6 +706,7 @@ Sent when a message is deleted.
 | ---------- | --------- | --------------------- |
 | id         | snowflake | the id of the message |
 | channel_id | snowflake | the id of the channel |
+| guild_id?  | snowflake | the id of the guild   |
 
 #### Message Delete Bulk
 
@@ -717,6 +718,7 @@ Sent when multiple messages are deleted at once.
 | ---------- | ------------------- | ----------------------- |
 | ids        | array of snowflakes | the ids of the messages |
 | channel_id | snowflake           | the id of the channel   |
+| guild_id?  | snowflake           | the id of the guild     |
 
 #### Message Reaction Add
 
@@ -729,6 +731,7 @@ Sent when a user adds a reaction to a message.
 | user_id    | snowflake                                                    | the id of the user                                                                                              |
 | channel_id | snowflake                                                    | the id of the channel                                                                                           |
 | message_id | snowflake                                                    | the id of the message                                                                                           |
+| guild_id?  | snowflake                                                    | the id of the guild                                                                                             |
 | emoji      | a partial [emoji](#DOCS_RESOURCES_EMOJI/emoji-object) object | the emoji used to react - [example](#DOCS_RESOURCES_EMOJI/emoji-object-gateway-reaction-standard-emoji-example) |
 
 #### Message Reaction Remove
@@ -742,6 +745,7 @@ Sent when a user removes a reaction from a message.
 | user_id    | snowflake                                                    | the id of the user                                                                                              |
 | channel_id | snowflake                                                    | the id of the channel                                                                                           |
 | message_id | snowflake                                                    | the id of the message                                                                                           |
+| guild_id?  | snowflake                                                    | the id of the guild                                                                                             |
 | emoji      | a partial [emoji](#DOCS_RESOURCES_EMOJI/emoji-object) object | the emoji used to react - [example](#DOCS_RESOURCES_EMOJI/emoji-object-gateway-reaction-standard-emoji-example) |
 
 #### Message Reaction Remove All
@@ -754,6 +758,7 @@ Sent when a user explicitly removes all reactions from a message.
 | ---------- | --------- | --------------------- |
 | channel_id | snowflake | the id of the channel |
 | message_id | snowflake | the id of the message |
+| guild_id?  | snowflake | the id of the guild   |
 
 ### Presence
 
@@ -901,6 +906,7 @@ Sent when a user starts typing in a channel.
 | Field      | Type      | Description                                            |
 | ---------- | --------- | ------------------------------------------------------ |
 | channel_id | snowflake | id of the channel                                      |
+| guild_id?  | snowflake | id of the guild                                        |
 | user_id    | snowflake | id of the user                                         |
 | timestamp  | integer   | unix time (in seconds) of when the user started typing |
 


### PR DESCRIPTION
This should be everything 🙂 

The only thing I wasn't sure about was `user.member` inside of `message.mentions`. This is the only place where its present, even more specifically, only in `MESSAGE_CREATE`. Suggestions welcome on better placement!

Closes #582 