### PR TITLE
Minor Edits & Corrections to Create Message (multipart/form-data)

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -428,10 +428,8 @@ Post a message to a guild text or DM channel. If operating on a guild channel, t
 
 The maximum request size when sending a message is 8MB.
 
->warn
->This endpoint supports requests with `Content-Type`s of both `application/json` and `multipart/form-data`. You must however use `multipart/form-data` when uploading files.
->Note that when sending `multipart/form-data` requests the `embed` field cannot be used, however you can pass a JSON encoded body as form value for `payload_json`, where additional request parameters such as `embed` can be set.
->Additionally, note that when sending `application/json` you must send at least one of `content` or `embed`, and when sending `multipart/form-data`, you must send at least one of `content`, `embed` or `file`.
+
+This endpoint supports requests with `Content-Type`s of both `application/json` and `multipart/form-data`. You must however use `multipart/form-data` when uploading files. Note that when sending `multipart/form-data` requests the `embed` field cannot be used, however you can pass a JSON encoded body as form value for `payload_json`, where additional request parameters such as `embed` can be set. Additionally, note that when sending `application/json` you must send at least one of `content` or `embed`, and when sending `multipart/form-data`, you must send at least one of `content`, `embed` or `file`.
 
 ###### Params
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -428,7 +428,7 @@ Post a message to a guild text or DM channel. If operating on a guild channel, t
 
 The maximum request size when sending a message is 8MB.
 
-This endpoint supports requests with `Content-Type`s of both `application/json` and `multipart/form-data`. You must however use `multipart/form-data` when uploading files. Note that when sending `multipart/form-data` requests the `embed` field cannot be used, however you can pass a JSON encoded body as form value for `payload_json`, where additional request parameters such as `embed` can be set. 
+This endpoint supports requests with `Content-Type`s of both `application/json` and `multipart/form-data`. You must however use `multipart/form-data` when uploading files. Note that when sending `multipart/form-data` requests the `embed` field cannot be used, however you can pass a JSON encoded body as form value for `payload_json`, where additional request parameters such as `embed` can be set.
 
 >info
 >Note that when sending `application/json` you must send at least one of `content` or `embed`, and when sending `multipart/form-data`, you must send at least one of `content`, `embed` or `file`.
@@ -471,8 +471,10 @@ This endpoint supports requests with `Content-Type`s of both `application/json` 
 |------------|------------|
 | content | Hello, World! |
 | tts | false |
-| payload_json | `"embed": { "title": "Hello, Embed!", "description": "This is an embedded message." }` |
 | file | file contents |
+
+>warn
+>When sending `payload_json` in multipart requests, fields except for `file` are ignored.
 
 ###### Using Attachments within Embeds
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -428,7 +428,6 @@ Post a message to a guild text or DM channel. If operating on a guild channel, t
 
 The maximum request size when sending a message is 8MB.
 
-
 This endpoint supports requests with `Content-Type`s of both `application/json` and `multipart/form-data`. You must however use `multipart/form-data` when uploading files. Note that when sending `multipart/form-data` requests the `embed` field cannot be used, however you can pass a JSON encoded body as form value for `payload_json`, where additional request parameters such as `embed` can be set. Additionally, note that when sending `application/json` you must send at least one of `content` or `embed`, and when sending `multipart/form-data`, you must send at least one of `content`, `embed` or `file`.
 
 ###### Params

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -438,7 +438,7 @@ The maximum request size when sending a message is 8MB.
 | content | string | the message contents (up to 2000 characters) | true |
 | nonce | snowflake | a nonce that can be used for optimistic message sending | false |
 | tts | boolean | true if this is a TTS message | false |
-| file | file contents | the contents of the file being sent | when sending `multipart/form-data` one of content, file, embeds must be present. |
+| file | file contents | the contents of the file being sent | when sending `multipart/form-data` at least one of content, file, embeds must be present. |
 | embed | [embed](#DOCS_RESOURCES_CHANNEL/embed-object) object | embedded `rich` content | false |
 | payload_json | string | JSON encoded body used in place of the `embed` field | `multipart/form-data` only
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -428,21 +428,51 @@ Post a message to a guild text or DM channel. If operating on a guild channel, t
 
 The maximum request size when sending a message is 8MB.
 
-This endpoint supports requests with `Content-Type`s of both `application/json` and `multipart/form-data`. You must however use `multipart/form-data` when uploading files. Note that when sending `multipart/form-data` requests the `embed` field cannot be used, however you can pass a JSON encoded body as form value for `payload_json`, where additional request parameters such as `embed` can be set. Additionally, note that when sending `application/json` you must send at least one of `content` or `embed`, and when sending `multipart/form-data`, you must send at least one of `content`, `embed` or `file`.
+This endpoint supports requests with `Content-Type`s of both `application/json` and `multipart/form-data`. You must however use `multipart/form-data` when uploading files. Note that when sending `multipart/form-data` requests the `embed` field cannot be used, however you can pass a JSON encoded body as form value for `payload_json`, where additional request parameters such as `embed` can be set. 
+
+>info
+>Note that when sending `application/json` you must send at least one of `content` or `embed`, and when sending `multipart/form-data`, you must send at least one of `content`, `embed` or `file`.
 
 ###### Params
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-| content | string | the message contents (up to 2000 characters) | true |
-| nonce | snowflake | a nonce that can be used for optimistic message sending | false |
-| tts | boolean | true if this is a TTS message | false |
-| file | file contents | the contents of the file being sent | false, `multipart/form-data` only |
-| embed | [embed](#DOCS_RESOURCES_CHANNEL/embed-object) object | embedded `rich` content | false, `application/json` only |
-| payload_json | string | JSON encoded body of additional request parameters, such as `embed` | false, `multipart/form-data` only |
+| Field | Type | Description |
+|-------|------|-------------|
+| content | string | the message contents (up to 2000 characters) |
+| nonce | snowflake | a nonce that can be used for optimistic message sending |
+| tts | boolean | true if this is a TTS message |
+| file | file contents | the contents of the file being sent |
+| embed | [embed](#DOCS_RESOURCES_CHANNEL/embed-object) object | embedded `rich` content |
+| payload_json | string | JSON encoded body of any additional request fields. |
 
 >info
 >For the embed object, you can set every field except `type` (it will be `rich` regardless of if you try to set it), `provider`, `video`, and any `height`, `width`, or `proxy_url` values for images.
+
+###### Example Request Body (application/json)
+
+```json
+{
+  "content": "Hello, World!",
+  "tts": false,
+  "embed": {
+    "title": "Hello, Embed!",
+    "description": "This is an embedded message."
+  }
+}
+```
+
+###### Example Request Bodies (multipart/form-data) 
+
+| Field Name | Form Value |
+|------------|------------|
+| payload_json | `"content": "Hello, World!", "tts": false, "embed": { "title": "Hello, Embed!", "description": "This is an embedded message." }` |
+| file | file contents |
+
+| Field Name | Form Value |
+|------------|------------|
+| content | Hello, World! |
+| tts | false |
+| payload_json | `"embed": { "title": "Hello, Embed!", "description": "This is an embedded message." }` |
+| file | file contents |
 
 ###### Using Attachments within Embeds
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -438,12 +438,13 @@ The maximum request size when sending a message is 8MB.
 | content | string | the message contents (up to 2000 characters) | true |
 | nonce | snowflake | a nonce that can be used for optimistic message sending | false |
 | tts | boolean | true if this is a TTS message | false |
-| file | file contents | the contents of the file being sent | one of content, file, embeds (`multipart/form-data` only) |
+| file | file contents | the contents of the file being sent | when sending `multipart/form-data` one of content, file, embeds must be present. |
 | embed | [embed](#DOCS_RESOURCES_CHANNEL/embed-object) object | embedded `rich` content | false |
-| payload_json | string | url-encoded JSON body used in place of the `embed` field | `multipart/form-data` only
+| payload_json | string | JSON encoded body used in place of the `embed` field | `multipart/form-data` only
 
 >info
 >For the embed object, you can set every field except `type` (it will be `rich` regardless of if you try to set it), `provider`, `video`, and any `height`, `width`, or `proxy_url` values for images.
+>`payload_json` must be of the format `{ embed: [embed](#DOCS_RESOURCES_CHANNEL/embed-object) }`, not simply the embed object.
 
 ###### Using Attachments within Embeds
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -444,6 +444,8 @@ The maximum request size when sending a message is 8MB.
 
 >info
 >For the embed object, you can set every field except `type` (it will be `rich` regardless of if you try to set it), `provider`, `video`, and any `height`, `width`, or `proxy_url` values for images.
+
+>info
 >`payload_json` must be of the format `{ embed: [embed](#DOCS_RESOURCES_CHANNEL/embed-object) }`, not simply the embed object.
 
 ###### Using Attachments within Embeds

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -429,7 +429,9 @@ Post a message to a guild text or DM channel. If operating on a guild channel, t
 The maximum request size when sending a message is 8MB.
 
 >warn
->This endpoint supports both JSON and form data bodies. It does require multipart/form-data requests instead of the normal JSON request type when uploading files. Make sure you set your `Content-Type` to `multipart/form-data` if you're doing that. Note that in that case, the `embed` field cannot be used, but you can pass an url-encoded JSON body as a form value for `payload_json`.
+>This endpoint supports requests with `Content-Type`s of both `application/json` and `multipart/form-data`. You must however use `multipart/form-data` when uploading files.
+>Note that when sending `multipart/form-data` requests the `embed` field cannot be used, however you can pass a JSON encoded body as form value for `payload_json`, where additional request parameters such as `embed` can be set.
+>Additionally, note that when sending `application/json` you must send at least one of `content` or `embed`, and when sending `multipart/form-data`, you must send at least one of `content`, `embed` or `file`.
 
 ###### Params
 
@@ -438,15 +440,12 @@ The maximum request size when sending a message is 8MB.
 | content | string | the message contents (up to 2000 characters) | true |
 | nonce | snowflake | a nonce that can be used for optimistic message sending | false |
 | tts | boolean | true if this is a TTS message | false |
-| file | file contents | the contents of the file being sent | when sending `multipart/form-data` at least one of content, file, embeds must be present. |
-| embed | [embed](#DOCS_RESOURCES_CHANNEL/embed-object) object | embedded `rich` content | false |
-| payload_json | string | JSON encoded body used in place of the `embed` field | `multipart/form-data` only
+| file | file contents | the contents of the file being sent | false, `multipart/form-data` only |
+| embed | [embed](#DOCS_RESOURCES_CHANNEL/embed-object) object | embedded `rich` content | false, `application/json` only |
+| payload_json | string | JSON encoded body of additional request parameters, such as `embed` | false, `multipart/form-data` only |
 
 >info
 >For the embed object, you can set every field except `type` (it will be `rich` regardless of if you try to set it), `provider`, `video`, and any `height`, `width`, or `proxy_url` values for images.
-
->info
->`payload_json` must be of the format `{ embed: [embed](#DOCS_RESOURCES_CHANNEL/embed-object) }`, not simply the embed object.
 
 ###### Using Attachments within Embeds
 

--- a/docs/resources/Webhook.md
+++ b/docs/resources/Webhook.md
@@ -112,6 +112,7 @@ Same as above, except this call does not require authentication.
 | tts | boolean | true if this is a TTS message | false |
 | file | file contents | the contents of the file being sent | one of content, file, embeds |
 | embeds | array of [embed](#DOCS_RESOURCES_CHANNEL/embed-object) objects | embedded `rich` content | one of content, file, embeds |
+| payload_json | string | See [message create](#DOCS_RESOURCES_CHANNEL/create-message) | `multipart/form-data` only |
 
 >info
 >For the webhook embed objects, you can set every field except `type` (it will be `rich` regardless of if you try to set it), `provider`, `video`, and any `height`, `width`, or `proxy_url` values for images.


### PR DESCRIPTION
There are some inconsistencies in how the docs explain this endpoint and how it works in practice, so I thought I'd add clarification to the article. 

- The description on `file` is quite vague and hard to understand.
- If you pass an URL-encoded JSON object to the `payload_json` field it will error out- it needs to be a plain string. 
- `payload_json` can't simply be the JSON embed, it needs to be wrapped inside another JSON object - this isn't made clear at the moment.