### PR TITLE
chore: document missing properties in Modify Channel Positions endpoint

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -546,10 +546,11 @@ This endpoint takes a JSON array of parameters in the following format:
 
 ###### JSON Params
 
-| Field    | Type      | Description                     |
-| -------- | --------- | ------------------------------- |
-| id       | snowflake | channel id                      |
-| position | ?integer  | sorting position of the channel |
+| Field            | Type      | Description                                                                      |
+| ---------------- | --------- | -------------------------------------------------------------------------------- |
+| id               | snowflake | channel id                                                                       |
+| position         | ?integer  | sorting position of the channel                                                  |
+| lock_permissions | ?boolean  | syncs the permission overwrites with the new parent, if moving to a new category |
 
 ## Get Guild Member % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/members/{user.id#DOCS_RESOURCES_USER/user-object}
 

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -551,7 +551,7 @@ This endpoint takes a JSON array of parameters in the following format:
 | id               | snowflake  | channel id                                                                       |
 | position         | ?integer   | sorting position of the channel                                                  |
 | lock_permissions | ?boolean   | syncs the permission overwrites with the new parent, if moving to a new category |
-| parent_id        | ?snowflake | The new parent ID for the channel that is moved                                  |
+| parent_id        | ?snowflake | the new parent ID for the channel that is moved                                  |
 
 ## Get Guild Member % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/members/{user.id#DOCS_RESOURCES_USER/user-object}
 

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -546,11 +546,12 @@ This endpoint takes a JSON array of parameters in the following format:
 
 ###### JSON Params
 
-| Field            | Type      | Description                                                                      |
-| ---------------- | --------- | -------------------------------------------------------------------------------- |
-| id               | snowflake | channel id                                                                       |
-| position         | ?integer  | sorting position of the channel                                                  |
-| lock_permissions | ?boolean  | syncs the permission overwrites with the new parent, if moving to a new category |
+| Field            | Type       | Description                                                                      |
+| ---------------- | ---------- | -------------------------------------------------------------------------------- |
+| id               | snowflake  | channel id                                                                       |
+| position         | ?integer   | sorting position of the channel                                                  |
+| lock_permissions | ?boolean   | syncs the permission overwrites with the new parent, if moving to a new category |
+| parent_id        | ?snowflake | The new parent ID for the channel that is moved                                  |
 
 ## Get Guild Member % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/members/{user.id#DOCS_RESOURCES_USER/user-object}
 


### PR DESCRIPTION
This PR adds the missing `lock_permissions` value you can use when patching channel positions to sync text/voice channels permissions to the parent category, if any, as well as the missing `parent_id` property which is used to change the parent of a channel

Question: Is this how we're supposed to sync up channel permissions when setting a new parent for a text/voice/store/news/whatever-future-type channel? Should this lock_permissions be suggested to Modify Channel?