### PR TITLE
Game SDK - cast Discord.CreateFlags.Default to UInt64 in Unity primer

### DIFF
--- a/docs/game_sdk/SDK_Starter_Guide.md
+++ b/docs/game_sdk/SDK_Starter_Guide.md
@@ -58,7 +58,7 @@ Now we're gonna start coding. Didn't think we'd get there so fast, did ya? _Thin
 
 ```cs
 // Grab that Client ID from earlier
-var discord = new Discord.Discord(CLIENT_ID, Discord.CreateFlags.Default);
+var discord = new Discord.Discord(CLIENT_ID, (UInt64)Discord.CreateFlags.Default);
 ```
 
 - Make sure to call `discord.RunCallbacks()` in your main game loop; for Unity, that's your `Update()` function.


### PR DESCRIPTION
The `Coder Primer - Unity (Csharp)` section contains this snippet:
```cs
// Grab that Client ID from earlier
var discord = new Discord.Discord(CLIENT_ID, Discord.CreateFlags.Default);
```
`Discord.CreateFlags` is an enum. `Discord.Discord` takes a `UInt64` for the second parameter, so running this snippet as-is results in an error.

The example `Program.cs` file uses the following snippet:
```cs
var discord = new Discord.Discord(Int64.Parse(clientID), (UInt64)Discord.CreateFlags.Default);
```

This PR simply adds the `(UInt64)` cast from the `Program.cs` file into the documentation.