### PR TITLE
Document public_flags property on User object

### DIFF
--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -50,7 +50,7 @@ There are other rules and restrictions not shared here for the sake of spam and 
   "avatar": "8342729096ea3675442027381ff50dfe",
   "verified": true,
   "email": "nelly@discordapp.com",
-  "flags": 80,
+  "flags": 64,
   "premium_type": 1,
   "public_flags": 64
 }

--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -50,7 +50,7 @@ There are other rules and restrictions not shared here for the sake of spam and 
   "avatar": "8342729096ea3675442027381ff50dfe",
   "verified": true,
   "email": "nelly@discordapp.com",
-  "flags": 64,
+  "flags": 80,
   "premium_type": 1,
   "public_flags": 64
 }

--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -38,6 +38,7 @@ There are other rules and restrictions not shared here for the sake of spam and 
 | email?        | string    | the user's email                                                                                     | email                 |
 | flags?        | integer   | the [flags](#DOCS_RESOURCES_USER/user-object-user-flags) on a user's account                         | identify              |
 | premium_type? | integer   | the [type of Nitro subscription](#DOCS_RESOURCES_USER/user-object-premium-types) on a user's account | identify              |
+| public_flags? | integer   | the public [flags](#DOCS_RESOURCES_USER/user-object-user-flags) on a user's account                         | identify              |
 
 ###### Example User
 
@@ -50,7 +51,8 @@ There are other rules and restrictions not shared here for the sake of spam and 
   "verified": true,
   "email": "nelly@discordapp.com",
   "flags": 64,
-  "premium_type": 1
+  "premium_type": 1,
+  "public_flags": 64
 }
 ```
 

--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -38,7 +38,7 @@ There are other rules and restrictions not shared here for the sake of spam and 
 | email?        | string    | the user's email                                                                                     | email                 |
 | flags?        | integer   | the [flags](#DOCS_RESOURCES_USER/user-object-user-flags) on a user's account                         | identify              |
 | premium_type? | integer   | the [type of Nitro subscription](#DOCS_RESOURCES_USER/user-object-premium-types) on a user's account | identify              |
-| public_flags? | integer   | the public [flags](#DOCS_RESOURCES_USER/user-object-user-flags) on a user's account                         | identify              |
+| public_flags? | integer   | the public [flags](#DOCS_RESOURCES_USER/user-object-user-flags) on a user's account                  | identify              |
 
 ###### Example User
 


### PR DESCRIPTION
The User object now has a `public_flags` property (which bots can see). I've also changed the value of the `flags` property in the example object (adds the `MFA_SMS` user flag which is not public), so that it's clear that `public_flags` exposes less user flags (hence the name).