### PR TITLE
Add a note about bots respecting user limit in voice channels

### DIFF
--- a/docs/topics/Voice_Connections.md
+++ b/docs/topics/Voice_Connections.md
@@ -53,6 +53,11 @@ If our request succeeded, the gateway will respond with _two_ events—a [Voice 
 
 With this information, we can move on to establishing a voice websocket connection.
 
+> info
+> Bot users respect the voice channel's user limit, if set. When the voice channel is full, you will not receive
+> the Voice State Update or Voice Server Update events in response to your own Voice State Update. Having `MANAGE_CHANNELS`
+> permission bypasses this limit and allows you to join regardless of the channel being full or not.
+
 ## Establishing a Voice Websocket Connection
 
 Once we retrieve a session\_id, token, and endpoint information, we can connect and handshake with the voice server over another secure websocket. Unlike the gateway endpoint we receive in an HTTP [Get Gateway](#DOCS_TOPICS_GATEWAY/get-gateway) request, the endpoint received from our [Voice Server Update](#DOCS_TOPICS_GATEWAY/voice-server-update) payload does not contain a URL protocol, so some libraries may require manually prepending it with "wss://" before connecting. Once connected to the voice websocket endpoint, we can send an [Opcode 0 Identify](#DOCS_TOPICS_OPCODES_AND_STATUS_CODES/voice-opcodes) payload with our server\_id, user\_id, session\_id, and token:


### PR DESCRIPTION
Through some ~~bug reports~~ testing, I realized that bots are subject to a voice channel's user limit, unless they have sufficient permissions (`MANAGE_CHANNELS`) to bypass it.

In the API, this means your `VOICE_STATE_UPDATE` is simply ignored - you won't receive the `VOICE_STATE_UPDATE` & `VOICE_SERVER_UPDATE` in response.

It would appear that implementations need to rely on cached data of permissions, the channel limit setting, and the number of users in the channel to properly determine if they will be able to enter a voice channel - or otherwise expect the VSU to have failed after some timeout length. Maybe some recommendation should be added in that regard.. I left it out for now.

I wasn't sure on the best place to document this, so please advise if there's a better spot :)

This is essentially a partner to the "If our request succeeded, ..." from the previous paragraph, pointing out specific cases where the VSU can be *expected* to fail.