### PR TITLE
Add member field to Typing Start Event Fields

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -930,13 +930,13 @@ Sent when a user starts typing in a channel.
 
 ###### Typing Start Event Fields
 
-| Field      | Type                                                       | Description                                            |
-| ---------- | ---------------------------------------------------------- | ------------------------------------------------------ |
-| channel_id | snowflake                                                  | id of the channel                                      |
-| guild_id?  | snowflake                                                  | id of the guild                                        |
-| user_id    | snowflake                                                  | id of the user                                         |
-| timestamp  | integer                                                    | unix time (in seconds) of when the user started typing |
-| member     | [member](#DOCS_RESOURCES_GUILD/guild-member-object) object | the member who started typing                          |
+| Field      | Type                                                       | Description                                               |
+| ---------- | ---------------------------------------------------------- | --------------------------------------------------------- |
+| channel_id | snowflake                                                  | id of the channel                                         |
+| guild_id?  | snowflake                                                  | id of the guild                                           |
+| user_id    | snowflake                                                  | id of the user                                            |
+| timestamp  | integer                                                    | unix time (in seconds) of when the user started typing    |
+| member?    | [member](#DOCS_RESOURCES_GUILD/guild-member-object) object | the member who started typing if this happened in a guild |
 
 #### User Update
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -930,12 +930,13 @@ Sent when a user starts typing in a channel.
 
 ###### Typing Start Event Fields
 
-| Field      | Type      | Description                                            |
-| ---------- | --------- | ------------------------------------------------------ |
-| channel_id | snowflake | id of the channel                                      |
-| guild_id?  | snowflake | id of the guild                                        |
-| user_id    | snowflake | id of the user                                         |
-| timestamp  | integer   | unix time (in seconds) of when the user started typing |
+| Field      | Type                                                       | Description                                            |
+| ---------- | ---------------------------------------------------------- | ------------------------------------------------------ |
+| channel_id | snowflake                                                  | id of the channel                                      |
+| guild_id?  | snowflake                                                  | id of the guild                                        |
+| user_id    | snowflake                                                  | id of the user                                         |
+| timestamp  | integer                                                    | unix time (in seconds) of when the user started typing |
+| member     | [member](#DOCS_RESOURCES_GUILD/guild-member-object) object | the member who started typing                          |
 
 #### User Update
 


### PR DESCRIPTION
There is a new optional member field in typing start event fields as shown here:
```json
{
  "t": "TYPING_START",
  "s": 6,
  "op": 0,
  "d": {
    "user_id": "XXXXXXXXXX",
    "timestamp": 1574970936,
    "member": {
      "user": {
        "username": "Shadorc",
        "id": "XXXXXXXXXX",
        "discriminator": "8423",
        "avatar": "98a5d76eb4384bb5918ceeab009e4c11"
      },
      "roles": [],
      "mute": false,
      "joined_at": "2017-07-25T08:09:41.111000+00:00",
      "hoisted_role": null,
      "deaf": false
    },
    "channel_id": "XXXXXXXXXX",
    "guild_id": "XXXXXXXXX"
  }
}
```