### PR TITLE
Remove mentions of reverted pipe argument for Discord_Initialize()

### DIFF
--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -6,7 +6,7 @@
 
 Ask to Join no longer requires approval or whitelisting to use. You are welcome to create in-game UI, but all Ask to Join requests are also now handled by the Discord overlay.
 
-There have also been some small additions to the Rich Presence SDK. This includes the addition of the `pipe` parameter to the `Initialize()` function, which allows you to specify the Discord client to connect to if multiple clients are running locally. The previously undocumented `UpdateHandlers()` function has also been documented.
+There have also been some small additions to the Rich Presence SDK. The previously undocumented `UpdateHandlers()` function is now documented.
 
 ## Documentation: Dispatch Store Listings
 

--- a/docs/rich_presence/How_To.md
+++ b/docs/rich_presence/How_To.md
@@ -56,8 +56,8 @@ void InitDiscord()
     handlers.spectateGame = handleDiscordSpectateGame;
     handlers.joinRequest = handleDiscordJoinRequest;
 
-    // Discord_Initialize(const char* applicationId, DiscordEventHandlers* handlers, int autoRegister, const char* optionalSteamId, int pipe)
-    Discord_Initialize("418562325121990661", &handlers, 1, "1234", 0);
+    // Discord_Initialize(const char* applicationId, DiscordEventHandlers* handlers, int autoRegister, const char* optionalSteamId)
+    Discord_Initialize("418562325121990661", &handlers, 1, "1234");
 }
 ```
 
@@ -67,7 +67,6 @@ A quick breakdown on the `Discord_Initialize()` function:
 - `handlers`: the callback functions you registered for each Discord event
 - `autoRegister`: whether or not to register an application protocol for your game on the player's computer—necessary to launch games from Discord
 - `optionalSteamId`: your game's Steam application id, if your game is distributed on Steam
-- `pipe`: the instance of the Discord client, starting at 0, you want to connect to. Useful if you have multiple Discord clients running
 
 When you are ready to publish your integration, we recommend digging into the source code of the SDK and copying `discord_register.h`, `discord_register_win.cpp`, `discord_register_osx.m`, and `discord_register_linux.cpp` into your installation and update process. By registering your application protocols on installation and update, your players won't need to run the game before being able to interact with invites, Ask to Join, and spectating in Discord.
 


### PR DESCRIPTION
There never was a release for this and it already has been [reverted](https://github.com/discordapp/discord-rpc/commit/c59fd6df20c6904ab39f026e87af1dd90fcac7ff).