### PR TITLE
Fix Broken Jump Links

### DIFF
--- a/docs/dispatch/Branches_and_Builds.md
+++ b/docs/dispatch/Branches_and_Builds.md
@@ -494,7 +494,7 @@ If you understand and agree to the above, run the following command on each of t
 dispatch build drm-wrap <application_id> <path_to_executable_to_wrap>
 ```
 
-This function will only work with Windows executables. If you want to wrap a unix executable, you'll need to instead use [ValidateOrExit](#DOCS_GAME_SDK_APPLICATIONS/validate-or-exit).
+This function will only work with Windows executables. If you want to wrap a unix executable, you'll need to instead use [ValidateOrExit](#DOCS_GAME_SDK_APPLICATIONS/validateorexit).
 
 ## Pushing Our First Build
 

--- a/docs/dispatch/List_of_Commands.md
+++ b/docs/dispatch/List_of_Commands.md
@@ -93,7 +93,7 @@ Deletes a build from a branch.
 
 ## build drm-wrap
 
-Wraps your executable in Discord's DRM. This only works for Windows executables. If you want to DRM wrap a unix executable, you'll need to instead use [ValidateOrExit](#DOCS_GAME_SDK_APPLICATIONS/validate-or-exit).
+Wraps your executable in Discord's DRM. This only works for Windows executables. If you want to DRM wrap a unix executable, you'll need to instead use [ValidateOrExit](#DOCS_GAME_SDK_APPLICATIONS/validateorexit).
 
 > danger
 > This action is destructive and overwrites the executable. Make sure you've got a backup handy if needed!


### PR DESCRIPTION
Within the documentation, there are two links that go to "validate-or-exit" on the SDK Applications page.
Unfortunately, the real link is "validateorexit".
This PR **validate**s the accuracy of those links so users will not **exit** their mind trying to figure out what they're supposed to be looking at.