### PR TITLE
Dispatch: Fix a typo under "multiple-manifests-and-dlc-content"

### DIFF
--- a/docs/dispatch/Branches_and_Builds.md
+++ b/docs/dispatch/Branches_and_Builds.md
@@ -546,7 +546,7 @@ Your manifest would look something like this:
           "mappings": [
             {
               "local_path": ".",
-              "install_Path": "./game_data/Assets/AssetBundles/DLC" // Puts the DLC in the proper folder structure
+              "install_path": "./game_data/Assets/AssetBundles/DLC" // Puts the DLC in the proper folder structure
             }
           ]
         }


### PR DESCRIPTION
Changes "install_Path" to "install_path" on line 549, "install_Path" being an invalid field. 