### PR TITLE
Add invite links to discord for libraries

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -39,7 +39,6 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [Sword](https://github.com/Azoy/Sword)                       | Swift      |                                               |
 | [Discordeno](https://github.com/Skillz4Killz/Discordeno)     | TypeScript | [Invite](https://discord.gg/J4NqJ72)          |
 
-
 ## Game SDK Tools
 
 Discord Game SDK's lobby and networking layer shares similarities with other gaming platforms (i.e. Valve's Steamworks SDK). The following open source library provides developers a uniform interface for these shared features and can simplify developing for multiple platforms. Note: this library is tailored for Unity3D development.

--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -10,34 +10,35 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 
 ###### Discord Libraries
 
-| Name                                                         | Language   |
-| ------------------------------------------------------------ | ---------- |
-| [discljord](https://github.com/igjoshua/discljord)           | Clojure    |
-| [aegis.cpp](https://github.com/zeroxs/aegis.cpp)             | C++        |
-| [discordcr](https://github.com/discordcr/discordcr)          | Crystal    |
-| [Discord.Net](https://github.com/RogueException/Discord.Net) | C#         |
-| [DSharpPlus](https://github.com/DSharpPlus/DSharpPlus)       | C#         |
-| [dscord](https://github.com/b1naryth1ef/dscord)              | D          |
-| [DiscordGo](https://github.com/bwmarrin/discordgo)           | Go         |
-| [DisGord](https://github.com/andersfylling/disgord)          | Go         |
-| [catnip](https://github.com/mewna/catnip)                    | Java       |
-| [Discord4J](https://discord4j.com/)                          | Java       |
-| [Javacord](https://github.com/Javacord/Javacord)             | Java       |
-| [JDA](https://github.com/DV8FromTheWorld/JDA)                | Java       |
-| [discord.js](https://github.com/discordjs/discord.js)        | JavaScript |
-| [Eris](https://github.com/abalabahaha/eris)                  | JavaScript |
-| [Discord.jl](https://github.com/Xh4H/Discord.jl)             | Julia      |
-| [Discordia](https://github.com/SinisterRectus/Discordia)     | Lua        |
-| [discordnim](https://github.com/Krognol/discordnim)          | Nim        |
-| [RestCord](https://www.restcord.com/)                        | PHP        |
-| [discord.py](https://github.com/Rapptz/discord.py)           | Python     |
-| [disco](https://github.com/b1naryth1ef/disco)                | Python     |
-| [discordrb](https://github.com/discordrb/discordrb)          | Ruby       |
-| [discord-rs](https://github.com/SpaceManiac/discord-rs)      | Rust       |
-| [Serenity](https://github.com/serenity-rs/serenity)          | Rust       |
-| [AckCord](https://github.com/Katrix/AckCord)                 | Scala      |
-| [Sword](https://github.com/Azoy/Sword)                       | Swift      |
-| [Discordeno](https://github.com/Skillz4Killz/Discordeno)     | TypeScript |
+| Name                                                         | Language   | Discord Server                                |
+| ------------------------------------------------------------ | ---------- | --------------------------------------------- | 
+| [discljord](https://github.com/igjoshua/discljord)           | Clojure    | [Invite](https://discord.gg/284PgKZ)          |
+| [aegis.cpp](https://github.com/zeroxs/aegis.cpp)             | C++        |                                               |
+| [discordcr](https://github.com/discordcr/discordcr)          | Crystal    |                                               |
+| [Discord.Net](https://github.com/RogueException/Discord.Net) | C#         |                                               |
+| [DSharpPlus](https://github.com/DSharpPlus/DSharpPlus)       | C#         | [Invite](https://discord.gg/KeAS3pU)          |
+| [dscord](https://github.com/b1naryth1ef/dscord)              | D          |                                               |
+| [DiscordGo](https://github.com/bwmarrin/discordgo)           | Go         | [Invite](https://discord.gg/0f1SbxBZjYq9jLBk) |
+| [DisGord](https://github.com/andersfylling/disgord)          | Go         |                                               |
+| [catnip](https://github.com/mewna/catnip)                    | Java       |                                               |
+| [Discord4J](https://discord4j.com/)                          | Java       | [Invite](https://discord.gg/NxGAeCY)          |
+| [Javacord](https://github.com/Javacord/Javacord)             | Java       | [Invite](https://discord.gg/0qJ2jjyneLEgG7y3) |
+| [JDA](https://github.com/DV8FromTheWorld/JDA)                | Java       | [Invite](https://discord.gg/0hMr4ce0tIk3pSjp) |
+| [discord.js](https://github.com/discordjs/discord.js)        | JavaScript | [Invite](https://discord.gg/bRCvFy9)          |
+| [Eris](https://github.com/abalabahaha/eris)                  | JavaScript |                                               |
+| [Discord.jl](https://github.com/Xh4H/Discord.jl)             | Julia      |                                               |
+| [Discordia](https://github.com/SinisterRectus/Discordia)     | Lua        |                                               |
+| [discordnim](https://github.com/Krognol/discordnim)          | Nim        |                                               |
+| [RestCord](https://www.restcord.com/)                        | PHP        | [Invite](https://discord.gg/0duG4FF1ElFGUFVq) |
+| [discord.py](https://github.com/Rapptz/discord.py)           | Python     | [Invite](https://discord.gg/dpy)              |
+| [disco](https://github.com/b1naryth1ef/disco)                | Python     |                                               |
+| [discordrb](https://github.com/discordrb/discordrb)          | Ruby       |                                               |
+| [discord-rs](https://github.com/SpaceManiac/discord-rs)      | Rust       |                                               |
+| [Serenity](https://github.com/serenity-rs/serenity)          | Rust       | [Invite](https://discord.gg/9X7vCus)          |
+| [AckCord](https://github.com/Katrix/AckCord)                 | Scala      | [Invite](https://discord.gg/5UH627u)          |
+| [Sword](https://github.com/Azoy/Sword)                       | Swift      |                                               |
+| [Discordeno](https://github.com/Skillz4Killz/Discordeno)     | TypeScript | [Invite](https://discord.gg/J4NqJ72)          |
+
 
 ## Game SDK Tools
 

--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -13,9 +13,9 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | Name                                                         | Language   | Support Server                                |
 | ------------------------------------------------------------ | ---------- | --------------------------------------------- | 
 | [discljord](https://github.com/igjoshua/discljord)           | Clojure    | [Invite](https://discord.gg/284PgKZ)          |
-| [aegis.cpp](https://github.com/zeroxs/aegis.cpp)             | C++        |                                               |
-| [discordcr](https://github.com/discordcr/discordcr)          | Crystal    |                                               |
-| [Discord.Net](https://github.com/RogueException/Discord.Net) | C#         |                                               |
+| [aegis.cpp](https://github.com/zeroxs/aegis.cpp)             | C++        | [Invite](https://discord.gg/w7Y3Bb8)          |
+| [discordcr](https://github.com/discordcr/discordcr)          | Crystal    | [Invite](https://discord.gg/puaxPkK)          |
+| [Discord.Net](https://github.com/RogueException/Discord.Net) | C#         | [Invite](https://discord.gg/jkrBmQR)          |
 | [DSharpPlus](https://github.com/DSharpPlus/DSharpPlus)       | C#         | [Invite](https://discord.gg/KeAS3pU)          |
 | [dscord](https://github.com/b1naryth1ef/dscord)              | D          |                                               |
 | [DiscordGo](https://github.com/bwmarrin/discordgo)           | Go         | [Invite](https://discord.gg/0f1SbxBZjYq9jLBk) |
@@ -25,18 +25,18 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [Javacord](https://github.com/Javacord/Javacord)             | Java       | [Invite](https://discord.gg/0qJ2jjyneLEgG7y3) |
 | [JDA](https://github.com/DV8FromTheWorld/JDA)                | Java       | [Invite](https://discord.gg/0hMr4ce0tIk3pSjp) |
 | [discord.js](https://github.com/discordjs/discord.js)        | JavaScript | [Invite](https://discord.gg/bRCvFy9)          |
-| [Eris](https://github.com/abalabahaha/eris)                  | JavaScript |                                               |
-| [Discord.jl](https://github.com/Xh4H/Discord.jl)             | Julia      |                                               |
+| [Eris](https://github.com/abalabahaha/eris)                  | JavaScript | [Invite](https://discord.gg/D8FNF2P)          |
+| [Discord.jl](https://github.com/Xh4H/Discord.jl)             | Julia      | [Invite](https://discord.gg/ng9TjYd)          |
 | [Discordia](https://github.com/SinisterRectus/Discordia)     | Lua        | [Invite](https://discord.gg/EzRYYDW)          |
 | [discordnim](https://github.com/Krognol/discordnim)          | Nim        |                                               |
 | [RestCord](https://www.restcord.com/)                        | PHP        | [Invite](https://discord.gg/0duG4FF1ElFGUFVq) |
 | [discord.py](https://github.com/Rapptz/discord.py)           | Python     | [Invite](https://discord.gg/r3sSKJJ)          |
 | [disco](https://github.com/b1naryth1ef/disco)                | Python     |                                               |
-| [discordrb](https://github.com/discordrb/discordrb)          | Ruby       |                                               |
+| [discordrb](https://github.com/discordrb/discordrb)          | Ruby       | [Invite](https://discord.gg/cyK3Hjm)          |
 | [discord-rs](https://github.com/SpaceManiac/discord-rs)      | Rust       |                                               |
 | [Serenity](https://github.com/serenity-rs/serenity)          | Rust       | [Invite](https://discord.gg/9X7vCus)          |
 | [AckCord](https://github.com/Katrix/AckCord)                 | Scala      | [Invite](https://discord.gg/5UH627u)          |
-| [Sword](https://github.com/Azoy/Sword)                       | Swift      |                                               |
+| [Sword](https://github.com/Azoy/Sword)                       | Swift      | [Invite](https://discord.gg/99a3xNk)          |
 | [Discordeno](https://github.com/Skillz4Killz/Discordeno)     | TypeScript | [Invite](https://discord.gg/J4NqJ72)          |
 
 ## Game SDK Tools

--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -10,7 +10,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 
 ###### Discord Libraries
 
-| Name                                                         | Language   | Discord Server                                |
+| Name                                                         | Language   | Support Server                                |
 | ------------------------------------------------------------ | ---------- | --------------------------------------------- | 
 | [discljord](https://github.com/igjoshua/discljord)           | Clojure    | [Invite](https://discord.gg/284PgKZ)          |
 | [aegis.cpp](https://github.com/zeroxs/aegis.cpp)             | C++        |                                               |

--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -19,7 +19,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [DSharpPlus](https://github.com/DSharpPlus/DSharpPlus)       | C#         | [Invite](https://discord.gg/KeAS3pU)          |
 | [dscord](https://github.com/b1naryth1ef/dscord)              | D          |                                               |
 | [DiscordGo](https://github.com/bwmarrin/discordgo)           | Go         | [Invite](https://discord.gg/0f1SbxBZjYq9jLBk) |
-| [DisGord](https://github.com/andersfylling/disgord)          | Go         |                                               |
+| [DisGord](https://github.com/andersfylling/disgord)          | Go         | [Invite](https://discord.gg/0f1SbxBZjYq9jLBk) |
 | [catnip](https://github.com/mewna/catnip)                    | Java       | [Invite](https://discord.gg/yeF2HpP)          |
 | [Discord4J](https://discord4j.com/)                          | Java       | [Invite](https://discord.gg/NxGAeCY)          |
 | [Javacord](https://github.com/Javacord/Javacord)             | Java       | [Invite](https://discord.gg/0qJ2jjyneLEgG7y3) |

--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -20,7 +20,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [dscord](https://github.com/b1naryth1ef/dscord)              | D          |                                               |
 | [DiscordGo](https://github.com/bwmarrin/discordgo)           | Go         | [Invite](https://discord.gg/0f1SbxBZjYq9jLBk) |
 | [DisGord](https://github.com/andersfylling/disgord)          | Go         |                                               |
-| [catnip](https://github.com/mewna/catnip)                    | Java       |                                               |
+| [catnip](https://github.com/mewna/catnip)                    | Java       | [Invite](https://discord.gg/yeF2HpP)          |
 | [Discord4J](https://discord4j.com/)                          | Java       | [Invite](https://discord.gg/NxGAeCY)          |
 | [Javacord](https://github.com/Javacord/Javacord)             | Java       | [Invite](https://discord.gg/0qJ2jjyneLEgG7y3) |
 | [JDA](https://github.com/DV8FromTheWorld/JDA)                | Java       | [Invite](https://discord.gg/0hMr4ce0tIk3pSjp) |

--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -37,7 +37,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [Serenity](https://github.com/serenity-rs/serenity)          | Rust       | [Invite](https://discord.gg/9X7vCus)          |
 | [AckCord](https://github.com/Katrix/AckCord)                 | Scala      | [Invite](https://discord.gg/5UH627u)          |
 | [Sword](https://github.com/Azoy/Sword)                       | Swift      | [Invite](https://discord.gg/99a3xNk)          |
-| [Discordeno](https://github.com/Skillz4Killz/Discordeno)     | TypeScript | [Invite](https://discord.gg/J4NqJ72)          |
+| [Discordeno](https://github.com/Skillz4Killz/Discordeno)     | TypeScript | [Invite](https://discord.gg/5vBgXk3UcZ)       |
 
 ## Game SDK Tools
 

--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -27,10 +27,10 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [discord.js](https://github.com/discordjs/discord.js)        | JavaScript | [Invite](https://discord.gg/bRCvFy9)          |
 | [Eris](https://github.com/abalabahaha/eris)                  | JavaScript |                                               |
 | [Discord.jl](https://github.com/Xh4H/Discord.jl)             | Julia      |                                               |
-| [Discordia](https://github.com/SinisterRectus/Discordia)     | Lua        |                                               |
+| [Discordia](https://github.com/SinisterRectus/Discordia)     | Lua        | [Invite](https://discord.gg/EzRYYDW)          |
 | [discordnim](https://github.com/Krognol/discordnim)          | Nim        |                                               |
 | [RestCord](https://www.restcord.com/)                        | PHP        | [Invite](https://discord.gg/0duG4FF1ElFGUFVq) |
-| [discord.py](https://github.com/Rapptz/discord.py)           | Python     | [Invite](https://discord.gg/dpy)              |
+| [discord.py](https://github.com/Rapptz/discord.py)           | Python     | [Invite](https://discord.gg/r3sSKJJ)          |
 | [disco](https://github.com/b1naryth1ef/disco)                | Python     |                                               |
 | [discordrb](https://github.com/discordrb/discordrb)          | Ruby       |                                               |
 | [discord-rs](https://github.com/SpaceManiac/discord-rs)      | Rust       |                                               |


### PR DESCRIPTION
After seeing a conversation in DDevs, it brought back an idea to me that night had to have per library support links. I added the ones that I was able to find. If yours is missing, please leave a comment below and ill add it in.

**Preview:**

![image](https://user-images.githubusercontent.com/23035000/94342962-d9ccf080-ffe2-11ea-9803-6e96db07746a.png)

