### PR TITLE
Add DisC++ to community resources.

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -14,6 +14,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | ------------------------------------------------------------ | ---------- |
 | [discljord](https://github.com/igjoshua/discljord)           | Clojure    |
 | [aegis.cpp](https://github.com/zeroxs/aegis.cpp)             | C++        |
+| [DisC++](https://github.com/DisCPP/DisCPP)                   | C++        |
 | [discordcr](https://github.com/discordcr/discordcr)          | Crystal    |
 | [Discord.Net](https://github.com/RogueException/Discord.Net) | C#         |
 | [DSharpPlus](https://github.com/DSharpPlus/DSharpPlus)       | C#         |


### PR DESCRIPTION
I would like to add my library to the community resources list. Here's my rate limiting code: [HandleRateLimits](https://github.com/DisCPP/DisCPP/blob/cf90040442e4247969cdee90d23626d871561090/src/utils.cpp#L345), and [WaitForRateLimits](https://github.com/DisCPP/DisCPP/blob/cf90040442e4247969cdee90d23626d871561090/src/utils.cpp#L286). If you need links to any other code, just ask and I can give it to you.