### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,4 +11,4 @@
 2. Modifications to the overall structure and format of the API docs.
 3. Additions that replicate or needlessly restructure current documentation.
 
-By submitting pull requests to this repository, you waive any rights or ownership of the included contents to Discord. Contributions to this repository must conform to the [Discord App TOS](https://discordapp.com/tos).
+By submitting pull requests to this repository, you waive any rights or ownership of the included contents to Discord. Contributions to this repository must conform to the [Discord App TOS](https://discordapp.com/terms).


### PR DESCRIPTION
Changed "discordapp.com/tos" to "discordapp.com/terms". "discordapp.com/tos" redirects you to "discordapp.com/terms" but it looks cleaner to have a link that takes you to the page it says rather than a redirect