### PR TITLE
Update DSharpPlus link

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -13,7 +13,7 @@ The Discord team curates the following list of officially vetted libraries that 
 | [discljord](https://github.com/igjoshua/discljord) | Clojure |
 | [discordcr](https://github.com/meew0/discordcr) | Crystal |
 | [Discord.Net](https://github.com/RogueException/Discord.Net) | C# |
-| [DSharpPlus](https://github.com/NaamloosDT/DSharpPlus) | C# |
+| [DSharpPlus](https://github.com/DSharpPlus/DSharpPlus) | C# |
 | [dscord](https://github.com/b1naryth1ef/dscord) | D |
 | [DiscordGo](https://github.com/bwmarrin/discordgo) | Go |
 | [DisGord](https://github.com/andersfylling/disgord) | Go |


### PR DESCRIPTION
As DSharpPlus is now under a GitHub Team and I messed up redirects on my end, this is the link that directly points to the right repository.