### PR TITLE
Add Serenity to compliant Discord API libraries.

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -31,6 +31,7 @@ The Discord team curates the following list of officially vetted libraries that 
 | [disco](https://github.com/b1naryth1ef/disco) | Python |
 | [discordrb](https://github.com/meew0/discordrb) | Ruby |
 | [discord-rs](https://github.com/SpaceManiac/discord-rs) | Rust |
+| [Serenity](https://github.com/serenity-rs/serenity) | Rust |
 | [AckCord](https://github.com/Katrix/AckCord) | Scala |
 | [Sword](https://github.com/Azoy/Sword) | Swift |
 


### PR DESCRIPTION
Hello, we would like to add the Serenity Discord API library to the curated list.

Serenity covers the full documented feature-set and has its own channel on the Discord API guild.

Here is our ratelimit implementation: https://github.com/serenity-rs/serenity/blob/b49719f327403b91a351bdacb266084c0cd8d005/src/http/ratelimiting.rs

Thanks for your time!