### PR TITLE
Add aegis.cpp to library list

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -11,6 +11,7 @@ The Discord team curates the following list of officially vetted libraries that 
 | Name | Language |
 |------|----------|
 | [discljord](https://github.com/igjoshua/discljord) | Clojure |
+| [aegis.cpp](https://github.com/zeroxs/aegis.cpp) | C++ |
 | [discordcr](https://github.com/meew0/discordcr) | Crystal |
 | [Discord.Net](https://github.com/RogueException/Discord.Net) | C# |
 | [DSharpPlus](https://github.com/DSharpPlus/DSharpPlus) | C# |


### PR DESCRIPTION
Hello. I would like to add my library to the list.

Ratelimit code: [ratelimit.hpp](https://github.com/zeroxs/aegis.cpp/blob/master/include/aegis/ratelimit/ratelimit.hpp) [bucket.hpp](https://github.com/zeroxs/aegis.cpp/blob/master/include/aegis/ratelimit/bucket.hpp)