### PR TITLE
Update documentation about new permission fields for API v6.

### DIFF
--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## New Permission Fields
+
+#### July 28, 2020
+
+Documented `permissions_new`, `allow_new`, and `deny_new` as string-serialized permission bitfields.
+
 ## Legacy Mention Behavior Deprecation
 
 #### May 11, 2020

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -29,12 +29,12 @@ Represents a guild or DM channel within Discord.
 
 ###### Channel Types
 
-| Type           | ID  | Description                                                                                                                                             |
-| -------------- | --- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| GUILD_TEXT     | 0   | a text channel within a server                                                                                                                          |
-| DM             | 1   | a direct message between users                                                                                                                          |
-| GUILD_VOICE    | 2   | a voice channel within a server                                                                                                                         |
-| GROUP_DM       | 3   | a direct message between multiple users                                                                                                                 |
+| Type           | ID  | Description                                                                                                                                          |
+| -------------- | --- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GUILD_TEXT     | 0   | a text channel within a server                                                                                                                       |
+| DM             | 1   | a direct message between users                                                                                                                       |
+| GUILD_VOICE    | 2   | a voice channel within a server                                                                                                                      |
+| GROUP_DM       | 3   | a direct message between multiple users                                                                                                              |
 | GUILD_CATEGORY | 4   | an [organizational category](https://support.discord.com/hc/en-us/articles/115001580171-Channel-Categories-101) that contains up to 50 channels      |
 | GUILD_NEWS     | 5   | a channel that [users can follow and crosspost into their own server](https://support.discord.com/hc/en-us/articles/360032008192)                    |
 | GUILD_STORE    | 6   | a channel in which game developers can [sell their game on Discord](https://discord.com/developers/docs/game-and-server-management/special-channels) |
@@ -373,14 +373,18 @@ Represents a message sent in a channel within Discord.
 
 ### Overwrite Object
 
+See [permissions](#DOCS_TOPICS_PERMISSIONS/permissions) for more information about the `allow` and `deny` fields.
+
 ###### Overwrite Structure
 
-| Field | Type      | Description               |
-| ----- | --------- | ------------------------- |
-| id    | snowflake | role or user id           |
-| type  | string    | either "role" or "member" |
-| allow | integer   | permission bit set        |
-| deny  | integer   | permission bit set        |
+| Field     | Type      | Description               |
+| --------- | --------- | ------------------------- |
+| id        | snowflake | role or user id           |
+| type      | string    | either "role" or "member" |
+| allow     | integer   | legacy permission bit set |
+| allow_new | string    | permission bit set        |
+| deny      | integer   | legacy permission bit set |
+| deny_new  | string    | permission bit set        |
 
 ### Embed Object
 
@@ -592,10 +596,10 @@ user 125 in the content.
 
 ```json
 {
-    "content": "<@123> Time for some memes.",
-    "allowed_mentions": {
-        "users": ["123", "125"]
-    }
+  "content": "<@123> Time for some memes.",
+  "allowed_mentions": {
+    "users": ["123", "125"]
+  }
 }
 ```
 
@@ -629,18 +633,18 @@ Update a channel's settings. Requires the `MANAGE_CHANNELS` permission for the g
 
 ###### JSON Params
 
-| Field                 | Type                                                                    | Description                                                                                                                                                                     | Channel Type              |
-| --------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| name                  | string                                                                  | 2-100 character channel name                                                                                                                                                    | All                       |
-| type                  | integer                                                                | the [type of channel](#DOCS_RESOURCES_CHANNEL/channel-object-channel-types); only conversion between text and news is supported and only in guilds with the "NEWS" feature      | Text, News                |
-| position              | ?integer                                                                | the position of the channel in the left-hand listing                                                                                                                            | All                       |
-| topic                 | ?string                                                                 | 0-1024 character channel topic                                                                                                                                                  | Text, News                |
-| nsfw                  | ?boolean                                                                | whether the channel is nsfw                                                                                                                                                     | Text, News, Store         |
-| rate_limit_per_user   | ?integer                                                                | amount of seconds a user has to wait before sending another message (0-21600); bots, as well as users with the permission `manage_messages` or `manage_channel`, are unaffected | Text                      |
-| bitrate               | ?integer                                                                | the bitrate (in bits) of the voice channel; 8000 to 96000 (128000 for VIP servers)                                                                                              | Voice                     |
-| user_limit            | ?integer                                                                | the user limit of the voice channel; 0 refers to no limit, 1 to 99 refers to a user limit                                                                                       | Voice                     |
-| permission_overwrites | ?array of [overwrite](#DOCS_RESOURCES_CHANNEL/overwrite-object) objects | channel or category-specific permissions                                                                                                                                        | All                       |
-| parent_id             | ?snowflake                                                              | id of the new parent category for a channel                                                                                                                                     | Text, News, Store, Voice  |
+| Field                 | Type                                                                    | Description                                                                                                                                                                     | Channel Type             |
+| --------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| name                  | string                                                                  | 2-100 character channel name                                                                                                                                                    | All                      |
+| type                  | integer                                                                 | the [type of channel](#DOCS_RESOURCES_CHANNEL/channel-object-channel-types); only conversion between text and news is supported and only in guilds with the "NEWS" feature      | Text, News               |
+| position              | ?integer                                                                | the position of the channel in the left-hand listing                                                                                                                            | All                      |
+| topic                 | ?string                                                                 | 0-1024 character channel topic                                                                                                                                                  | Text, News               |
+| nsfw                  | ?boolean                                                                | whether the channel is nsfw                                                                                                                                                     | Text, News, Store        |
+| rate_limit_per_user   | ?integer                                                                | amount of seconds a user has to wait before sending another message (0-21600); bots, as well as users with the permission `manage_messages` or `manage_channel`, are unaffected | Text                     |
+| bitrate               | ?integer                                                                | the bitrate (in bits) of the voice channel; 8000 to 96000 (128000 for VIP servers)                                                                                              | Voice                    |
+| user_limit            | ?integer                                                                | the user limit of the voice channel; 0 refers to no limit, 1 to 99 refers to a user limit                                                                                       | Voice                    |
+| permission_overwrites | ?array of [overwrite](#DOCS_RESOURCES_CHANNEL/overwrite-object) objects | channel or category-specific permissions                                                                                                                                        | All                      |
+| parent_id             | ?snowflake                                                              | id of the new parent category for a channel                                                                                                                                     | Text, News, Store, Voice |
 
 ## Delete/Close Channel % DELETE /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}
 
@@ -840,11 +844,11 @@ Edit the channel permission overwrites for a user or role in a channel. Only usa
 
 ###### JSON Params
 
-| Field | Type    | Description                                     |
-| ----- | ------- | ----------------------------------------------- |
-| allow | integer | the bitwise value of all allowed permissions    |
-| deny  | integer | the bitwise value of all disallowed permissions |
-| type  | string  | "member" for a user or "role" for a role        |
+| Field | Type              | Description                                     |
+| ----- | ----------------- | ----------------------------------------------- |
+| allow | integer or string | the bitwise value of all allowed permissions    |
+| deny  | integer or string | the bitwise value of all disallowed permissions |
+| type  | string            | "member" for a user or "role" for a role        |
 
 ## Get Channel Invites % GET /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/invites
 

--- a/docs/topics/Permissions.md
+++ b/docs/topics/Permissions.md
@@ -2,7 +2,9 @@
 
 Permissions in Discord are a way to limit and grant certain abilities to users. A set of base permissions can be configured at the guild level for different roles. When these roles are attached to users, they grant or revoke specific privileges within the guild. Along with the guild-level permissions, Discord also supports permission overwrites that can be assigned to individual guild roles or guild members on a per-channel basis.
 
-Permissions are stored within a 53-bit integer and are calculated using bitwise operations. The total permissions integer can be determined by ORing together each individual value, and flags can be checked using AND operations.
+Permissions are stored within an infinite-length integer serialized into a string, and are calculated using bitwise operations. For example, the permission value `123` will be serialized as `"123"`.We recommend deserializing the permissions using your languages' Big Integer libraries, if necessary. The total permissions integer can be determined by ORing together each individual value, and flags can be checked using AND operations.
+
+For compatibility with existing API v6 clients, the `permissions`, `allow`, and `deny` fields in roles and overwrites are still serialized as a number; however, these numbers shall not grow beyond 31 bits. During the remaining lifetime of API v6, all new permission bits will only be introduced in `permissions_new`, `allow_new` and `deny_new` fields.
 
 ```python
 # Permissions value that can Send Messages (0x800) and Add Reactions (0x40):
@@ -159,16 +161,17 @@ Roles represent a set of permissions attached to a group of users. Roles have un
 
 ###### Role Structure
 
-| Field       | Type      | Description                                      |
-| ----------- | --------- | ------------------------------------------------ |
-| id          | snowflake | role id                                          |
-| name        | string    | role name                                        |
-| color       | integer   | integer representation of hexadecimal color code |
-| hoist       | boolean   | if this role is pinned in the user listing       |
-| position    | integer   | position of this role                            |
-| permissions | integer   | permission bit set                               |
-| managed     | boolean   | whether this role is managed by an integration   |
-| mentionable | boolean   | whether this role is mentionable                 |
+| Field           | Type      | Description                                      |
+| --------------- | --------- | ------------------------------------------------ |
+| id              | snowflake | role id                                          |
+| name            | string    | role name                                        |
+| color           | integer   | integer representation of hexadecimal color code |
+| hoist           | boolean   | if this role is pinned in the user listing       |
+| position        | integer   | position of this role                            |
+| permissions     | integer   | legacy permission bit set                        |
+| permissions_new | string    | permission bit set                               |
+| managed         | boolean   | whether this role is managed by an integration   |
+| mentionable     | boolean   | whether this role is mentionable                 |
 
 Roles without colors (`color == 0`) do not count towards the final computed color in the user list.
 
@@ -182,6 +185,7 @@ Roles without colors (`color == 0`) do not count towards the final computed colo
   "hoist": true,
   "position": 1,
   "permissions": 66321471,
+  "permissions_new": "66321471",
   "managed": false,
   "mentionable": false
 }

--- a/docs/topics/Permissions.md
+++ b/docs/topics/Permissions.md
@@ -4,7 +4,7 @@ Permissions in Discord are a way to limit and grant certain abilities to users. 
 
 Permissions are stored within a variable-length integer serialized into a string, and are calculated using bitwise operations. For example, the permission value `123` will be serialized as `"123"`. For long-term stability, we recommend deserializing the permissions using your languages' Big Integer libraries. The total permissions integer can be determined by ORing together each individual value, and flags can be checked using AND operations.
 
-For compatibility with existing API v6 clients, the `permissions`, `allow`, and `deny` fields in roles and overwrites are still serialized as a number; however, these numbers shall not grow beyond 31 bits. During the remaining lifetime of API v6, all new permission bits will only be introduced in `permissions_new`, `allow_new`, and `deny_new`.
+For compatibility with existing API v6 clients, the `permissions`, `allow`, and `deny` fields in roles and overwrites are still serialized as a number; however, these numbers shall not grow beyond 31 bits. During the remaining lifetime of API v6, all new permission bits will only be introduced in `permissions_new`, `allow_new`, and `deny_new`. These `_new` fields are just for response serialization; requests with these fields should continue to use the original `permissions`, `allow`, and `deny` fields, which accept both string or number values.
 
 ```python
 # Permissions value that can Send Messages (0x800) and Add Reactions (0x40):

--- a/docs/topics/Permissions.md
+++ b/docs/topics/Permissions.md
@@ -2,9 +2,9 @@
 
 Permissions in Discord are a way to limit and grant certain abilities to users. A set of base permissions can be configured at the guild level for different roles. When these roles are attached to users, they grant or revoke specific privileges within the guild. Along with the guild-level permissions, Discord also supports permission overwrites that can be assigned to individual guild roles or guild members on a per-channel basis.
 
-Permissions are stored within an infinite-length integer serialized into a string, and are calculated using bitwise operations. For example, the permission value `123` will be serialized as `"123"`.We recommend deserializing the permissions using your languages' Big Integer libraries, if necessary. The total permissions integer can be determined by ORing together each individual value, and flags can be checked using AND operations.
+Permissions are stored within a variable-length integer serialized into a string, and are calculated using bitwise operations. For example, the permission value `123` will be serialized as `"123"`. For long-term stability, we recommend deserializing the permissions using your languages' Big Integer libraries. The total permissions integer can be determined by ORing together each individual value, and flags can be checked using AND operations.
 
-For compatibility with existing API v6 clients, the `permissions`, `allow`, and `deny` fields in roles and overwrites are still serialized as a number; however, these numbers shall not grow beyond 31 bits. During the remaining lifetime of API v6, all new permission bits will only be introduced in `permissions_new`, `allow_new` and `deny_new` fields.
+For compatibility with existing API v6 clients, the `permissions`, `allow`, and `deny` fields in roles and overwrites are still serialized as a number; however, these numbers shall not grow beyond 31 bits. During the remaining lifetime of API v6, all new permission bits will only be introduced in `permissions_new`, `allow_new`, and `deny_new`.
 
 ```python
 # Permissions value that can Send Messages (0x800) and Add Reactions (0x40):


### PR DESCRIPTION
# Summary

I'm not 100% sold on the tone of voice I used for this. In some ways, English is harder to write than code for me... Basically the documented changes are:

`permissions_new`, `deny_new`, and `allow_new` are now fields. We incentivize people to read off those if they want new permissions. However there aren't any new permissions right now, so they don't have to switch (but I didn't mention this). Old fields only get 31 bits.