### PR TITLE
Fix typo in Modify Guild Integration

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -508,7 +508,7 @@ Attach an [integration](#DOCS_RESOURCES_GUILD/integration-object) object from th
 
 ## Modify Guild Integration % PATCH /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/integrations/{integration.id#DOCS_RESOURCES_GUILD/integration-object}
 
-Modify the behavior and settings of a [integration](#DOCS_RESOURCES_GUILD/integration-object) object for the guild. Requires the 'MANAGE_GUILD' permission. Returns a 204 empty response on success. Fires a [Guild Integrations Update](#DOCS_TOPICS_GATEWAY/guild-integrations-update) Gateway event.
+Modify the behavior and settings of an [integration](#DOCS_RESOURCES_GUILD/integration-object) object for the guild. Requires the 'MANAGE_GUILD' permission. Returns a 204 empty response on success. Fires a [Guild Integrations Update](#DOCS_TOPICS_GATEWAY/guild-integrations-update) Gateway event.
 
 ###### JSON Params
 


### PR DESCRIPTION
Fixed a typo from `a integration` to `an integration`.