### PR TITLE
Made one of the the Permission Hierarchy rules clearer

### DIFF
--- a/docs/topics/Permissions.md
+++ b/docs/topics/Permissions.md
@@ -62,7 +62,7 @@ Note that these internal permission names may be referred to differently by the 
 
 How permissions apply may at first seem intuitive, but there are some hidden restrictions that prevent bots from performing certain inappropriate actions based on a bot's highest role compared to its target's highest role. A bot's or user's highest role is its role that has the greatest position value in the guild, with the default @everyone role starting at 0. Permissions follow a hierarchy with the following rules:
 
-* A bot can grant roles to other users that are of a lower position than it's own highest role.
+* A bot can grant roles to other users that are of a lower position than its own highest role.
 * A bot can edit roles of a lower position than its highest role, but it can only grant permissions it has to those roles.
 * A bot can only sort roles lower than its highest role.
 * A bot can only kick/ban users whose highest role is lower than the bot's highest role.

--- a/docs/topics/Permissions.md
+++ b/docs/topics/Permissions.md
@@ -62,7 +62,7 @@ Note that these internal permission names may be referred to differently by the 
 
 How permissions apply may at first seem intuitive, but there are some hidden restrictions that prevent bots from performing certain inappropriate actions based on a bot's highest role compared to its target's highest role. A bot's or user's highest role is its role that has the greatest position value in the guild, with the default @everyone role starting at 0. Permissions follow a hierarchy with the following rules:
 
-* A bot can grant roles to other users that are of a lower position than their highest role.
+* A bot can grant roles to other users that are of a lower position than it's own highest role.
 * A bot can edit roles of a lower position than its highest role, but it can only grant permissions it has to those roles.
 * A bot can only sort roles lower than its highest role.
 * A bot can only kick/ban users whose highest role is lower than the bot's highest role.


### PR DESCRIPTION
`their` felt like it was referring to the "other users" bit - this made me understand that the following wasn't possible (while it of course is):

Role #1 - Bot's highest role
Role #2 - The role I want to give
Role #3 - Highest role of the user I want to give the role to

This small edit clears up the confusion.