### PR TITLE
Add missing Dispatch commands

### DIFF
--- a/docs/dispatch/List_of_Commands.md
+++ b/docs/dispatch/List_of_Commands.md
@@ -199,7 +199,6 @@ Downloads the build for the given application id and branch id to the given inst
 
 Mark a build as corrupted.
 
-
 ###### Arguments
 
 | name           | values | description                   |
@@ -218,7 +217,6 @@ Corrupted build "491362538965958686"
 
 Displays a preview of the install paths that a build will put files in, for a given platform/locale. Additionally, will show which files are considered user data.
 
-
 ###### Arguments
 
 | name             | values                                                                        | description                                                                                           
@@ -232,6 +230,26 @@ Displays a preview of the install paths that a build will put files in, for a gi
 
 ```
 -> build preview-files config.json . --locale en-US --platform win64
+```
+
+## build repair
+
+Repairs an application build.
+
+###### Arguments
+
+| name             | values                                                           | description                                                                                           |
+| ---------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| application_id   | int                                                              | your application ID/client ID                                                                         |
+| branch_id        | int                                                              | the id of the branch to check                                                                         |
+| build_id         | int                                                              | the id of the build to reapir                                                                         |
+| application_root | file path                                                        | the directory that dispatch will treat as the local root for operations—`.` for the current directory |
+| --platform       | [platform](#DOCS_DISPATCH_FIELD_VALUES/manifest-platform-values) | the build platform to reapair                                                                         |
+
+###### Example
+
+```
+-> build repair 290926444748734465 491362538965958686 491362538965958686 . --platform win64
 ```
 
 ## completions generate

--- a/docs/dispatch/List_of_Commands.md
+++ b/docs/dispatch/List_of_Commands.md
@@ -195,6 +195,24 @@ Downloads the build for the given application id and branch id to the given inst
 -> dispatch build update 290926444748734465 491362538965958686 C:\my-game --platform win64 --locale en-US
 ```
 
+## build corrupt
+
+Mark a build as corrupted.
+
+
+###### Arguments
+
+| name           | values | description                   |
+| -------------- | ------ | ----------------------------- |
+| application_id | int    | your application ID/client ID |
+| build_id       | int    | the id of the build to delete |
+
+###### Example
+
+```
+-> dispatch build corrupt 290926444748734465 491362538965958686
+```
+
 ## completions generate
 
 Generations shell command completions; run `dispatch completions --help` for more info, as it varies by shell

--- a/docs/dispatch/List_of_Commands.md
+++ b/docs/dispatch/List_of_Commands.md
@@ -205,12 +205,33 @@ Mark a build as corrupted.
 | name           | values | description                   |
 | -------------- | ------ | ----------------------------- |
 | application_id | int    | your application ID/client ID |
-| build_id       | int    | the id of the build to delete |
+| build_id       | int    | the id of the build to corrupt|
 
 ###### Example
 
 ```
 -> dispatch build corrupt 290926444748734465 491362538965958686
+Corrupted build "491362538965958686"
+```
+
+## build preview-files
+
+Displays a preview of the install paths that a build will put files in, for a given platform/locale. Additionally, will show which files are considered user data.
+
+
+###### Arguments
+
+| name             | values                                                                        | description                                                                                           
+| ---------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| config_file      | filename                                                                      | the [JSON config file](#DOCS_DISPATCH_BRANCHES_AND_BUILDS/setting-up-our-first-build) for the build   |
+| application_root | file path                                                                     | the directory that dispatch will treat as the local root for operations—`.` for the current directory |
+| --locale         | [locale](#DOCS_DISPATCH_FIELD_VALES/predefined-field-values-accepted-locales) | the build locale to preview                                                                           |
+| --platform       | [platform](#DOCS_DISPATCH_FIELD_VALUES/manifest-platform-values)              | the build platform to preview                                                                         |
+
+###### Example
+
+```
+-> build preview-files config.json . --locale en-US --platform win64
 ```
 
 ## completions generate

--- a/docs/dispatch/List_of_Commands.md
+++ b/docs/dispatch/List_of_Commands.md
@@ -249,7 +249,24 @@ Repairs an application build.
 ###### Example
 
 ```
--> build repair 290926444748734465 491362538965958686 491362538965958686 . --platform win64
+-> build repair 290926444748734465 491362538965958686 489230031839821824 . --platform win64
+```
+
+## build run-launch-setup
+
+Runs the launch setup for an application.
+
+###### Arguments
+
+| name             | values                                                           | description                                                                                           |
+| ---------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| application_root | file path                                                        | the directory that dispatch will treat as the local root for operations—`.` for the current directory |
+| --platform       | [platform](#DOCS_DISPATCH_FIELD_VALUES/manifest-platform-values) | the build platform to do the launch setup                                                             |
+
+###### Example
+
+```
+-> build run-launch-setup . --platform win64
 ```
 
 ## completions generate


### PR DESCRIPTION
Added:
- dispatch build corrupt
- dispatch build preview-files
- dispatch build repair
- dispatch build run-launch-setup

These were some missing commands.