### PR TITLE
chore: Add GuildMember#hoisted_role

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -252,15 +252,19 @@ A partial [guild](#DOCS_RESOURCES_GUILD/guild-object) object. Represents an Offl
 
 ###### Guild Member Structure
 
-| Field          | Type                                            | Description                                                                                                                |
-| -------------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| user?          | [user](#DOCS_RESOURCES_USER/user-object) object | the user this guild member represents                                                                                      |
-| nick           | ?string                                         | this users guild nickname                                                                                                  |
-| roles          | array of snowflakes                             | array of [role](#DOCS_TOPICS_PERMISSIONS/role-object) object ids                                                           |
-| joined_at      | ISO8601 timestamp                               | when the user joined the guild                                                                                             |
-| premium_since? | ?ISO8601 timestamp                              | when the user started [boosting](https://support.discord.com/hc/en-us/articles/360028038352-Server-Boosting-) the guild |
-| deaf           | boolean                                         | whether the user is deafened in voice channels                                                                             |
-| mute           | boolean                                         | whether the user is muted in voice channels                                                                                |
+| Field           | Type                                            | Description                                                                                                                |
+| --------------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| user?           | [user](#DOCS_RESOURCES_USER/user-object) object | the user this guild member represents                                                                                      |
+| nick            | ?string                                         | this users guild nickname                                                                                                  |
+| roles           | array of snowflakes                             | array of [role](#DOCS_TOPICS_PERMISSIONS/role-object) object ids                                                           |
+| joined_at       | ISO8601 timestamp                               | when the user joined the guild                                                                                             |
+| premium_since?  | ?ISO8601 timestamp                              | when the user started [boosting](https://support.discord.com/hc/en-us/articles/360028038352-Server-Boosting-) the guild    |
+| deaf            | boolean                                         | whether the user is deafened in voice channels                                                                             |
+| mute            | boolean                                         | whether the user is muted in voice channels                                                                                |
+| hoisted_role?\* | ?string                                         | role id that represents the member's hoisted role in the guild                                                             |
+
+\* The `hoisted_role` property is provided only on the author's member object obtained from [MESSAGE_CREATE](#DOCS_TOPICS_GATEWAY/message-create) and [MESSAGE_UPDATE](#DOCS_TOPICS_GATEWAY/message-update) events.
+It is also present on each member object that is part of a [Message Object's](#DOCS_RESOURCES_CHANNEL/message-object) `mentions` item, provided that it comes from a [MESSAGE_CREATE](#DOCS_TOPICS_GATEWAY/message-create) event.
 
 > info
 > The field `user` won't be included in the member object attached to `MESSAGE_CREATE` and `MESSAGE_UPDATE` gateway events.

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -261,7 +261,7 @@ A partial [guild](#DOCS_RESOURCES_GUILD/guild-object) object. Represents an Offl
 | premium_since?  | ?ISO8601 timestamp                              | when the user started [boosting](https://support.discord.com/hc/en-us/articles/360028038352-Server-Boosting-) the guild    |
 | deaf            | boolean                                         | whether the user is deafened in voice channels                                                                             |
 | mute            | boolean                                         | whether the user is muted in voice channels                                                                                |
-| hoisted_role?\* | ?string                                         | role id that represents the member's hoisted role in the guild                                                             |
+| hoisted_role?\* | ?snowflake                                      | role id that represents the member's hoisted role in the guild                                                             |
 
 \* The `hoisted_role` property is provided only on the author's member object obtained from [MESSAGE_CREATE](#DOCS_TOPICS_GATEWAY/message-create) and [MESSAGE_UPDATE](#DOCS_TOPICS_GATEWAY/message-update) events.
 It is also present on each member object that is part of a [Message Object's](#DOCS_RESOURCES_CHANNEL/message-object) `mentions` item, provided that it comes from a [MESSAGE_CREATE](#DOCS_TOPICS_GATEWAY/message-create) event.


### PR DESCRIPTION
The wording of this parameter might need some changing around as it could be confusing (I tried my best to make it as clear as possible)

Should the notice for the `mentions` object be added to messages as an `info` block? Or is it placed where it should be?

Thanks!