### PR TITLE
Fixed broken hyperlink in Discord.md

### DIFF
--- a/docs/game_sdk/Discord.md
+++ b/docs/game_sdk/Discord.md
@@ -60,7 +60,7 @@ Discord passes a number of environment variables down to the SDK. These are acce
 
 | name                   | method                                                                                  | description                                                                                                  |
 | ---------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| DISCORD_INSTANCE_ID    | [Local Testing](#DOCS_GAME_SDK_SDK_STARTER_GUIDE/testing-with-two-clients)              | the locally running instance of Discord to connect to; allows you to choose between multiple running clients |
+| DISCORD_INSTANCE_ID    | [Local Testing](#DOCS_GAME_SDK_SDK_STARTER_GUIDE/testing-locally-with-two-clients)      | the locally running instance of Discord to connect to; allows you to choose between multiple running clients |
 | DISCORD_ACCESS_TOKEN   | [ApplicationManager.GetOAuth2Token()](#DOCS_GAME_SDK_APPLICATIONS/get-oauth2-token)     | the connected user's bearer token                                                                            |
 | DISCORD_CURRENT_LOCALE | [ApplicationManager.GetCurrentLocale](#DOCS_GAME_SDK_APPLICATIONS/get-current-locale)   | the language that Discord is in for the connected user                                                       |
 | DISCORD_CURRENT_BRANCH | [ApplicationManager.GetCurrentBranch()](#DOCS_GAME_SDK_APPLICATIONS/get-current-branch) | the branch of the running application that the user has launched                                             |


### PR DESCRIPTION
`[Local Testing](#DOCS_GAME_SDK_SDK_STARTER_GUIDE/testing-with-two-clients)`
to
`[Local Testing](#DOCS_GAME_SDK_SDK_STARTER_GUIDE/testing-locally-with-two-clients)`