### PR TITLE
Fix Create Reaction endpoint listing

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -753,7 +753,7 @@ For example:
 > info
 > The the following endpoints, `emoji` takes the form of `name:id` for custom guild emoji, or Unicode characters.
 
-## Create Reaction % PUT /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/messages/{message.id#DOCS_RESOURCES_CHANNEL/message-object}/reactions/{emoji#DOCS_RESOURCES_EMOJI/emoji-object}
+## Create Reaction % PUT /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/messages/{message.id#DOCS_RESOURCES_CHANNEL/message-object}/reactions/{emoji#DOCS_RESOURCES_EMOJI/emoji-object}/@me
 
 Create a reaction for the message. This endpoint requires the 'READ_MESSAGE_HISTORY' permission to be present on the current user. Additionally, if nobody else has reacted to the message using this emoji, this endpoint requires the 'ADD_REACTIONS' permission to be present on the current user. Returns a 204 empty response on success.
 The `emoji` must be [URL Encoded](https://en.wikipedia.org/wiki/Percent-encoding) or the request will fail with `10014: Unknown Emoji`.


### PR DESCRIPTION
It appears this endpoint listing was mistakenly modified in 33ecdc9. 
The currently listed endpoint will fail with 405.