### PR TITLE
Removed games from the Premium Types enum

### DIFF
--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -83,8 +83,8 @@ There are other rules and restrictions not shared here for the sake of spam and 
 
 | Value | Name          | Description                                                                           |
 | ----- | ------------- | ------------------------------------------------------------------------------------- |
-| 1     | Nitro Classic | includes app perks like animated emojis and avatars, but not games or server boosting |
-| 2     | Nitro         | includes app perks as well as the games subscription service and server boosting      |
+| 1     | Nitro Classic | includes app perks like animated emojis and avatars, but not server boosting          |
+| 2     | Nitro         | includes app perks as well as server boosting                                         |
 
 ### Connection Object
 

--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -81,10 +81,12 @@ There are other rules and restrictions not shared here for the sake of spam and 
 
 ###### Premium Types
 
-| Value | Name          | Description                                                                           |
-| ----- | ------------- | ------------------------------------------------------------------------------------- |
-| 1     | Nitro Classic | includes app perks like animated emojis and avatars, but not server boosting          |
-| 2     | Nitro         | includes app perks as well as server boosting                                         |
+Premium types denote the level of premium a user has. Visit the [Nitro](https://discordapp.com/nitro) page to learn more about the premium plans we currently offer.
+
+| Value | Name          |
+| ----- | ------------- |
+| 1     | Nitro Classic |
+| 2     | Nitro         |
 
 ### Connection Object
 


### PR DESCRIPTION
Since the removal of the Nitro Games store, it seems that the docs haven't been updated yet.