### PR TITLE
doc: more precise rate limit precision

### DIFF
--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## More Precise Rate Limits
+
+#### August 12, 2019
+
+You can now get more precise rate limit reset times, via a new request header. Check out the [rate limits](#DOCS_TOPICS_RATE_LIMITS/more-precise-rate-limit-resets) documentation for more information.
+
 ## Bot Tokens for Achievements
 
 #### July 18, 2019

--- a/docs/topics/Rate_Limits.md
+++ b/docs/topics/Rate_Limits.md
@@ -123,3 +123,23 @@ If set to `millisecond` you will receive a more precise `X-RateLimit-Remaining`.
   "global": false
 }
 ```
+
+Setting it to an invalid value, will net you a special error message contained in `X-RateLimit-Reset`.
+
+```
+> GET /api/v6/some-endpoint
+> X-RateLimit-Precision: garbage
+
+< HTTP/1.1 429 TOO MANY REQUESTS
+< Content-Type: application/json
+< Retry-After: 6457
+< X-RateLimit-Limit: 10
+< X-RateLimit-Remaining: 0
+< X-RateLimit-Reset: Invalid X-RateLimit-Precision, valid options are (second, millisecond)
+< X-RateLimit-Bucket: abcd1234
+{
+  "message": "You are being rate limited.",
+  "retry_after": 6457,
+  "global": false
+}
+```

--- a/docs/topics/Rate_Limits.md
+++ b/docs/topics/Rate_Limits.md
@@ -104,7 +104,7 @@ If the `X-RateLimit-Precision` header isn't set, it defaults to `second` precisi
 }
 ```
 
-If set to `millisecond` you will receive a more precise `X-RateLimit-Remaining`.
+If set to `millisecond` you will receive a more precise `X-RateLimit-Reset`.
 
 ```
 > GET /api/v6/some-endpoint

--- a/docs/topics/Rate_Limits.md
+++ b/docs/topics/Rate_Limits.md
@@ -77,3 +77,49 @@ Note that the normal rate-limiting headers will be sent in this response. The ra
   "global": true
 }
 ```
+
+## More Precise Rate Limit Resets
+
+By default, the `X-RateLimit-Reset` header returns the time the rate limit will reset, rounded up to the nearest second. However, for more precise rate limit handling, you can now request `millisecond` level precision by using sending the `X-RateLimit-Precision` header and setting it to `millisecond`. This means that you will get a more precise response, rounded to the nearest millisecond.
+
+###### Example Responses
+
+If the `X-RateLimit-Precision` header isn't set, it defaults to `second` precision.
+
+```
+> GET /api/v6/some-endpoint
+> X-RateLimit-Precision: second
+
+< HTTP/1.1 429 TOO MANY REQUESTS
+< Content-Type: application/json
+< Retry-After: 6457
+< X-RateLimit-Limit: 10
+< X-RateLimit-Remaining: 0
+< X-RateLimit-Reset: 1470173023
+< X-RateLimit-Bucket: abcd1234
+{
+  "message": "You are being rate limited.",
+  "retry_after": 6457,
+  "global": false
+}
+```
+
+If set to `millisecond` you will receive a more precise `X-RateLimit-Remaining`.
+
+```
+> GET /api/v6/some-endpoint
+> X-RateLimit-Precision: millisecond
+
+< HTTP/1.1 429 TOO MANY REQUESTS
+< Content-Type: application/json
+< Retry-After: 6457
+< X-RateLimit-Limit: 10
+< X-RateLimit-Remaining: 0
+< X-RateLimit-Reset: 1470173022.420
+< X-RateLimit-Bucket: abcd1234
+{
+  "message": "You are being rate limited.",
+  "retry_after": 6457,
+  "global": false
+}
+```


### PR DESCRIPTION
Discord will soon support returning a more precise `X-RateLimit-Reset` header, such that bots can deal with sub-second rate limits more effectively. 

This change isn't deployed to production yet, but luckily, it's entirely forward compatible. If you start sending the header right now, it will still return `second` level precision, but once deployed, you'll simply get more precise timestamp in `X-RateLimit-Reset`. Assuming you handle it being a float, things will just work!

Specifying an invalid `X-RateLimit-Precision` header, will cause the `X-RateLimit-Reset` header to return a string error, telling you that you set `X-RateLimit-Precision` to an invalid value. 

# todo:

- [x] deploy to production
