### PR TITLE
"Channel with Guild" mention format

### DIFF
--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## "Channel with Guild" Mention Format
+
+#### July 19, 2019
+
+Channel mentions can now reference channels in other guilds using a new [Channel with Guild format](#DOCS_REFERENCE/message-formatting). This format is intended for (but not limited to) crossposted messages via Channel Following and for linking to Lurkable guilds. Normal channel mentions (`<#CHANNEL_ID>`) will continue to work as expected, this is simply an additional format to support new behavior. Like normal channel mentions, Users must be able to see (or be able to lurk in) the target channel to mention it.
+
 ## Bot Tokens for Achievements
 
 #### July 18, 2019

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -145,6 +145,7 @@ Discord utilizes a subset of markdown for rendering message content on its clien
 | User | <@USER_ID> | <@80351110224678912> |
 | User (Nickname) | <@!USER_ID> | <@!80351110224678912> |
 | Channel | <#CHANNEL_ID> | <#103735883630395392> |
+| Channel with Guild | <#CHANNEL_ID-GUILD_ID-CHANNEL_NAME> | <#103735883630395392-11771983423143937-general> |
 | Role | <@&ROLE_ID> | <@&165511591545143296> |
 | Custom Emoji | <:NAME:ID> | <:mmLol:216154654256398347> |
 | Custom Emoji (Animated) | <a:NAME:ID> | <a:b1nzy:392938283556143104> |

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -145,7 +145,7 @@ Discord utilizes a subset of markdown for rendering message content on its clien
 | User | <@USER_ID> | <@80351110224678912> |
 | User (Nickname) | <@!USER_ID> | <@!80351110224678912> |
 | Channel | <#CHANNEL_ID> | <#103735883630395392> |
-| Channel with Guild | <#CHANNEL_ID-GUILD_ID-CHANNEL_NAME> | <#103735883630395392-11771983423143937-general> |
+| Channel with Guild | <#CHANNEL_ID:GUILD_ID:CHANNEL_NAME> | <#103735883630395392:11771983423143937:general> |
 | Role | <@&ROLE_ID> | <@&165511591545143296> |
 | Custom Emoji | <:NAME:ID> | <:mmLol:216154654256398347> |
 | Custom Emoji (Animated) | <a:NAME:ID> | <a:b1nzy:392938283556143104> |


### PR DESCRIPTION
This PR adds documentation around the new "Channel with Guild" mention format in messages. The change in documentation is minimal, but has had a large impact and was not publicized before shipping, so I'd like to give some context and further explanation.

### tl;dr

We shipped a new channel mention format with a bug that changed all channel mentions to this format instead of acting as a new format.

This new alternate format looks like `<#CHANNEL_ID:GUILD_ID:CHANNEL_NAME>`. It does _not_ replace or invalidate the original `<#CHANNEL_ID>` mention format.

We are reverting the broken code and will redeploy with fixes and the updated new format in the near future. Read on for more explanation.

### What happened

A few days ago we shipped a new mention format for referencing a channel in another guild. This change was intended to only appear in crossposted messages (messages that get sent to your server from another server's News channels via [Following](https://support.discordapp.com/hc/en-us/articles/360028384531-Server-Following-FAQ)), but unintentionally caused all channel mentions in guilds with the `LURKABLE` feature to use the new format. **This was not intended to change how channel mentions work in general, but instead add a new format for new behavior. The fact that normal channel mentions changed was a bug and is being reverted until it can be fixed.**

Because we did not update the documentation or announce this change before the feature shipped, devs had no way of anticipating this change and it ended up [causing errors for some bots in these servers](https://github.com/discordapp/discord-api-docs/issues/1029).

While this change is still part of an experiment, it is highly visible and should have been communicated in some way as part of it getting shipped. We understand that core changes can have large impacts, and our assumption that this change in particular would be minimal until fully shipped (it is currently only active in a handful of servers) was flawed. This was our mistake, and we're going to work on making sure that communicating these kinds of changes is a deeper part of our process moving forward, especially around updates to long-established syntax and patterns.

### Why this change

[As has been pointed out](https://github.com/discordapp/discord-api-docs/issues/1029#issuecomment-513344520), it is technically already possible to link to channels across guilds using the existing format, but this requires that every recipient be able to see the channel (i.e., is a member of the server and has access to the channel) for the link to function correctly.

This new syntax enables linking to `LURKABLE` servers even if the recipient is not a member of that server. While this _could_ be implemented using the original channel mention syntax, it would have huge performance implications and thundering herd problems, as every client would have to hit the API to check if they have access to the mentioned channel and then fetch that channel's information to display a name. With the new format, we can validate the mention on message send, and then only do those other checks when a user interacts with the mention. It also opens some opportunities to other unexplored UX features in the future.


### What next

Our plan moving forward with this change is:

  - Revert the existing deployment that added this new syntax. After this, all channel mentions will be back to using the original syntax. This is nearing deployment now.
  - **Change the new format to be consistent with other mention formats, using colons (`:`) as segment delimiters instead of dashes (`-`). The documentation in this PR uses the updated syntax that will be shipped here.**
  - Roll out the updated Channel with Guild mention format, with fixes to keep using the normal mention syntax by default and only use the new format for crossposts.

For devs, you should be able to use [`<#(\d+)(?::(\d+):([^>]+))?>`](https://regex101.com/r/NhDPbW/2/) to match both kinds of channel mentions going forward (after we ship the new, fixed implementation). This is not a "guaranteed to always work forever regex", but should be sufficient for the forseeable future.


Note: Existing messages that include the new mention syntax will not be updated/removed. If you are parsing the raw message content instead of using the `mentions` objects, you can accomodate for this either by strictly matching simple channel mentions with `<#\d+>` and ignoring these other mentions, or by loosely matching the channel id at the start of the mention with something like `<#\d+[^>]*>`. The channel ID should be the first segment of the mention regardless of the format being used.

**EDIT:** After some discussion, a better regex to use for parsing is [`<#(\d+)(?::(\d+):([^>]{1,100}))?>`](https://regex101.com/r/NhDPbW/2/). This enforces the 100 character name limit while still accepting spaces in channel names. This is all-around simpler than enforcing trying to enforce an encoding on the name to remove spaces.