### PR TITLE
Document undeletable channels for Public servers

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -648,6 +648,9 @@ Delete a channel, or close a private message. Requires the `MANAGE_CHANNELS` per
 > warn
 > Deleting a guild channel cannot be undone. Use this with caution, as it is impossible to undo this action when performed on a guild channel. In contrast, when used with a private message, it is possible to undo the action by opening a private message with the recipient again.
 
+> info
+> For Public servers, the set Rules or Guidelines channel and the Moderators-only (Public Server Updates) channel cannot be deleted.
+
 ## Get Channel Messages % GET /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/messages
 
 Returns the messages for a channel. If operating on a guild channel, this endpoint requires the `VIEW_CHANNEL` permission to be present on the current user. If the current user is missing the 'READ_MESSAGE_HISTORY' permission in the channel then this will return no messages (since they cannot read the message history). Returns an array of [message](#DOCS_RESOURCES_CHANNEL/message-object) objects on success.


### PR DESCRIPTION
For Public servers, the "rules or guidelines channel" and the "moderators-only channel" cannot be deleted, failing with the error "Cannot delete a channel required for public servers". This PR documents that.