### PR TITLE
Add additional Connection object fields

### DIFF
--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -89,17 +89,24 @@ The connection object that the user has attached.
 
 ###### Connection Structure
 
-| Field        | Type    | Description                                                                         |
-| ------------ | ------- | ----------------------------------------------------------------------------------- |
-| id           | string  | id of the connection account                                                        |
-| name         | string  | the username of the connection account                                              |
-| type         | string  | the service of the connection (twitch, youtube)                                     |
-| revoked      | boolean | whether the connection is revoked                                                   |
-| integrations | array   | an array of partial [server integrations](#DOCS_RESOURCES_GUILD/integration-object) |
-| verified     | boolean | whether the connection is verified                                                  |
-| friend_sync  | boolean | whether friend sync is enabled for this connection                                  |
-| show_activity | boolean | whether activities related to this connection will be shown in presence updates    |
-| visibility    | integer | visibility options for this connection                                             |
+| Field         | Type    | Description                                                                         |
+| ------------- | ------- | ----------------------------------------------------------------------------------- |
+| id            | string  | id of the connection account                                                        |
+| name          | string  | the username of the connection account                                              |
+| type          | string  | the service of the connection (twitch, youtube)                                     |
+| revoked       | boolean | whether the connection is revoked                                                   |
+| integrations  | array   | an array of partial [server integrations](#DOCS_RESOURCES_GUILD/integration-object) |
+| verified      | boolean | whether the connection is verified                                                  |
+| friend_sync   | boolean | whether friend sync is enabled for this connection                                  |
+| show_activity | boolean | whether activities related to this connection will be shown in presence updates     |
+| visibility    | integer | [visibility](#DOCS_RESOURCES_USER/user-object-visibility-types) of this connection  |
+
+###### Visibility Types
+
+| Value | Name          | Description                                      |
+| ----- | ------------- | ------------------------------------------------ |
+| 0     | None          | invisible to everyone except the user themselves |
+| 1     | Everyone      | visible to everyone                              |
 
 ## Get Current User % GET /users/@me
 

--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -96,6 +96,10 @@ The connection object that the user has attached.
 | type         | string  | the service of the connection (twitch, youtube)                                     |
 | revoked      | boolean | whether the connection is revoked                                                   |
 | integrations | array   | an array of partial [server integrations](#DOCS_RESOURCES_GUILD/integration-object) |
+| verified     | boolean | whether the connection is verified                                                  |
+| friend_sync  | boolean | whether friend sync is enabled for this connection                                  |
+| show_activity | boolean | whether activities related to this connection will be shown in presence updates    |
+| visibility    | integer | visibility options for this connection                                             |
 
 ## Get Current User % GET /users/@me
 


### PR DESCRIPTION
`visibility` is an enum, but I don't know all of its members beyond hidden, "show on profile", and "display spotify as your status". If those are the only members I can add a table like other enum fields.