### PR TITLE
Use "whether" instead of "if" to suit the rest of the docs

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -15,7 +15,7 @@ Represents a guild or DM channel within Discord.
 | permission\_overwrites? | array of [overwrite](#DOCS_RESOURCES_CHANNEL/overwrite-object) objects | explicit permission overwrites for members and roles  |
 | name? | string | the name of the channel (2-100 characters) |
 | topic? | ?string | the channel topic (0-1024 characters) |
-| nsfw? | boolean | if the channel is nsfw
+| nsfw? | boolean | whether the channel is nsfw
 | last\_message\_id? | ?snowflake | the id of the last message sent in this channel (may not point to an existing or valid message) |
 | bitrate? | integer | the bitrate (in bits) of the voice channel |
 | user\_limit? | integer | the user limit of the voice channel |
@@ -385,7 +385,7 @@ Update a channels settings. Requires the 'MANAGE_CHANNELS' permission for the gu
 | name | string | 2-100 character channel name | All |
 | position | integer | the position of the channel in the left-hand listing | All |
 | topic | string | 0-1024 character channel topic | Text |
-| nsfw | boolean | if the channel is nsfw | Text |
+| nsfw | boolean | whether the channel is nsfw | Text |
 | rate\_limit\_per\_user | integer | amount of seconds a user has to wait before sending another message (0-120); bots, as well as users with the permission `manage_messages` or `manage_channel`, are unaffected | Text |
 | bitrate | integer | the bitrate (in bits) of the voice channel; 8000 to 96000 (128000 for VIP servers) | Voice |
 | user_limit | integer | the user limit of the voice channel; 0 refers to no limit, 1 to 99 refers to a user limit | Voice |

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -121,7 +121,7 @@ A partial [guild](#DOCS_RESOURCES_GUILD/guild-object) object. Represents an Offl
 
 | Field | Type | Description |
 |-------|------|-------------|
-| enabled | boolean | if the embed is enabled |
+| enabled | boolean | whether the embed is enabled |
 | channel_id | ?snowflake | the embed channel id |
 
 ###### Example Guild Embed
@@ -143,8 +143,8 @@ A partial [guild](#DOCS_RESOURCES_GUILD/guild-object) object. Represents an Offl
 | nick? | string | this users guild nickname (if one is set) |
 | roles | array of snowflakes | array of [role](#DOCS_TOPICS_PERMISSIONS/role-object) object ids |
 | joined_at | ISO8601 timestamp | when the user joined the guild |
-| deaf | boolean | if the user is deafened |
-| mute | boolean | if the user is muted |
+| deaf | boolean | whether the user is deafened |
+| mute | boolean | whether the user is muted |
 
 ###### Example Guild Member
 
@@ -298,7 +298,7 @@ Create a new [channel](#DOCS_RESOURCES_CHANNEL/channel-object) object for the gu
 | rate\_limit\_per\_user | integer | amount of seconds a user has to wait before sending another message (0-120); bots, as well as users with the permission `manage_messages` or `manage_channel`, are unaffected |
 | permission_overwrites | array of [overwrite](#DOCS_RESOURCES_CHANNEL/overwrite-object) objects | the channel's permission overwrites |
 | parent_id | snowflake | id of the parent category for a channel |
-| nsfw | boolean | if the channel is nsfw |
+| nsfw | boolean | whether the channel is nsfw |
 
 ## Modify Guild Channel Positions % PATCH /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/channels
 
@@ -348,8 +348,8 @@ Adds a user to the guild, provided you have a valid oauth2 access token for the 
 | access_token | string | an oauth2 access token granted with the `guilds.join` to the bot's application for the user you want to add to the guild | |
 | nick | string | value to set users nickname to | MANAGE_NICKNAMES |
 | roles | array of snowflakes | array of role ids the member is assigned | MANAGE_ROLES |
-| mute | boolean | if the user is muted | MUTE_MEMBERS |
-| deaf | boolean | if the user is deafened | DEAFEN_MEMBERS |
+| mute | boolean | whether the user is muted | MUTE_MEMBERS |
+| deaf | boolean | whether the user is deafened | DEAFEN_MEMBERS |
 
 ## Modify Guild Member % PATCH /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/members/{user.id#DOCS_RESOURCES_USER/user-object}
 
@@ -365,8 +365,8 @@ Modify attributes of a [guild member](#DOCS_RESOURCES_GUILD/guild-member-object)
 |-------|------|-------------|------------|
 | nick | string | value to set users nickname to | MANAGE_NICKNAMES |
 | roles | array of snowflakes | array of role ids the member is assigned | MANAGE_ROLES |
-| mute | boolean | if the user is muted | MUTE_MEMBERS |
-| deaf | boolean | if the user is deafened | DEAFEN_MEMBERS |
+| mute | boolean | whether the user is muted | MUTE_MEMBERS |
+| deaf | boolean | whether the user is deafened | DEAFEN_MEMBERS |
 | channel_id | snowflake | id of channel to move user to (if they are connected to voice) | MOVE_MEMBERS |
 
 ## Modify Current User Nick % PATCH /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/members/@me/nick


### PR DESCRIPTION
A lot of files use as description `Whether something is/should...` while some others use `If something is...`; this PR addresses this.