### PR TITLE
Refer to registry paths as backward slashes

### DIFF
--- a/docs/dispatch/Branches_and_Builds.md
+++ b/docs/dispatch/Branches_and_Builds.md
@@ -313,7 +313,7 @@ For installation scripts, `name` is a user friendly name that Discord will surfa
 }
 ```
 
-Don't forget to the notice the double forward slashes in the path name!
+Don't forget to the notice the double backward slashes in the path name!
 
 ## Launch Options
 


### PR DESCRIPTION
Windows registry paths use backward slashes, not forward slashes. Previously referred to them as forward slashes.