### PR TITLE
Fix minor grammatical error in certified_devices.md

### DIFF
--- a/docs/topics/Certified_Devices.md
+++ b/docs/topics/Certified_Devices.md
@@ -46,7 +46,7 @@ Each time you update, send a full array of `devices`, sorted by your preffered p
 
 ## Getting Device UUID
 
-For each device in the `SET_CERTIFIED_DEVICES` payload, there is an `id` field. This `id` should be the Window's device UUID, retrieved through the native Windows API. You'll get back something that looks like `{0.0.1.00000000}.{6cff2b76-44a8-46b9-b528-262ad8609d9f}`.
+For each device in the `SET_CERTIFIED_DEVICES` payload, there is an `id` field. This `id` should be the Windows device's UUID, retrieved through the native Windows API. You'll get back something that looks like `{0.0.1.00000000}.{6cff2b76-44a8-46b9-b528-262ad8609d9f}`.
 
 >info
 >On macOS, the `id` will be the name of the device.
@@ -198,4 +198,3 @@ The socket will respond with a `200 OK` status code and the following JSON.
 | AUDIO_INPUT  | "audioinput"  |
 | AUDIO_OUTPUT | "audiooutput" |
 | VIDEO_INPUT  | "videoinput"  |
-


### PR DESCRIPTION
There's a minor grammatical error where a Windows device is referred to as a "Window's device".  Since Windows is a proper noun, I've fixed this by making the device hold the possessive case instead of Windows itself.