### PR TITLE
`premium_subscription_count` can be `null`

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -48,7 +48,7 @@ Guilds in Discord represent an isolated collection of users and channels, and ar
 | description                   | ?string                                                                             | the description for the guild                                                                                                    |
 | banner                        | ?string                                                                             | [banner hash](#DOCS_REFERENCE/image-formatting)                                                                                  |
 | premium_tier                  | integer                                                                             | [premium tier](#DOCS_RESOURCES_GUILD/guild-object-premium-tier)                                                                  |
-| premium_subscription_count?   | integer                                                                             | the total number of users currently boosting this server                                                                         |
+| premium_subscription_count?   | ?integer                                                                            | the total number of users currently boosting this server                                                                         |
 | preferred_locale              | string                                                                              | the preferred locale of this guild only set if guild has the "DISCOVERABLE" feature, defaults to en-US                           |
 
 ** \* These fields are only sent within the [GUILD_CREATE](#DOCS_TOPICS_GATEWAY/guild-create) event **


### PR DESCRIPTION
As far as I can tell from the payloads I have been looking at
is that all of them, but I may be wrong. This is a followup to
the pr #1284.