### PR TITLE
[OAuth2] Update arguments in example python code

### DIFF
--- a/docs/topics/OAuth2.md
+++ b/docs/topics/OAuth2.md
@@ -94,7 +94,7 @@ def exchange_code(code):
   headers = {
     'Content-Type': 'application/x-www-form-urlencoded'
   }
-  r = requests.post('%s/oauth2/token' % API_ENDPOINT, data, headers)
+  r = requests.post('%s/oauth2/token' % API_ENDPOINT, data=data, headers=headers)
   r.raise_for_status()
   return r.json()
 ```
@@ -142,7 +142,7 @@ def refresh_token(refresh_token):
   headers = {
     'Content-Type': 'application/x-www-form-urlencoded'
   }
-  r = requests.post('%s/oauth2/token' % API_ENDPOINT, data, headers)
+  r = requests.post('%s/oauth2/token' % API_ENDPOINT, data=data, headers=headers)
   r.raise_for_status()
   return r.json()
 ```
@@ -192,7 +192,7 @@ def get_token():
   headers = {
     'Content-Type': 'application/x-www-form-urlencoded'
   }
-  r = requests.post('%s/oauth2/token' % API_ENDPOINT, data, headers, auth=(CLIENT_ID, CLIENT_SECRET))
+  r = requests.post('%s/oauth2/token' % API_ENDPOINT, data=data, headers=headers, auth=(CLIENT_ID, CLIENT_SECRET))
   r.raise_for_status()
   return r.json()
 ```


### PR DESCRIPTION
Currently, in the developer docs (under oauth2), it says:
```py
r = requests.post('%s/oauth2/token' % API_ENDPOINT, data, headers)
```
However, this is not valid, and leads to issues with requests not thinking that you are passing it as data and header arguments, and leads to this JSON response:
```json
{'error': 'invalid_grant'}
```
After that, I tried changing it into the following in my code, and it responded with the correct JSON message:
```py
r = requests.post('%s/oauth2/token' % API_ENDPOINT, data=data, headers=headers)
```
This PR addressed this issue in the docs.