### PR TITLE
Adding compute_prune_count option for prune operations

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -479,13 +479,14 @@ Returns an object with one 'pruned' key indicating the number of members that wo
 
 ## Begin Guild Prune % POST /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/prune
 
-Begin a prune operation. Requires the `KICK_MEMBERS` permission. Returns an object with one 'pruned' key indicating the number of members that were removed in the prune operation. Fires multiple [Guild Member Remove](#DOCS_TOPICS_GATEWAY/guild-member-remove) Gateway events.
+Begin a prune operation. Requires the `KICK_MEMBERS` permission. Returns an object with one 'pruned' key indicating the number of members that were removed in the prune operation if the `count` option is specified, otherwise 0. Fires multiple [Guild Member Remove](#DOCS_TOPICS_GATEWAY/guild-member-remove) Gateway events.
 
 ###### Query String Params
 
 | Field | Type | Description |
 |-------|------|-------------|
 | days | integer | number of days to prune (1 or more) |
+| count | boolean | whether 'pruned' is returned, discouraged for large guilds |
 
 ## Get Guild Voice Regions % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/regions
 

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -479,14 +479,14 @@ Returns an object with one 'pruned' key indicating the number of members that wo
 
 ## Begin Guild Prune % POST /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/prune
 
-Begin a prune operation. Requires the `KICK_MEMBERS` permission. Returns an object with one 'pruned' key indicating the number of members that were removed in the prune operation if the `count` option is specified, otherwise 0. Fires multiple [Guild Member Remove](#DOCS_TOPICS_GATEWAY/guild-member-remove) Gateway events.
+Begin a prune operation. Requires the `KICK_MEMBERS` permission. Returns an object with one 'pruned' key indicating the number of members that were removed in the prune operation if the `compute_prune_count` option is specified, otherwise 0. Fires multiple [Guild Member Remove](#DOCS_TOPICS_GATEWAY/guild-member-remove) Gateway events.
 
 ###### Query String Params
 
 | Field | Type | Description |
 |-------|------|-------------|
 | days | integer | number of days to prune (1 or more) |
-| count | boolean | whether 'pruned' is returned, discouraged for large guilds |
+| compute_prune_count | boolean | whether 'pruned' is returned, discouraged for large guilds |
 
 ## Get Guild Voice Regions % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/regions
 

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -479,7 +479,7 @@ Returns an object with one 'pruned' key indicating the number of members that wo
 
 ## Begin Guild Prune % POST /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/prune
 
-Begin a prune operation. Requires the `KICK_MEMBERS` permission. Returns an object with one 'pruned' key indicating the number of members that were removed in the prune operation if the `compute_prune_count` option is specified, otherwise 0. Fires multiple [Guild Member Remove](#DOCS_TOPICS_GATEWAY/guild-member-remove) Gateway events.
+Begin a prune operation. Requires the `KICK_MEMBERS` permission. Returns an object with one 'pruned' key indicating the number of members that were removed in the prune operation. For large guilds it's recommended to set the `compute_prune_count` option to `false`, returning a 0 'pruned' count. Fires multiple [Guild Member Remove](#DOCS_TOPICS_GATEWAY/guild-member-remove) Gateway events.
 
 ###### Query String Params
 

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -479,7 +479,7 @@ Returns an object with one 'pruned' key indicating the number of members that wo
 
 ## Begin Guild Prune % POST /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/prune
 
-Begin a prune operation. Requires the `KICK_MEMBERS` permission. Returns an object with one 'pruned' key indicating the number of members that were removed in the prune operation. For large guilds it's recommended to set the `compute_prune_count` option to `false`, returning a 0 'pruned' count. Fires multiple [Guild Member Remove](#DOCS_TOPICS_GATEWAY/guild-member-remove) Gateway events.
+Begin a prune operation. Requires the `KICK_MEMBERS` permission. Returns an object with one 'pruned' key indicating the number of members that were removed in the prune operation. For large guilds it's recommended to set the `compute_prune_count` option to `false`, forcing 'pruned' to `None`. Fires multiple [Guild Member Remove](#DOCS_TOPICS_GATEWAY/guild-member-remove) Gateway events.
 
 ###### Query String Params
 

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -479,7 +479,7 @@ Returns an object with one 'pruned' key indicating the number of members that wo
 
 ## Begin Guild Prune % POST /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/prune
 
-Begin a prune operation. Requires the `KICK_MEMBERS` permission. Returns an object with one 'pruned' key indicating the number of members that were removed in the prune operation. For large guilds it's recommended to set the `compute_prune_count` option to `false`, forcing 'pruned' to `None`. Fires multiple [Guild Member Remove](#DOCS_TOPICS_GATEWAY/guild-member-remove) Gateway events.
+Begin a prune operation. Requires the `KICK_MEMBERS` permission. Returns an object with one 'pruned' key indicating the number of members that were removed in the prune operation. For large guilds it's recommended to set the `compute_prune_count` option to `false`, forcing 'pruned' to `null`. Fires multiple [Guild Member Remove](#DOCS_TOPICS_GATEWAY/guild-member-remove) Gateway events.
 
 ###### Query String Params
 


### PR DESCRIPTION
Prune guild has a `compute_prune_count` option now. If set to false it won't count users. This is a fix for preventing timeouts when operating over large guilds.