### PR TITLE
Add AckCord to libraries

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -29,6 +29,7 @@ The Discord team curates the following list of officially vetted libraries that 
 | [disco](https://github.com/b1naryth1ef/disco) | Python |
 | [discordrb](https://github.com/meew0/discordrb) | Ruby |
 | [discord-rs](https://github.com/SpaceManiac/discord-rs) | Rust |
+| [AckCord](https://github.com/Katrix/AckCord) | Scala |
 | [Sword](https://github.com/Azoy/Sword) | Swift |
 
 ## Permission Calculators


### PR DESCRIPTION
Adds [AckCord ](https://github.com/Katrix/AckCord) as a library to the library section. AckCord is a library for Scala using reactive streams.

AckCord handles ratelimiting by backpressuring the current stream when a request would have caused a 429.
Here is the most of the code that handles ratelimits in Ackcord.

[Ratelimiter.scala](https://github.com/Katrix/AckCord/blob/master/ackCordNetwork/src/main/scala/net/katsstuff/ackcord/http/requests/Ratelimiter.scala)

Here is a simple demo for testing the ratelimiting using something like this
```scala
Source(0 until 10)
  .map(i => channel.sendMessage(s"Msg$i"))
  .to(requests.sinkIgnore)
Source(0 until 10)
  .map(i => channel.sendMessage(s"Msg$i"))
  .to(requests.sinkIgnore(RequestProperties.ordered))
```

![Ratelimit demo](https://user-images.githubusercontent.com/11007080/50799129-b1fb9d80-12d2-11e9-842a-ee5287bc5888.gif)

Currently, the cases where a 429 can occour are.
* Ratelimit info hasn't been received for an endpoint yet, and many requests are made to that endpoint at the same time. (Can be worked around by using ordered request handling for those few cases where it could pose a problem)
* Global ratelimits. AckCord lacks the proper information to prevent these before they happen. 

How to handle these when they do occour is up to the user, altough AckCord does provide a retry behavior to easily retry the request a few times.