### PR TITLE
Update guild IDs and examples

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -41,17 +41,17 @@ Represents a guild or DM channel within Discord.
 
 ```json
 {
-	"id": "41771983423143937",
-	"guild_id": "41771983423143937",
-	"name": "general",
-	"type": 0,
-	"position": 6,
-	"permission_overwrites": [],
-	"rate_limit_per_user": 2,
-	"nsfw": true,
-	"topic": "24/7 chat about how to gank Mike #2",
-	"last_message_id": "155117677105512449",
-	"parent_id": "399942396007890945"
+    "guild_id": "81384788765712384",
+    "name": "rules",
+    "permission_overwrites": [],
+    "topic": null,
+    "parent_id": "356505375207456768",
+    "nsfw": false,
+    "position": 0,
+    "rate_limit_per_user": 0,
+    "last_message_id": "381898139189116930",
+    "type": 0,
+    "id": "381898062269775883"
 }
 ```
 
@@ -59,16 +59,16 @@ Represents a guild or DM channel within Discord.
 
 ```json
 {
-	"id": "155101607195836416",
-	"guild_id": "41771983423143937",
-	"name": "ROCKET CHEESE",
-	"type": 2,
-	"nsfw": false,
-	"position": 5,
-	"permission_overwrites": [],
-	"bitrate": 64000,
-	"user_limit": 0,
-	"parent_id": null
+    "permission_overwrites": [],
+    "name": "Testing",
+    "user_limit": 23,
+    "type": 2,
+    "parent_id": "356503376785309697",
+    "nsfw": false,
+    "position": 3,
+    "guild_id": "81384788765712384",
+    "bitrate": 96000,
+    "id": "85482585546833920"
 }
 ```
 
@@ -122,13 +122,13 @@ Represents a guild or DM channel within Discord.
 ```json
 {
     "permission_overwrites": [],
-    "name": "Test",
+    "name": "Information",
     "parent_id": null,
     "nsfw": false,
     "position": 0,
-    "guild_id": "290926798629997250",
+    "guild_id": "81384788765712384",
     "type": 4,
-    "id": "399942396007890945"
+    "id": "356505375207456768"
 }
 ```
 
@@ -210,30 +210,31 @@ Represents a message sent in a channel within Discord.
     "reactions": [
         {
             "count": 1,
-            "me": false,
+            "me": true,
             "emoji": {
-                "id": null,
-                "name": "🔥"
+                "animated": false,
+                "id": "358805857925857280",
+                "name": "blobhypersweatthink"
             }
         }
     ],
     "attachments": [],
     "tts": false,
     "embeds": [],
-    "timestamp": "2017-07-11T17:27:07.299000+00:00",
+    "timestamp": "2018-04-04T23:26:55.845000+00:00",
     "mention_everyone": false,
-    "id": "334385199974967042",
+    "id": "431233237915009044",
     "pinned": false,
     "edited_timestamp": null,
     "author": {
-        "username": "Mason",
-        "discriminator": "9999",
-        "id": "53908099506183680",
-        "avatar": "a_bab14f271d565501444b2ca3be944b25"
+        "username": "b1nzy",
+        "discriminator": "0852",
+        "id": "80351110224678912",
+        "avatar": "a_311bd5b25a77bab2bd554516c3dea864"
     },
     "mention_roles": [],
-    "content": "Supa Hot",
-    "channel_id": "290926798999357250",
+    "content": "lol",
+    "channel_id": "381870553235193857",
     "mentions": [],
     "type": 0
 }

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -78,27 +78,32 @@ Guilds in Discord represent an isolated collection of users and channels, and ar
 
 ```json
 {
-	"id": "41771983423143937",
-	"application_id": null,
-	"name": "Discord Developers",
-	"icon": "86e39f7ae3307e811784e2ffd11a7310",
-	"splash": null,
-	"owner_id": "80351110224678912",
-	"region": "us-east",
-	"afk_channel_id": "42072017402331136",
-	"afk_timeout": 300,
-	"embed_enabled": true,
-	"embed_channel_id": "41771983444115456",
-	"verification_level": 1,
-	"default_message_notifications": 0,
-	"explicit_content_filter": 0,
-	"mfa_level": 0,
-	"widget_enabled": false,
-	"widget_channel_id": "41771983423143937",
-	"roles": [],
-	"emojis": [],
-	"features": ["INVITE_SPLASH"],
-	"unavailable": false
+    "application_id": null,
+    "features": [
+        "VIP_REGIONS",
+        "VANITY_URL",
+        "INVITE_SPLASH"
+    ],
+    "afk_timeout": 3600,
+    "default_message_notifications": 1,
+    "afk_channel_id": null,
+    "explicit_content_filter": 1,
+    "max_presences": 25000,
+    "id": "81384788765712384",
+    "verification_level": 3,
+    "widget_channel_id": null,
+    "embed_channel_id": null,
+    "splash": null,
+    "emojis": [],
+    "embed_enabled": true,
+    "owner_id": "80088516616269824",
+    "mfa_level": 1,
+    "system_channel_id": null,
+    "widget_enabled": true,
+    "icon": "9b4e388133f7199806daac41441a9403",
+    "name": "Discord API",
+    "roles": [],
+    "region": "vip-us-east"
 }
 ```
 
@@ -110,7 +115,7 @@ A partial [guild](#DOCS_RESOURCES_GUILD/guild-object) object. Represents an Offl
 
 ```json
 {
-	"id": "41771983423143937",
+	"id": "86004744966914048",
 	"unavailable": true
 }
 ```
@@ -129,7 +134,7 @@ A partial [guild](#DOCS_RESOURCES_GUILD/guild-object) object. Represents an Offl
 ```json
 {
 	"enabled": true,
-	"channel_id": "41771983444115456"
+	"channel_id": "381898062269775883"
 }
 ```
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -405,8 +405,8 @@ Sent when a client wants to join, move, or disconnect from a voice channel.
 
 ```json
 {
-  "guild_id": "41771983423143937",
-  "channel_id": "127121515262115840",
+  "guild_id": "81384788765712384",
+  "channel_id": "85482585546833920",
   "self_mute": false,
   "self_deaf": false
 }
@@ -936,7 +936,7 @@ Sent when a guild's voice server is updated. This is sent when initially connect
 ```json
 {
   "token": "my_token",
-  "guild_id": "41771983423143937",
+  "guild_id": "81384788765712384",
   "endpoint": "smart.loyal.discord.gg"
 }
 ```

--- a/docs/topics/Voice_Connections.md
+++ b/docs/topics/Voice_Connections.md
@@ -26,8 +26,8 @@ The first step in connecting to a voice server (and in turn, a guild's voice cha
 {
 	"op": 4,
 	"d": {
-		"guild_id": "41771983423143937",
-		"channel_id": "127121515262115840",
+		"guild_id": "81384788765712384",
+		"channel_id": "85482585546833920",
 		"self_mute": false,
 		"self_deaf": false
 	}
@@ -45,7 +45,7 @@ If our request succeeded, the gateway will respond with _two_ events—a [Voice 
 	"op": 0,
 	"d": {
 		"token": "my_token",
-		"guild_id": "41771983423143937",
+		"guild_id": "81384788765712384",
 		"endpoint": "smart.loyal.discord.gg"
 	}
 }
@@ -63,7 +63,7 @@ Once we retrieve a session\_id, token, and endpoint information, we can connect 
 {
 	"op": 0,
 	"d": {
-		"server_id": "41771983423143937",
+		"server_id": "81384788765712384",
 		"user_id": "104694319306248192",
 		"session_id": "my_session_id",
 		"token": "my_token"
@@ -228,7 +228,7 @@ When your client detects that its connection has been severed, it should open a 
 {
 	"op": 7,
 	"d": {
-		"server_id": "41771983423143937",
+		"server_id": "81384788765712384",
 		"session_id": "my_session_id",
 		"token": "my_token"
 	}


### PR DESCRIPTION
Updated all instances of the DDevs IDs and relevant examples with the IDs for the DAPI equivalents ~~(plus an extra meme in there for good measure)~~. See Matt's comment on [#697](https://github.com/discordapp/discord-api-docs/pull/697#issuecomment-428898886) for what Mason had to say about IDs in the docs.