### PR TITLE
Resolve discrepancy on embed usage

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -463,10 +463,10 @@ Post a message to a guild text or DM channel. If operating on a guild channel, t
 
 The maximum request size when sending a message is 8MB.
 
-This endpoint supports requests with `Content-Type`s of both `application/json` and `multipart/form-data`. You must however use `multipart/form-data` when uploading files. Note that when sending `multipart/form-data` requests the `embed` field cannot be used, however you can pass a JSON encoded body as form value for `payload_json`, where additional request parameters such as `embed` can be set.
+This endpoint supports requests with `Content-Type`s of both `application/json` and `multipart/form-data`. You must however use `multipart/form-data` when uploading files. Note that when sending `multipart/form-data` requests the `embeds` field cannot be used, however you can pass a JSON encoded body as form value for `payload_json`, where additional request parameters such as `embed` can be set.
 
 >info
->Note that when sending `application/json` you must send at least one of `content` or `embed`, and when sending `multipart/form-data`, you must send at least one of `content`, `embed` or `file`.
+>Note that when sending `application/json` you must send at least one of `content` or `embed`, and when sending `multipart/form-data`, you must send at least one of `content`, `embeds` or `file`.
 
 ###### Params
 
@@ -501,7 +501,7 @@ This endpoint supports requests with `Content-Type`s of both `application/json` 
 
 | Field Name | Form Value |
 |------------|------------|
-| payload_json | `"content": "Hello, World!", "tts": false, "embed": { "title": "Hello, Embed!", "description": "This is an embedded message." }` |
+| payload_json | `"content": "Hello, World!", "tts": false, "embeds": [ { "title": "Hello, Embed!", "description": "This is an embedded message." } ] ` |
 | file | file contents |
 
 | Field Name | Form Value |
@@ -523,11 +523,13 @@ For example:
 
 ```json
 {
-	"embed": {
+	"embeds": [
+	    {
 		"image": {
 			"url": "attachment://screenshot.png"
 		}
-	}
+	    }
+	]
 }
 ```
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -476,7 +476,7 @@ This endpoint supports requests with `Content-Type`s of both `application/json` 
 | nonce | snowflake | a nonce that can be used for optimistic message sending |
 | tts | boolean | true if this is a TTS message |
 | file | file contents | the contents of the file being sent |
-| embeds | [embeds](#DOCS_RESOURCES_CHANNEL/embed-object) object | embedded `rich` content |
+| embeds | array of [embed](#DOCS_RESOURCES_CHANNEL/embed-object) objects | embedded `rich` content |
 | payload_json | string | JSON encoded body of any additional request fields. |
 
 >info

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -476,7 +476,7 @@ This endpoint supports requests with `Content-Type`s of both `application/json` 
 | nonce | snowflake | a nonce that can be used for optimistic message sending |
 | tts | boolean | true if this is a TTS message |
 | file | file contents | the contents of the file being sent |
-| embed | [embed](#DOCS_RESOURCES_CHANNEL/embed-object) object | embedded `rich` content |
+| embeds | [embeds](#DOCS_RESOURCES_CHANNEL/embed-object) object | embedded `rich` content |
 | payload_json | string | JSON encoded body of any additional request fields. |
 
 >info
@@ -488,10 +488,12 @@ This endpoint supports requests with `Content-Type`s of both `application/json` 
 {
   "content": "Hello, World!",
   "tts": false,
-  "embed": {
-    "title": "Hello, Embed!",
-    "description": "This is an embedded message."
-  }
+  "embeds": [
+    {
+      "title": "Hello, Embed!",
+      "description": "This is an embedded message."
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
`/resources/Webhook.md` says to use `embeds` which is accurate to the current standard, but this page said to use the `embed` key pointing to a singular embed object rather than `embeds` pointing to an array of embed objects. This has now been resolved and this page is consistent with Webhook.md

This was discovered when I was asking for help because I was using the older documentation. See https://www.reddit.com/r/discordapp/comments/bkq22v/i_could_use_a_hand_with_webhooks/emizrob