### PR TITLE
Fix broken link for allowed mention types

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -512,11 +512,11 @@ The allowed mention field allows for more granular control over mentions without
 
 ###### Allowed Mentions Structure
 
-| Field | Type                           | Description                                                                                                   |
-| ----- | ------------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| parse | array of allowed mention types | An array of [allowed mention types](#DOCS_RESOURCES_CHANNEL/allowed-mention-types) to parse from the content. |
-| roles | list of snowflakes             | Array of role_ids to mention (Max size of 100)                                                                |
-| users | list of snowflakes             | Array of user_ids to mention (Max size of 100)                                                                |
+| Field | Type                           | Description                                                                                                                           |
+| ----- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| parse | array of allowed mention types | An array of [allowed mention types](#DOCS_RESOURCES_CHANNEL/allowed-mentions-object-allowed-mention-types) to parse from the content. |
+| roles | list of snowflakes             | Array of role_ids to mention (Max size of 100)                                                                                        |
+| users | list of snowflakes             | Array of user_ids to mention (Max size of 100)                                                                                        |
 
 ###### Allowed Mentions Reference
 


### PR DESCRIPTION
The link for [Allowed mention types](https://discordapp.com/developers/docs/resources/channel#allowed-mentions-object-allowed-mention-types) is currently broken as it links to `allowed-mention-types` instead of `allowed-mentions-object-allowed-mention-types`

This is corrected in this PR.