### PR TITLE
Add JSON error code 40007

### DIFF
--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -124,8 +124,9 @@ Along with the HTTP error code, our API can also return more detailed error code
 | 30005  | Maximum number of guild roles reached (250)                                                                     |
 | 30010  | Maximum number of reactions reached (20)                                                                        |
 | 30013  | Maximum number of guild channels reached (500)                                                                  |
-| 30016  | Maximum number of invites reached (1000)                                                                  |
+| 30016  | Maximum number of invites reached (1000)                                                                        |
 | 40001  | Unauthorized                                                                                                    |
+| 40007  | The user is banned from this guild                                                                              |
 | 50001  | Missing access                                                                                                  |
 | 50002  | Invalid account type                                                                                            |
 | 50003  | Cannot execute action on a DM channel                                                                           |


### PR DESCRIPTION
This error code occurs when trying to use the Add Guild Member endpoint on a user who is banned from the guild.