### PR TITLE
Move `?` to the Field column on User docs

### DIFF
--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -38,7 +38,7 @@ There are other rules and restrictions not shared here for the sake of spam and 
 | id            | snowflake | the user's id                                              | identify              |
 | username      | string    | the user's username, not unique across the platform        | identify              |
 | discriminator | string    | the user's 4-digit discord-tag                             | identify              |
-| avatar        | ?string   | the user's [avatar hash](#DOCS_REFERENCE/image-formatting) | identify              |
+| avatar?       | string    | the user's [avatar hash](#DOCS_REFERENCE/image-formatting) | identify              |
 | bot?          | boolean   | whether the user belongs to an OAuth2 application          | identify              |
 | mfa_enabled?  | boolean   | whether the user has two factor enabled on their account   | identify              |
 | locale?       | string    | the user's chosen language option                          | identify              |


### PR DESCRIPTION
I found that all fields have the `?` for optional indication on the `Field` column except for `avatar` which had it prefixing the type. If this was intended, you can ignore this PR, but for consistency I think it should be `avatar? | string` instead of `avatar | ?string`