### PR TITLE
Fix typo in info tip for reaction endpoints

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -755,7 +755,7 @@ For example:
 > Only filenames with proper image extensions are supported for the time being.
 
 > info
-> The the following endpoints, `emoji` takes the form of `name:id` for custom guild emoji, or Unicode characters.
+> For the following endpoints, `emoji` takes the form of `name:id` for custom guild emoji, or Unicode characters.
 
 ## Create Reaction % PUT /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/messages/{message.id#DOCS_RESOURCES_CHANNEL/message-object}/reactions/{emoji#DOCS_RESOURCES_EMOJI/emoji-object}/@me
 


### PR DESCRIPTION
In the "Channel" resource above where the reaction endpoints are listed, there is an information message with a minor typo (includes a second "the"). I'm just assuming the intended word was "for".