### PR TITLE
Fix optional operator column position

### DIFF
--- a/docs/resources/Voice.md
+++ b/docs/resources/Voice.md
@@ -9,7 +9,7 @@ Used to represent a user's voice connection status.
 | Field        | Type                                                             | Description                                    |
 | ------------ | ---------------------------------------------------------------- | ---------------------------------------------- |
 | guild_id?    | snowflake                                                        | the guild id this voice state is for           |
-| channel_id   | ?snowflake                                                       | the channel id this user is connected to       |
+| channel_id?  | snowflake                                                        | the channel id this user is connected to       |
 | user_id      | snowflake                                                        | the user id this voice state is for            |
 | member?      | [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object | the guild member this voice state is for       |
 | session_id   | string                                                           | the session id for this voice state            |


### PR DESCRIPTION
The optional operator indicating that the `channel_id` of a voice state object was in the wrong column. It was next to `snowflake` in the `Type` column and should be appended in the `Field` column instead. 