### PR TITLE
[bug] State that snowflakes are signed interegers

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -51,7 +51,9 @@ All HTTP-layer services and protocols (e.g. http, websocket) within the Discord 
 
 ## Snowflakes
 
-Discord utilizes Twitter's [snowflake](https://github.com/twitter/snowflake/tree/snowflake-2010) format for uniquely identifiable descriptors (IDs). These IDs are guaranteed to be unique across all of Discord, except in some unique scenarios in which child objects share their parent's ID. Because Snowflake IDs are up to 64 bits in size (e.g. a uint64), they are always returned as strings in the HTTP API to prevent integer overflows in some languages. See [Gateway ETF/JSON](#DOCS_TOPICS_GATEWAY/etf-json) for more information regarding Gateway encoding.
+> Snowflakes are serialised signed 64 bit integers
+
+Discord utilizes Twitter's [snowflake](https://github.com/twitter/snowflake/tree/snowflake-2010) format for uniquely identifiable descriptors (IDs). These IDs are guaranteed to be unique across all of Discord, except in some unique scenarios in which child objects share their parent's ID. Because Snowflake IDs are up to 64 bits in size (int64), they are always returned as strings in the HTTP API to prevent integer overflows in some languages. See [Gateway ETF/JSON](#DOCS_TOPICS_GATEWAY/etf-json) for more information regarding Gateway encoding.
 
 ###### Snowflake ID Broken Down in Binary
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -51,7 +51,7 @@ All HTTP-layer services and protocols (e.g. http, websocket) within the Discord 
 
 ## Snowflakes
 
-> Snowflakes are serialised signed 64 bit integers
+> Snowflakes are signed 64 bit integers as a string
 
 Discord utilizes Twitter's [snowflake](https://github.com/twitter/snowflake/tree/snowflake-2010) format for uniquely identifiable descriptors (IDs). These IDs are guaranteed to be unique across all of Discord, except in some unique scenarios in which child objects share their parent's ID. Because Snowflake IDs are up to 64 bits in size (int64), they are always returned as strings in the HTTP API to prevent integer overflows in some languages. See [Gateway ETF/JSON](#DOCS_TOPICS_GATEWAY/etf-json) for more information regarding Gateway encoding.
 


### PR DESCRIPTION
One of my lib users just got a crash as the snowflake value was negative. This PR changes the reference side to state that the snowflakes values are signed 64 bit integers.