### PR TITLE
Mention that users can hide currently played game

### DIFF
--- a/docs/game_sdk/Activities.md
+++ b/docs/game_sdk/Activities.md
@@ -160,6 +160,7 @@ activityManager.RegisterSteam(1938123);
 ## UpdateActivity
 
 Sets a user's presence in Discord to a new activity. This has a rate limit of 5 updates per 20 seconds.
+Bear in mind that it's possible for users to hide their currently played game (User Settings -> Game Activity).
 
 Returns a `Discord.Result` via callback.
 


### PR DESCRIPTION
Activities is the feature that most devs will try out during development, some have come to me asking why their statuses weren't updating, in both cases they had forgotten that they disabled this feature in their settings.