### PR TITLE
Update streaming activity type format

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -814,7 +814,7 @@ Active sessions are indicated with an "online", "idle", or "dnd" string per plat
 | ID  | Name      | Format              | Example                   |
 | --- | --------- | ------------------- | ------------------------- |
 | 0   | Game      | Playing {name}      | "Playing Rocket League"   |
-| 1   | Streaming | Streaming {name}    | "Streaming Rocket League" |
+| 1   | Streaming | Streaming {details} | "Streaming Rocket League" |
 | 2   | Listening | Listening to {name} | "Listening to Spotify"    |
 
 > info

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -818,7 +818,7 @@ Active sessions are indicated with an "online", "idle", or "dnd" string per plat
 | 2   | Listening | Listening to {name} | "Listening to Spotify"    |
 
 > info
-> The streaming type currently only supports Twitch. Only `https://twitch.tv/` urls will work.
+> The streaming type currently only supports Twitch and YouTube. Only `https://twitch.tv/` and `https://youtube.com/` urls will work.
 
 ###### Activity Timestamps
 
@@ -866,9 +866,11 @@ Active sessions are indicated with an "online", "idle", or "dnd" string per plat
 
 ```json
 {
-  "name": "Rocket League",
+  "details": "24H RL Stream for Charity",
+  "state": "Rocket League",
+  "name": "Twitch",
   "type": 1,
-  "url": "https://www.twitch.tv/123"
+  "url": "https://www.twitch.tv/discordapp"
 }
 ```
 


### PR DESCRIPTION
The stream title no longer appears in the name but instead in `details`. The name only shows `"Twitch"` now:

```json
{
   "assets":{
      "large_image":"twitch:example"
   },
   "name":"Twitch",
   "created_at":1573760586651,
   "details":"<Title>",
   "state":"League of Legends",
   "id":"5fe368665af3868f",
   "type":1,
   "url":"https://www.twitch.tv/example"
}
```

I'm not sure how final this new structure is so I haven't updated the example.