### PR TITLE
Add basic example of permissions bitwise operations

### DIFF
--- a/docs/topics/Permissions.md
+++ b/docs/topics/Permissions.md
@@ -2,7 +2,21 @@
 
 Permissions in Discord are a way to limit and grant certain abilities to users. A set of base permissions can be configured at the guild level for different roles. When these roles are attached to users, they grant or revoke specific privileges within the guild. Along with the guild-level permissions, Discord also supports permission overwrites that can be assigned to individual guild roles or guild members on a per-channel basis.
 
-Permissions are stored within a 53-bit integer and are calculated using bitwise operations. The total permissions integer can be determined by ORing together each individual value. Additional logic is required when permission overwrites are involved; this is further explained below. For more information about bitwise operations and flags, see [this page](https://en.wikipedia.org/wiki/Bit_field).
+Permissions are stored within a 53-bit integer and are calculated using bitwise operations. The total permissions integer can be determined by ORing together each individual value, and flags can be checked using AND operations.
+
+```python
+# Permissions value that can Send Messages (0x800) and Add Reactions (0x40):
+permissions = 0x40 | 0x800 # 2112
+
+# Checking for flags that are set:
+(permissions & 0x40) == 0x40   # True
+(permissions & 0x800) == 0x800 # True
+
+# Kick Members (0x2) was not set:
+(permissions & 0x2) == 0x2 # False
+```
+
+Additional logic is required when permission overwrites are involved; this is further explained below. For more information about bitwise operations and flags, see [this page](https://en.wikipedia.org/wiki/Bit_field).
 
 Below is a table of all current permissions, their integer values in hexadecimal, brief descriptions of the privileges that they grant, and the channel type they apply to, if applicable.
 


### PR DESCRIPTION
Many users who don't have experience working with bit flags before struggle to get started with interpreting permissions values. Lots of people come to the support channel simply trying to check whether a single flag is set, and we usually throw them the bone of `(permissions & flag) == flag`.

Including a basic example of building a permissions value and breaking it down should help users connect the dots without having to leave the documentation to read the aforementioned Wikipedia page, as well as aid in understanding the more complex example for permission overwrite evaluation later on this page.