### PR TITLE
Mark icon as nullable in application

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -226,7 +226,7 @@ Represents a message sent in a channel within Discord.
 | id | snowflake | id of the application |
 | cover_image? | string | id of the embed's image asset |
 | description | string | application's description |
-| icon | string | id of the application's icon |
+| icon | ?string | id of the application's icon |
 | name | string | name of the application |
 
 ###### Message Activity Types


### PR DESCRIPTION
Because this was reported to me with this payload: 

```json
{
  "summary": "",
  "name": "ElDewrito",
  "icon": null,
  "description": "",
  "id": "378984448022020112"
}
```