### PR TITLE
Change audit log key description for clarity

### DIFF
--- a/docs/resources/Audit_Log.md
+++ b/docs/resources/Audit_Log.md
@@ -79,7 +79,7 @@ Whenever an admin action is performed on the API, an entry is added to the respe
 |-------|------|-------------|
 | new_value? | [mixed](#DOCS_RESOURCES_AUDIT_LOG/audit-log-change-object-audit-log-change-key) | new value of the key |
 | old_value? | [mixed](#DOCS_RESOURCES_AUDIT_LOG/audit-log-change-object-audit-log-change-key) | old value of the key |
-| key | string | type of audit log [change key](#DOCS_RESOURCES_AUDIT_LOG/audit-log-change-object-audit-log-change-key) |
+| key | string | name of audit log [change key](#DOCS_RESOURCES_AUDIT_LOG/audit-log-change-object-audit-log-change-key) |
 
 ###### Audit Log Change Key
 


### PR DESCRIPTION
Using the word "type" conflicts with the technical concept of "type" reserved for things like string, number, array. It is more accurate to refer to the "name", as labeled in the Audit Log Change Key table.