### PR TITLE
docs: Add team icon path to docs

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -182,7 +182,7 @@ Discord uses ids and hashes to render images in the client. These hashes can be 
 | User Avatar | avatars/[user_id](#DOCS_RESOURCES_USER/user-object)/[user_avatar](#DOCS_RESOURCES_USER/user-object).png \*\* | PNG, JPEG, WebP, GIF |
 | Application Icon | app-icons/[application_id](#MY_APPLICATIONS/top)/[icon](#DOCS_TOPICS_OAUTH2/get-current-application-information).png | PNG, JPEG, WebP |
 | Application Asset | app-assets/[application_id](#MY_APPLICATIONS/top)/[asset_id](#DOCS_TOPICS_GATEWAY/activity-object-activity-assets).png | PNG, JPEG, WebP |
-| Team Icon | team-icons/[team_id](#DOCS_TOPICS_TEAMS/team-object).png | PNG, JPEG, WebP |
+| Team Icon | team-icons/[team_id](#DOCS_TOPICS_TEAMS/team-object)/[team_icon](#DOCS_TOPICS_TEAMS/team-object).png | PNG, JPEG, WebP |
 
 \* In the case of the Default User Avatar endpoint, the value for `user_discriminator` in the path should be the user's discriminator modulo 5—Test#1337 would be `1337 % 5`, which evaluates to 2.
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -182,6 +182,7 @@ Discord uses ids and hashes to render images in the client. These hashes can be 
 | User Avatar | avatars/[user_id](#DOCS_RESOURCES_USER/user-object)/[user_avatar](#DOCS_RESOURCES_USER/user-object).png \*\* | PNG, JPEG, WebP, GIF |
 | Application Icon | app-icons/[application_id](#MY_APPLICATIONS/top)/[icon](#DOCS_TOPICS_OAUTH2/get-current-application-information).png | PNG, JPEG, WebP |
 | Application Asset | app-assets/[application_id](#MY_APPLICATIONS/top)/[asset_id](#DOCS_TOPICS_GATEWAY/activity-object-activity-assets).png | PNG, JPEG, WebP |
+| Team Icon | team-icons/[team_id](#DOCS_TOPICS_TEAMS/team-object).png | PNG, JPEG, WebP |
 
 \* In the case of the Default User Avatar endpoint, the value for `user_discriminator` in the path should be the user's discriminator modulo 5—Test#1337 would be `1337 % 5`, which evaluates to 2.
 


### PR DESCRIPTION
Per Minns question, this adds the `team-icons` path to the Reference.

I don't know if that is the correct way to link to the topics and team object, please let me know!