### PR TITLE
Change shard array in example Identify payload

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -146,7 +146,7 @@ Next, the client is expected to send an [Opcode 2 Identify](#DOCS_TOPICS_GATEWAY
   },
   "compress": true,
   "large_threshold": 250,
-  "shard": [1, 10],
+  "shard": [0, 1],
   "presence": {
     "game": {
       "name": "Cards Against Humanity",
@@ -318,7 +318,7 @@ Used to trigger the initial handshake with the gateway.
   },
   "compress": true,
   "large_threshold": 250,
-  "shard": [1, 10],
+  "shard": [0, 1],
   "presence": {
     "game": {
       "name": "Cards Against Humanity",


### PR DESCRIPTION
I, along with others, have come across many instances of new users of the gateway copying the example identify payload and changing most values to fit their values, but as most new users are unfamiliar with the concept of sharding, they don't know what that value does and leave it as is, which prevents their bot from working as intended (except for perhaps 10% of guilds, and if a new bot's hypothetical one guild that it is in isn't in that set of snowflakes, the bot wouldn't appear to be functioning at all).

This change changes the example to a state where the default value represents a working value for _most_ new users of the API not intending to interact with multiple shards, while still providing an example of the required structure for those intending to implement sharding. While not sending `shard` at all is the best option for those not dealing with multiple shards, I believe this change finds a good balance between being welcoming to newcomers and having adequate documentation for experienced users.