### PR TITLE
Update Discord API vanity invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ Alert boxes are achieved by using a block quote that has one of 'warn', 'danger'
 ## Join the Unofficial Discord API Server
 The Unofficial Discord API server is a common hangout for library and bot developers alike. It's a great starting point for those looking to dive in and learn bot-creation with the Discord API.
 
-[![](https://discord.com/api/guilds/81384788765712384/embed.png?style=banner1)](https://discord.gg/discord-api)
+[![](https://discord.com/api/guilds/81384788765712384/embed.png?style=banner1)](https://discord.gg/api)

--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -6,7 +6,7 @@ Discord has the best online community. At least, we like to think so, and this i
 
 The Discord team curates the following list of officially vetted libraries that conform to our APIs standards around authentication and rate limiting. Using custom implementations or non-compliant libraries that abuse the API or cause excessive rate limits may result in a **permanent** ban.
 
-Many of these libraries are represented in the [unofficial, community-driven Discord server for developers](https://discord.gg/discord-api). There you'll find community members who can help answer questions about our API, community libraries, bot creation, and other development questions.
+Many of these libraries are represented in the [unofficial, community-driven Discord server for developers](https://discord.gg/api). There you'll find community members who can help answer questions about our API, community libraries, bot creation, and other development questions.
 
 ###### Discord Libraries
 


### PR DESCRIPTION
Regrettably, the vanity invite for the Discord API server has been changed from `discord-api` to `api`. This PR updates the link in the official docs. To any readers, please spread the word and update your links in any third-party resources.