### PR TITLE
Add Guild#preferred_locale

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -46,6 +46,9 @@ Guilds in Discord represent an isolated collection of users and channels, and ar
 | banner                        | ?string                                                                          | [banner hash](#DOCS_REFERENCE/image-formatting)                                                                                  |
 | premium_tier                  | integer                                                                          | [premium tier](#DOCS_RESOURCES_GUILD/guild-object-premium-tier)                                                                  |
 | premium_subscription_count?   | integer                                                                          | the total number of users currently boosting this server                                                                         |
+| lfg                           |                                                                                  |                                                                                                                                  |
+| lazy                          | boolean                                                                          | if this guild has lazy loading enabled                                                                                           |
+| preferred_locale              | string                                                                           | the preferred locale of this guild                                                                                               |
 
 ** \* These fields are only sent within the [GUILD_CREATE](#DOCS_TOPICS_GATEWAY/guild-create) event **
 

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -46,7 +46,7 @@ Guilds in Discord represent an isolated collection of users and channels, and ar
 | banner                        | ?string                                                                          | [banner hash](#DOCS_REFERENCE/image-formatting)                                                                                  |
 | premium_tier                  | integer                                                                          | [premium tier](#DOCS_RESOURCES_GUILD/guild-object-premium-tier)                                                                  |
 | premium_subscription_count?   | integer                                                                          | the total number of users currently boosting this server                                                                         |
-| preferred_locale              | string                                                                           | the preferred locale of this guild                                                                                               |
+| preferred_locale              | string                                                                           | the preferred locale of this guild only set if guild has the "DISCOVERABLE" feature, defaults to en-US                           |
 
 ** \* These fields are only sent within the [GUILD_CREATE](#DOCS_TOPICS_GATEWAY/guild-create) event **
 

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -46,8 +46,6 @@ Guilds in Discord represent an isolated collection of users and channels, and ar
 | banner                        | ?string                                                                          | [banner hash](#DOCS_REFERENCE/image-formatting)                                                                                  |
 | premium_tier                  | integer                                                                          | [premium tier](#DOCS_RESOURCES_GUILD/guild-object-premium-tier)                                                                  |
 | premium_subscription_count?   | integer                                                                          | the total number of users currently boosting this server                                                                         |
-| lfg                           |                                                                                  |                                                                                                                                  |
-| lazy                          | boolean                                                                          | if this guild has lazy loading enabled                                                                                           |
 | preferred_locale              | string                                                                           | the preferred locale of this guild                                                                                               |
 
 ** \* These fields are only sent within the [GUILD_CREATE](#DOCS_TOPICS_GATEWAY/guild-create) event **


### PR DESCRIPTION
I just noticed that there are undocumented properties on Guilds which can be very useful for various bots (preferred_locale) and i would like that these get documented and also get some clarification on the new "lfg" property (i would assume this stand for looking for game?).

Also i noticed that all my guilds (atleast on my test bot) get lazy loaded now and the members array only has the Client User itself on it, so i would like to get some clarification on that aswell by a Discord Dev.