### PR TITLE
Add premium_since field to Guild Member Update

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -636,7 +636,7 @@ Sent when a guild member is updated.
 | roles         | array of snowflakes                               | user role ids                                      |
 | user          | a [user](#DOCS_RESOURCES_USER/user-object) object | the user                                           |
 | nick          | string                                            | nickname of the user in the guild                  |
-| premium_since | ?ISO8601 timestamp                                | when the user used their Nitro boost on the server |
+| premium_since | ?ISO8601 timestamp                                | when the user used their Nitro boost on the guild |
 
 #### Guild Members Chunk
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -630,13 +630,13 @@ Sent when a user is removed from a guild (leave/kick/ban).
 Sent when a guild member is updated.
 
 ###### Guild Member Update Event Fields
-
-| Field    | Type                                              | Description                       |
-| -------- | ------------------------------------------------- | --------------------------------- |
-| guild_id | snowflake                                         | the id of the guild               |
-| roles    | array of snowflakes                               | user role ids                     |
-| user     | a [user](#DOCS_RESOURCES_USER/user-object) object | the user                          |
-| nick     | string                                            | nickname of the user in the guild |
+| Field         | Type                                              | Description                                        |
+| ------------- | ------------------------------------------------- | -------------------------------------------------- |
+| guild_id      | snowflake                                         | the id of the guild                                |
+| roles         | array of snowflakes                               | user role ids                                      |
+| user          | a [user](#DOCS_RESOURCES_USER/user-object) object | the user                                           |
+| nick          | string                                            | nickname of the user in the guild                  |
+| premium_since | ?ISO8601 timestamp                                | when the user used their Nitro boost on the server |
 
 #### Guild Members Chunk
 


### PR DESCRIPTION
Example:
```json
{
  "t": "GUILD_MEMBER_UPDATE",
  "s": 6,
  "op": 0,
  "d": {
    "user": {
      "username": "Shadorc",
      "id": "XXXXXXXXXX",
      "discriminator": "8423",
      "avatar": "98a5d76eb4384bb5918ceeab009e4c11"
    },
    "roles": [],
    "premium_since": null,
    "nick": "Shad",
    "guild_id": "XXXXXXXXXX"
  }
}
```