### PR TITLE
Fix the name and link for Discord4J

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -17,7 +17,7 @@ The Discord team curates the following list of officially vetted libraries that 
 | [dscord](https://github.com/b1naryth1ef/dscord) | D |
 | [DiscordGo](https://github.com/bwmarrin/discordgo) | Go |
 | [DisGord](https://github.com/andersfylling/disgord) | Go |
-| [Discord4j](https://github.com/austinv11/Discord4J) | Java |
+| [Discord4J](https://discord4j.com/) | Java |
 | [Javacord](https://github.com/Javacord/Javacord) | Java |
 | [JDA](https://github.com/DV8FromTheWorld/JDA) | Java |
 | [discord.js](https://github.com/discordjs/discord.js) | JavaScript |


### PR DESCRIPTION
Dev of Discord4J here, I noticed that the J was lowercase when it shouldn't have been and I have updated the link to use the official project page as the previous github repository has been moved.