### PR TITLE
Update gateway URL params table

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -90,11 +90,11 @@ def on_websocket_message(msg):
 
 ###### Gateway URL Params
 
-| Field     | Type    | Description            |
-| --------- | ------- | ---------------------- |
-| v         | integer | Gateway Version to use |
-| encoding  | string  | 'json' or 'etf'        |
-| compress? | string  | 'zlib-stream'          |
+| Field     | Type    | Description            				| Example Value   |
+| --------- | ------- | ----------------------------------------------- | -------------   |
+| v         | integer | Gateway Version to use 				| 6		  |
+| encoding  | string  | The encoding of recieved gateway packets 	| 'json' or 'etf' |
+| compress? | string  | The (optional) compression of gateway packets 	| 'zlib-stream'	  |
 
 The first step in establishing connectivity to the gateway is requesting a valid websocket endpoint from the API. This can be done through either the [Get Gateway](#DOCS_TOPICS_GATEWAY/get-gateway) or the [Get Gateway Bot](#DOCS_TOPICS_GATEWAY/get-gateway-bot) endpoint.
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -92,7 +92,7 @@ def on_websocket_message(msg):
 
 | Field     | Type    | Description                                   | Accepted Values                                                            |
 | --------- | ------- | ----------------------------------------------| --------------------------------------------------------------------------|
-| v         | integer | Gateway Version to use                        | 6 (see [Gateway versions](#DOCS_TOPIC_GATEWAY/gateway-versions)) |
+| v         | integer | Gateway Version to use                        | 6 (see [Gateway versions](#DOCS_TOPICS_GATEWAY/gateway-versions)) |
 | encoding  | string  | The encoding of recieved gateway packets      | 'json' or 'etf'                                                            |
 | compress? | string  | The (optional) compression of gateway packets | 'zlib-stream'                                                              |
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -90,7 +90,7 @@ def on_websocket_message(msg):
 
 ###### Gateway URL Params
 
-| Field     | Type    | Description                                   | Possible Values                                                            |
+| Field     | Type    | Description                                   | Accepted Values                                                            |
 | --------- | ------- | ----------------------------------------------| --------------------------------------------------------------------------|
 | v         | integer | Gateway Version to use                        | 6 (see [Gateway versions](#DOCS_TOPIC_GATEWAY/gateway-versions)) |
 | encoding  | string  | The encoding of recieved gateway packets      | 'json' or 'etf'                                                            |

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -90,11 +90,11 @@ def on_websocket_message(msg):
 
 ###### Gateway URL Params
 
-| Field     | Type    | Description            				| Example Value   |
-| --------- | ------- | ----------------------------------------------- | -------------   |
-| v         | integer | Gateway Version to use 				| 6		  |
-| encoding  | string  | The encoding of recieved gateway packets 	| 'json' or 'etf' |
-| compress? | string  | The (optional) compression of gateway packets 	| 'zlib-stream'	  |
+| Field     | Type    | Description                                   | Possible Values                                                            |
+| --------- | ------- | ----------------------------------------------| --------------------------------------------------------------------------|
+| v         | integer | Gateway Version to use                        | 6 (see [Gateway versions](#DOCS_TOPIC_GATEWAY/gateway-versions)) |
+| encoding  | string  | The encoding of recieved gateway packets      | 'json' or 'etf'                                                            |
+| compress? | string  | The (optional) compression of gateway packets | 'zlib-stream'                                                              |
 
 The first step in establishing connectivity to the gateway is requesting a valid websocket endpoint from the API. This can be done through either the [Get Gateway](#DOCS_TOPICS_GATEWAY/get-gateway) or the [Get Gateway Bot](#DOCS_TOPICS_GATEWAY/get-gateway-bot) endpoint.
 


### PR DESCRIPTION
Right now, the only description for `encoding` and `compress?` in the Gateway URL Params table are just example values. Although these are quite self explanatory, they're not at all a description of what the fields actually contain for a non programmer.

This PR would put a description in the description field and add the example values in a separate example value column, so people know what to put in there, but also know why it's there and what it's for.