### PR TITLE
Add Clojure lib to community libraries

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -10,6 +10,7 @@ The Discord team curates the following list of officially vetted libraries that 
 
 | Name | Language |
 |------|----------|
+| [discljord](https://github.com/igjoshua/discljord) | Clojure |
 | [discordcr](https://github.com/meew0/discordcr) | Crystal |
 | [Discord.Net](https://github.com/RogueException/Discord.Net) | C# |
 | [DSharpPlus](https://github.com/NaamloosDT/DSharpPlus) | C# |


### PR DESCRIPTION
I've created a discord library which has gone through the approval process on the unofficial discord api server, and has a channel added there. I'd like to see the library included in the official docs too.