### PR TITLE
2020 Dev TOS Revisions

### DIFF
--- a/docs/Legal.md
+++ b/docs/Legal.md
@@ -14,7 +14,7 @@ Throughout this document, we use the word **_“Terms”_** to refer to the term
 
 ## a. Accepting the Terms
 
-By accessing or using our APIs you are agreeing to comply with the Terms and that the Terms control your relationship with us.. You are also agreeing that (i) you are 13 years of age and the minimum age of digital consent in your country, (ii) if you are the age of majority in your jurisdiction or over, that you have read, understood, and accept to be bound by the Terms, and (iii) if you are between 13 (or the minimum age of digital consent, as applicable) and the age of majority in your jurisdiction, that your legal guardian has reviewed and agrees to these Terms. Please read all the Terms carefully. 
+By accessing or using our APIs you are agreeing to comply with the Terms and that the Terms control your relationship with us. You are also agreeing that (i) you are 13 years of age and the minimum age of digital consent in your country, (ii) if you are the age of majority in your jurisdiction or over, that you have read, understood, and accept to be bound by the Terms, and (iii) if you are between 13 (or the minimum age of digital consent, as applicable) and the age of majority in your jurisdiction, that your legal guardian has reviewed and agrees to these Terms. Please read all the Terms carefully. 
 
 You may not use the APIs and may not accept the Terms if you are a person barred from using or receiving the APIs under the applicable laws of the United States or other countries including the country in which you are resident or from which you use the APIs.
 

--- a/docs/Legal.md
+++ b/docs/Legal.md
@@ -1,8 +1,8 @@
 # Discord Developer Terms of Service
 
-## Effective date: August 15, 2020 
+## Effective date: August 18, 2020 
 
-## Posted date: July 1, 2020
+## Posted date: July 15, 2020
  
 *For a link to the current terms, please see [here](https://github.com/discord/discord-api-docs/blob/b9edace323c9df64c79f104d85984690ae4e2977/docs/Legal.md).*
 
@@ -14,9 +14,9 @@ Throughout this document, we use the word **_“Terms”_** to refer to the term
 
 ## a. Accepting the Terms
 
-By accessing or using our APIs you are agreeing to comply with the Terms. You are also agreeing that the Terms control your relationship with us. Please read all the Terms carefully. 
+By accessing or using our APIs you are agreeing to comply with the Terms and that the Terms control your relationship with us.. You are also agreeing that (i) you are 13 years of age and the minimum age of digital consent in your country, (ii) if you are the age of majority in your jurisdiction or over, that you have read, understood, and accept to be bound by the Terms, and (iii) if you are between 13 (or the minimum age of digital consent, as applicable) and the age of majority in your jurisdiction, that your legal guardian has reviewed and agrees to these Terms. Please read all the Terms carefully. 
 
-You may not use the APIs and may not accept the Terms if (a) you are not of legal age to form a binding contract with Discord, or (b) you are a person barred from using or receiving the APIs under the applicable laws of the United States or other countries including the country in which you are resident or from which you use the APIs.
+You may not use the APIs and may not accept the Terms if you are a person barred from using or receiving the APIs under the applicable laws of the United States or other countries including the country in which you are resident or from which you use the APIs.
 
 If you are using the APIs on behalf of an entity, you represent and warrant that you have authority to bind that entity to the Terms and by accepting the Terms, you are doing so on behalf of that entity (and all references to "you" in the Terms refer to that entity).
 

--- a/docs/Policy.md
+++ b/docs/Policy.md
@@ -29,7 +29,6 @@ You may not use the APIs in any way to:
 - sell, license or otherwise commercialize any Discord Data; 
 - provide or direct services to children under the age of thirteen (13) in the United States or, outside of the United States, the relevant age of digital consent; 
 - process Discord Data in a way that surprises or violates Discord users’ expectations; or
-- access any unpublished portion of the APIs without express written permission from Discord.
 
 ## Don’t Do Anything Illegal, Harmful, or Otherwise Not Cool.
 

--- a/docs/Policy.md
+++ b/docs/Policy.md
@@ -28,7 +28,7 @@ You may not use the APIs in any way to:
 - obtain Discord User passwords to obtain access to Discord Data; 
 - sell, license or otherwise commercialize any Discord Data; 
 - provide or direct services to children under the age of thirteen (13) in the United States or, outside of the United States, the relevant age of digital consent; 
-- process Discord Data in a way that surprises or violates Discord users’ expectations; or
+- process Discord Data in a way that surprises or violates Discord users’ expectations.
 
 ## Don’t Do Anything Illegal, Harmful, or Otherwise Not Cool.
 


### PR DESCRIPTION
Opening a PR for visibility

---

Thank you all for your feedback about the 2020 Dev TOS changes. We've taken what you've said into account, and after some internal review, have made a few changes

# Changed "age to accept a contract" language in favor of standard TOS language

This language was confusing for lots of folks, as we don't in other places reference a "legal age to sign a binding contract". We've updated the language to reflect the language in our standard user TOS, found here: [https://discord.com/new/terms](https://discord.com/new/terms)

The legal thinking behind it is effectively the same: you must be at least 13 or the minimum age of digital consent in your own country to accept the terms, or have them reviewed by a parent or legal guardian. But this language should be more in line with what everyone's used to.

# Removed "unpublished API" clause from policy

Our API community was built on reverse engineering the Discord API to start. We recognize and appreciate that first bit of pioneering, and this clause was unnecessarily contentious. Our goal was to put a provision in place against use of APIs like our `/login` endpoint that are abused by spammers and self bots. But, we have enough provisions already against that kind of abuse, so there's no need to muddy the waters with this language.

# Updated effective date to August 18

We made changes in this PR and it'll take us a couple days for our script to send emails and System DMs to everyone, so the effective date has been updated to reflect the promised 30 day update window :)