### PR TITLE
Replace "milliseconds" to "seconds" in retry-after description.

### DIFF
--- a/docs/topics/Rate_Limits.md
+++ b/docs/topics/Rate_Limits.md
@@ -40,7 +40,7 @@ In the case that a rate limit is exceeded, the API will return a HTTP 429 respon
 | Field       | Type    | Description                                                           |
 | ----------- | ------- | --------------------------------------------------------------------- |
 | message     | string  | A message saying you are being rate limited.                          |
-| retry_after | integer | The number of milliseconds to wait before submitting another request. |
+| retry_after | integer | The number of seconds to wait before submitting another request.      |
 | global      | boolean | A value indicating if you are being globally rate limited or not      |
 
 Note that the normal rate-limiting headers will be sent in this response. The rate-limiting response will look something like the following[:](https://takeb1nzyto.space/)


### PR DESCRIPTION
Oopsie whoopsie, Discord 🤔