### PR TITLE
Fixes weird spacing in code blocks

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -148,9 +148,7 @@ Clients using the HTTP API must provide a valid [User Agent](https://www.w3.org/
 ###### User Agent Example
 
 ```
-
 User-Agent: DiscordBot ($url, $versionNumber)
-
 ```
 
 Clients may append more information and metadata to the _end_ of this string as they wish.
@@ -190,9 +188,7 @@ Using the markdown for either users, roles, or channels will mention the target(
 ###### Image Base Url
 
 ```
-
 https://cdn.discordapp.com/
-
 ```
 
 Discord uses ids and hashes to render images in the client. These hashes can be retrieved through various API requests, like [Get User](#DOCS_RESOURCES_USER/get-user). Below are the formats, size limitations, and CDN endpoints for images in Discord. The returned format can be changed by changing the [extension name](#DOCS_REFERENCE/image-formatting-image-formats) at the end of the URL. The returned size can be changed by appending a querystring of `?size=desired_size` to the URL. Image size can be any power of two between 16 and 2048.


### PR DESCRIPTION
![brave_jmqUMyeJ8o](https://user-images.githubusercontent.com/13603398/71324161-d8aee600-24db-11ea-84a3-4b80dde4688e.png)
![brave_loVKufp0OO](https://user-images.githubusercontent.com/13603398/71324162-d8aee600-24db-11ea-8136-3bc526ec31f9.png)

Unsure if it falls under the first rule for https://github.com/discordapp/discord-api-docs/blob/master/CONTRIBUTING.md#unwanted-changes, I apologize if it does. It just bothered me a bit how few code blocks looked like this.