### PR TITLE
fix: remove ineffective mitigation from warning

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -556,7 +556,7 @@ Returns a specific message in the channel. If operating on a guild channel, this
 > Before using this endpoint, you must connect to and identify with a [gateway](#DOCS_TOPICS_GATEWAY/gateways) at least once.
 
 > warn
-> Discord may strip certain characters from message content, like invalid unicode characters or characters which cause unexpected message formatting. If you are passing user-generated strings into message content, consider sanitizing the data to prevent unexpected behavior. For example, to prevent unexpected mentions you could consider stripping `@` characters or placing a zero-width space (U-200B) after them.
+> Discord may strip certain characters from message content, like invalid unicode characters or characters which cause unexpected message formatting. If you are passing user-generated strings into message content, consider sanitizing the data to prevent unexpected behavior. For example, to prevent unexpected mentions you could consider stripping `@` characters.
 
 Post a message to a guild text or DM channel. If operating on a guild channel, this endpoint requires the `SEND_MESSAGES` permission to be present on the current user. If the `tts` field is set to `true`, the `SEND_TTS_MESSAGES` permission is required for the message to be spoken. Returns a [message](#DOCS_RESOURCES_CHANNEL/message-object) object. Fires a [Message Create](#DOCS_TOPICS_GATEWAY/message-create) Gateway event. See [message formatting](#DOCS_REFERENCE/message-formatting) for more information on how to properly format messages.
 


### PR DESCRIPTION
Per #1241, messages with >250 special characters (in a row?) will have all special characters stripped from the message, including U-200B.  When this occurs, the U-200B placed between the "@" and "e" will also be stripped, making this method of mention mitigation ineffective.

While U-200B can be used to mitigate mentions if done with care, I think the complexity of this caveat means that most users will not implement effective mitigations, and thus be blindly vulnerable to the issue. Suggesting bot developers strip all "@" characters when an uncontrolled message is sent is a safer and more thorough solution.