### PR TITLE
docs: Add Team User Flag

### DIFF
--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -75,6 +75,7 @@ There are other rules and restrictions not shared here for the sake of spam and 
 | 1 << 7 | House Brilliance |
 | 1 << 8 | House Balance    |
 | 1 << 9 | Early Supporter  |
+| 1 << 10 | Team User       |
 
 ###### Premium Types
 


### PR DESCRIPTION
It seems like the team "users" (fake ones at that) have their `flags` property set as 1024 (1 << 10). This PR documents that