### PR TITLE
Game SDK: Sizes in ImageManager examples are incorrect

### DIFF
--- a/docs/game_sdk/Images.md
+++ b/docs/game_sdk/Images.md
@@ -178,7 +178,7 @@ imageManager.Fetch(handle, false, (result, handle) =>
 ```cs
 var discord = new Discord.Discord(clientId, Discord.CreateFlags.Default);
 
-// Request user's avatar data. Sizes can be powers of 2 between 16 and 2048
+// Request user's avatar data. Sizes can be powers of 2 between 16 and 256
 imageManager.Fetch(Discord.ImageHandle.User(53908232506183680, 128), (result, handle) =>
 {
   {

--- a/docs/game_sdk/Images.md
+++ b/docs/game_sdk/Images.md
@@ -50,7 +50,7 @@ Returns a `Discord.Result` and `Discord.ImageHandle` via callback.
 var handle = new Discord.ImageHandle()
 {
   Id = 53908232506183680,
-  Size = 1024
+  Size = 256
 };
 
 imageManager.Fetch(handle, false, (result, returnedHandle) =>
@@ -83,7 +83,7 @@ Returns `Discord.ImageDimensions`.
 var handle = new Discord.ImageHandle()
 {
   Id = 53908232506183680,
-  Size = 1024
+  Size = 256
 };
 var dimensions =  imageManager.GetDimensions(handle);
 ```
@@ -106,7 +106,7 @@ Gets the image data for a given user's avatar. In C#, this is overloaded by a he
 var handle = new Discord.ImageHandle()
 {
   Id = 53908232506183680,
-  Size = 1024
+  Size = 256
 };
 
 imageManager.Fetch(handle, false, (result, handle) =>
@@ -160,7 +160,7 @@ Returns a `Texture2D`.
 var handle = new Discord.ImageHandle()
 {
   Id = 53908232506183680,
-  Size = 1024
+  Size = 256
 };
 
 imageManager.Fetch(handle, false, (result, handle) =>


### PR DESCRIPTION
Valid sizes are 16, 32, 64, 128, 256 (as far as I know). Any other size would cause a InvalidPayload result.