### PR TITLE
Add shard property to the ready dispatch docs

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -487,6 +487,7 @@ The ready event is dispatched when a client has completed the initial handshake 
 | guilds           | array of [Unavailable Guild](#DOCS_RESOURCES_GUILD/unavailable-guild-object) objects | the guilds the user is in                                                  |
 | session_id       | string                                                                               | used for resuming connections                                              |
 | \_trace          | array of strings                                                                     | used for debugging - the guilds the user is in                             |
+| shard?           | array of two integers (shard_id, num_shards)	                                      | used for [Guild Sharding]((#DOCS_TOPICS_GATEWAY/sharding))                 |
 
 #### Resumed
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -479,15 +479,15 @@ The ready event is dispatched when a client has completed the initial handshake 
 
 ###### Ready Event Fields
 
-| Field            | Type                                                                                 | Description                                                                |
-| ---------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
-| v                | integer                                                                              | [gateway protocol version](#DOCS_TOPICS_GATEWAY/gateway-protocol-versions) |
-| user             | [user](#DOCS_RESOURCES_USER/user-object) object                                      | information about the user including email                                 |
-| private_channels | array                                                                                | empty array                                                                |
-| guilds           | array of [Unavailable Guild](#DOCS_RESOURCES_GUILD/unavailable-guild-object) objects | the guilds the user is in                                                  |
-| session_id       | string                                                                               | used for resuming connections                                              |
-| \_trace          | array of strings                                                                     | used for debugging - the guilds the user is in                             |
-| shard?           | array of two integers (shard_id, num_shards)	                                      | used for [Guild Sharding]((#DOCS_TOPICS_GATEWAY/sharding))                 |
+| Field            | Type                                                                                 | Description                                                                                                   |
+| ---------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| v                | integer                                                                              | [gateway protocol version](#DOCS_TOPICS_GATEWAY/gateway-protocol-versions)                                    |
+| user             | [user](#DOCS_RESOURCES_USER/user-object) object                                      | information about the user including email                                                                    |
+| private_channels | array                                                                                | empty array                                                                                                   |
+| guilds           | array of [Unavailable Guild](#DOCS_RESOURCES_GUILD/unavailable-guild-object) objects | the guilds the user is in                                                                                     |
+| session_id       | string                                                                               | used for resuming connections                                                                                 |
+| \_trace          | array of strings                                                                     | used for debugging - the guilds the user is in                                                                |
+| shard?           | array of two integers (shard_id, num_shards)	                                      | the [shard information](#DOCS_TOPICS_GATEWAY/sharding) associated with this session, if sent when identifying |
 
 #### Resumed
 


### PR DESCRIPTION
This adds a missing propert (`shard`) to the Ready dispatch docs whats sent if your bot is sharded. If you have any suggestions for a better description, just let me know 👍, since for now i just copied the description from the Identify payload docs. 