### PR TITLE
Remove Discord-rs

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -29,7 +29,6 @@ The Discord team curates the following list of officially vetted libraries that 
 | [discord.py](https://github.com/Rapptz/discord.py) | Python |
 | [disco](https://github.com/b1naryth1ef/disco) | Python |
 | [discordrb](https://github.com/meew0/discordrb) | Ruby |
-| [discord-rs](https://github.com/SpaceManiac/discord-rs) | Rust |
 | [AckCord](https://github.com/Katrix/AckCord) | Scala |
 | [Sword](https://github.com/Azoy/Sword) | Swift |
 


### PR DESCRIPTION
This library hasn't been updated for more than a year. From a quick glance, the progress of this library looks [stale](https://github.com/SpaceManiac/discord-rs/issues). 