### PR TITLE
Document the @everyone role ID

### DIFF
--- a/docs/topics/Permissions.md
+++ b/docs/topics/Permissions.md
@@ -153,7 +153,7 @@ Permissions with regards to categories and channels within categories are a bit 
 
 ### Role Object
 
-Roles represent a set of permissions attached to a group of users. Roles have unique names, colors, and can be "pinned" to the side bar, causing their members to be listed separately. Roles are unique per guild, and can have separate permission profiles for the global context (guild) and channel context.
+Roles represent a set of permissions attached to a group of users. Roles have unique names, colors, and can be "pinned" to the side bar, causing their members to be listed separately. Roles are unique per guild, and can have separate permission profiles for the global context (guild) and channel context. The `@everyone` role has the same ID as the guild it belongs to.
 
 ###### Role Structure
 


### PR DESCRIPTION
The only place that I could find that this is actually "documented" is in the permissions calculation psuedocode, if you happen to be careful to observe this.

I wasn't sure, but I figured the best place to write this out would be in the section that talks about a role's properties on the same page.