### PR TITLE
Fix documentation for 4014 close

### DIFF
--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -68,7 +68,7 @@ Our voice gateways have their own set of opcodes and close codes.
 | 4009 | Session timeout | Your session has timed out. |
 | 4011 | Server not found | We can't find the server you're trying to connect to. |
 | 4012 | Unknown Protocol | We didn't recognize the [protocol](#DOCS_RESOURCES_VOICE_CONNECTIONS/establishing-a-voice-udp-connection-example-select-protocol-payload) you sent. |
-| 4014 | Disconnected | Oh no! You've been disconnected! Try [resuming](#DOCS_RESOURCES_VOICE_CONNECTIONS/resuming-voice-connection). |
+| 4014 | Disconnected | Either the channel was deleted or you were kicked. Should not reconnect. |
 | 4015 | Voice server crashed | The server crashed. Our bad! Try [resuming](#DOCS_RESOURCES_VOICE_CONNECTIONS/resuming-voice-connection). |
 | 4016 | Unknown Encryption Mode | We didn't recognize your [encryption](#DOCS_RESOURCES_VOICE_CONNECTIONS/encrypting-and-sending-voice). |
 


### PR DESCRIPTION
This close code should definitely not be resumed:

The situations where this seems to be used:

- The channel was deleted (no channel to reconnect to)
- The main gateway session was dropped (no authorization to reconnect)
- The bot was kicked (don't reconnect when you were told to disconnect)