### PR TITLE
WIP - Update Gateway docs for new _trace

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -107,7 +107,20 @@ Once connected, the client should immediately receive an [Opcode 10 Hello](#DOCS
 ```json
 {
   "heartbeat_interval": 45000,
-  "_trace": ["discord-gateway-prd-1-99"]
+  "_trace": [
+      "discord-gateway-prd-1-99",
+      {
+          "micros": 1003,
+          "calls": [
+              "discord-sessions-prd-1-99", {
+                  "micros": 800
+              },
+              "discord-api-prd-1-99", {
+                  "micros": 500
+              }
+          ]
+      }
+  ]
 }
 ```
 
@@ -450,7 +463,7 @@ Sent on connection to the websocket. Defines the heartbeat interval that the cli
 | Field              | Type             | Description                                                     |
 | ------------------ | ---------------- | --------------------------------------------------------------- |
 | heartbeat_interval | integer          | the interval (in milliseconds) the client should heartbeat with |
-| \_trace            | array of strings | used for debugging, array of servers connected to               |
+| \_trace            | unspecified      | used for debugging, this is internal data and may change format |
 
 ###### Example Hello
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -480,7 +480,6 @@ The ready event is dispatched when a client has completed the initial handshake 
 #### Resumed
 
 The resumed event is dispatched when a client has sent a [resume payload](#DOCS_TOPICS_GATEWAY/resume) to the gateway (for resuming existing sessions).
-It has no special fields.
 
 #### Invalid Session
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -107,20 +107,6 @@ Once connected, the client should immediately receive an [Opcode 10 Hello](#DOCS
 ```json
 {
   "heartbeat_interval": 45000,
-  "_trace": [
-      "discord-gateway-prd-1-99",
-      {
-          "micros": 1003,
-          "calls": [
-              "discord-sessions-prd-1-99", {
-                  "micros": 800
-              },
-              "discord-api-prd-1-99", {
-                  "micros": 500
-              }
-          ]
-      }
-  ]
 }
 ```
 
@@ -463,14 +449,12 @@ Sent on connection to the websocket. Defines the heartbeat interval that the cli
 | Field              | Type             | Description                                                     |
 | ------------------ | ---------------- | --------------------------------------------------------------- |
 | heartbeat_interval | integer          | the interval (in milliseconds) the client should heartbeat with |
-| \_trace            | unspecified      | used for debugging, this is internal data and may change format |
 
 ###### Example Hello
 
 ```json
 {
-  "heartbeat_interval": 45000,
-  "_trace": ["discord-gateway-prd-1-99"]
+  "heartbeat_interval": 45000
 }
 ```
 
@@ -489,7 +473,6 @@ The ready event is dispatched when a client has completed the initial handshake 
 | private_channels | array                                                                                | empty array                                                                                                   |
 | guilds           | array of [Unavailable Guild](#DOCS_RESOURCES_GUILD/unavailable-guild-object) objects | the guilds the user is in                                                                                     |
 | session_id       | string                                                                               | used for resuming connections                                                                                 |
-| \_trace          | array of strings                                                                     | used for debugging - the guilds the user is in                                                                |
 | shard?           | array of two integers (shard_id, num_shards)	                                      | the [shard information](#DOCS_TOPICS_GATEWAY/sharding) associated with this session, if sent when identifying |
 
 #### Resumed
@@ -500,7 +483,6 @@ The resumed event is dispatched when a client has sent a [resume payload](#DOCS_
 
 | Field   | Type             | Description                                    |
 | ------- | ---------------- | ---------------------------------------------- |
-| \_trace | array of strings | used for debugging - the guilds the user is in |
 
 #### Invalid Session
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -4,6 +4,8 @@ Gateways are Discord's form of real-time communication over secure websockets. C
 
 The Discord Gateway has a versioning system which is separate from the core APIs. The documentation herein is only for the latest version in the following table, unless otherwise specified.
 
+Important note: Not all event fields are documented, in particular, fields prefixed with an underscore are considered _internal fields_ and should not be relied on. We may change the format at any time.
+
 ###### Gateway Versions
 
 | Version | Status       |

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -478,11 +478,7 @@ The ready event is dispatched when a client has completed the initial handshake 
 #### Resumed
 
 The resumed event is dispatched when a client has sent a [resume payload](#DOCS_TOPICS_GATEWAY/resume) to the gateway (for resuming existing sessions).
-
-###### Resumed Event Fields
-
-| Field   | Type             | Description                                    |
-| ------- | ---------------- | ---------------------------------------------- |
+It has no special fields.
 
 #### Invalid Session
 


### PR DESCRIPTION
This is a companion PR to clarify that `_trace` is internal (hence the prefixed underscore) and should not be relied on, but also documents the current (new) format in the example.