### PR TITLE
Add Twilight for Rust

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -35,6 +35,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [discordrb](https://github.com/discordrb/discordrb)          | Ruby       |
 | [discord-rs](https://github.com/SpaceManiac/discord-rs)      | Rust       |
 | [Serenity](https://github.com/serenity-rs/serenity)          | Rust       |
+| [Twilight](https://github.com/twilight-rs/twilight)          | Rust       |
 | [AckCord](https://github.com/Katrix/AckCord)                 | Scala      |
 | [Sword](https://github.com/Azoy/Sword)                       | Swift      |
 | [Discordeno](https://github.com/Skillz4Killz/Discordeno)     | TypeScript |


### PR DESCRIPTION
[Twilight](https://github.com/twilight-rs/twilight) is a flexible and scalable ecosystem of Rust libraries for the Discord API. It's designed to cater towards those who are experienced with Rust and already familiar with Discord bots and the API in general.

[Crates on crates.io](https://crates.io/teams/github:twilight-rs:core)
[Organisation](https://github.com/twilight-rs)
[Primary API repo](https://github.com/twilight-rs/twilight)
[The Book](https://twilight.rs)
[Development API docs](https://api.twilight.rs)

HTTP ratelimiting:

[Module source](https://github.com/twilight-rs/twilight/tree/trunk/http/src/ratelimiting)
Bucket ratelimits:
- [When the global limited header is received](https://github.com/twilight-rs/twilight/blob/a41550a03782b2b60bbab4150867a51ff9809e59/http/src/ratelimiting/bucket.rs#L206-L209)
- [Locking](https://github.com/twilight-rs/twilight/blob/a41550a03782b2b60bbab4150867a51ff9809e59/http/src/ratelimiting/bucket.rs#L235-L238)

Gateway session ratelimiting:

A [queue trait](https://github.com/twilight-rs/twilight/tree/a41550a03782b2b60bbab4150867a51ff9809e59/gateway/src/queue) is provided with default implementations and can be implemented by users, such as when working with multi-serviced applications:
- [Timed delay for requests](https://github.com/twilight-rs/twilight/blob/a41550a03782b2b60bbab4150867a51ff9809e59/gateway/src/queue/mod.rs#L121-L149)
- Shards making queue requests to initialize new sessions:
  - [gateway/src/shard/processor/impl.rs#L258](https://github.com/twilight-rs/twilight/blob/a41550a03782b2b60bbab4150867a51ff9809e59/gateway/src/shard/processor/impl.rs#L258)
  - [gateway/src/shard/processor/impl.rs#L766](https://github.com/twilight-rs/twilight/blob/a41550a03782b2b60bbab4150867a51ff9809e59/gateway/src/shard/processor/impl.rs#L766)