### PR TITLE
Add catnip to libraries

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -17,6 +17,7 @@ The Discord team curates the following list of officially vetted libraries that 
 | [dscord](https://github.com/b1naryth1ef/dscord) | D |
 | [DiscordGo](https://github.com/bwmarrin/discordgo) | Go |
 | [DisGord](https://github.com/andersfylling/disgord) | Go |
+| [catnip](https://github.com/mewna/catnip) | Java |
 | [Discord4j](https://github.com/austinv11/Discord4J) | Java |
 | [Javacord](https://github.com/Javacord/Javacord) | Java |
 | [JDA](https://github.com/DV8FromTheWorld/JDA) | Java |


### PR DESCRIPTION
I think it's obvious to everyone that we need a 6th JVM library / 4th Java library :P

[catnip](https://github.com/mewna/catnip) is a reactive lib for the JVM built on [vert.x](https://vertx.io), designed for microservices-style usage.

If needed, the majority of the ratelimiting code can be found [here](https://github.com/mewna/catnip/blob/ab4aa30b8de5c3af425f5b54d0d841dfdda631a8/src/main/java/com/mewna/catnip/rest/ratelimit/DefaultRateLimiter.java) as well as a little bit [here](https://github.com/mewna/catnip/blob/ab4aa30b8de5c3af425f5b54d0d841dfdda631a8/src/main/java/com/mewna/catnip/rest/requester/AbstractRequester.java#L244-L272). I've been using it actively on a relatively-large bot (~35k guilds) for the last ~4 months, and I believe the only cases where I might hit 429s at this point are where I forget to share ratelimit data between workers :sweat_smile: