### PR TITLE
filename is mandatory in file attachments

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -466,7 +466,7 @@ The maximum request size when sending a message is 8MB.
 This endpoint supports requests with `Content-Type`s of both `application/json` and `multipart/form-data`. You must however use `multipart/form-data` when uploading files. Note that when sending `multipart/form-data` requests the `embed` field cannot be used, however you can pass a JSON encoded body as form value for `payload_json`, where additional request parameters such as `embed` can be set.
 
 >info
->Note that when sending `application/json` you must send at least one of `content` or `embed`, and when sending `multipart/form-data`, you must send at least one of `content`, `embed` or `file`.
+>Note that when sending `application/json` you must send at least one of `content` or `embed`, and when sending `multipart/form-data`, you must send at least one of `content`, `embed` or `file`. For a `file` attachment, the `Content-Disposition` subpart header MUST contain a `filename` parameter.
 
 ###### Params
 
@@ -481,9 +481,6 @@ This endpoint supports requests with `Content-Type`s of both `application/json` 
 
 >info
 >For the embed object, you can set every field except `type` (it will be `rich` regardless of if you try to set it), `provider`, `video`, and any `height`, `width`, or `proxy_url` values for images.
-
->info
->For a `file` attachment, the `Content-Disposition` subpart header MUST contain a `filename` parameter.
 
 ###### Example Request Body (application/json)
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -482,6 +482,9 @@ This endpoint supports requests with `Content-Type`s of both `application/json` 
 >info
 >For the embed object, you can set every field except `type` (it will be `rich` regardless of if you try to set it), `provider`, `video`, and any `height`, `width`, or `proxy_url` values for images.
 
+>info
+>For a `file` attachment, the `Content-Disposition` subpart header MUST contain a `filename` parameter.
+
 ###### Example Request Body (application/json)
 
 ```json


### PR DESCRIPTION
Even though the `filename` parameter is only a SHOULD in RFC-7578, in practice it seems that Discord will not recognize file attachments that do not have a name. (Finding out this took most of an afternoon of interactive debugging in the #api channel).

I don't know if the filename needs to contain a recognized extension; if so that should probably also be documented.