### PR TITLE
add code 50020 and a bit more info for vanity-url endpoint

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -536,8 +536,7 @@ Modify a [guild embed](#DOCS_RESOURCES_GUILD/guild-embed-object) object for the 
 
 ## Get Guild Vanity URL % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/vanity-url
 
-Returns a partial [invite](#DOCS_RESOURCES_INVITE/invite-object) object for guilds with that feature enabled. Requires the 'MANAGE_GUILD' permission.
-'code' will be null if a vanity url for the guild is not set
+Returns a partial [invite](#DOCS_RESOURCES_INVITE/invite-object) object for guilds with that feature enabled. Requires the 'MANAGE_GUILD' permission. `code` will be null if a vanity url for the guild is not set
 
 ###### Example Partial Invite Object
 

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -537,6 +537,7 @@ Modify a [guild embed](#DOCS_RESOURCES_GUILD/guild-embed-object) object for the 
 ## Get Guild Vanity URL % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/vanity-url
 
 Returns a partial [invite](#DOCS_RESOURCES_INVITE/invite-object) object for guilds with that feature enabled. Requires the 'MANAGE_GUILD' permission.
+'code' will be null if a vanity url for the guild is not set
 
 ###### Example Partial Invite Object
 

--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -143,6 +143,7 @@ Along with the HTTP error code, our API can also return more detailed error code
 | 50015 | Note is too long |
 | 50016 | Provided too few or too many messages to delete. Must provide at least 2 and fewer than 100 messages to delete. |
 | 50019 | A message can only be pinned to the channel it was sent in |
+| 50020 | Invite code is either invalid or taken. |
 | 50021 | Cannot execute action on a system message |
 | 50025 | Invalid OAuth2 access token |
 | 50034 | A message provided was too old to bulk delete |


### PR DESCRIPTION
i was testing with the vanity-url endpoint and got the '50020' error code when trying to use it on a guild that doesn't have this feature enabled, checked the docs and saw it was missing.
also, the 'code' property will be 'null' if the guild has this feature enabled, but hasn't set a vanity url yet.