### PR TITLE
Add intents requirement to changelog and update identify docs

### DIFF
--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -9,7 +9,7 @@ We've introduced API and Gateway v8! Changes are noted throughout the documentat
 The changes are:
 
 - API and Gateway v8 are now available. v6 is still the default for the time being.
-- [Gateway Intents](#DOCS_GATEWAY/gateway-intents) are now required
+- [Gateway Intents](#DOCS_TOPICS_GATEWAY/gateway-intents) are now required
 - All permissions have been converted to strings-serialized numbers. As such, `permissions_new`, `allow_new`, and `deny_new` have been removed
 - The `game` field has been removed. If you need a direct replacement, you can instead reference the first element of `activities`
 - Channel Permission Overwrite `type`s are now numbers (0 and 1) instead of strings ("role" and "member"). However due to a current technical constraint, they are string-serialized numbers in audit log `options`.

--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -9,6 +9,7 @@ We've introduced API and Gateway v8! Changes are noted throughout the documentat
 The changes are:
 
 - API and Gateway v8 are now available. v6 is still the default for the time being.
+- [Gateway Intents](#DOCS_GATEWAY/gateway-intents) are now required
 - All permissions have been converted to strings-serialized numbers. As such, `permissions_new`, `allow_new`, and `deny_new` have been removed
 - The `game` field has been removed. If you need a direct replacement, you can instead reference the first element of `activities`
 - Channel Permission Overwrite `type`s are now numbers (0 and 1) instead of strings ("role" and "member"). However due to a current technical constraint, they are string-serialized numbers in audit log `options`.

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -152,6 +152,7 @@ This is a minimal `IDENTIFY` payload. `IDENTIFY` supports additional optional fi
   "op": 2,
   "d": {
     "token": "my_token",
+    "intents": 513,
     "properties": {
       "$os": "linux",
       "$browser": "my_library",
@@ -194,7 +195,7 @@ If the gateway ever issues a disconnect to your client, it will provide a close 
 ## Gateway Intents
 
 > info
-> Intents are optionally supported on the v6 gateway. They will become mandatory in a future gateway version.
+> Intents are optionally supported on the v6 gateway but required as of v8
 
 Maintaining a stateful application can be difficult when it comes to the amount of data you're expected to process, especially at scale. Gateway Intents are a system to help you lower that computational burden.
 
@@ -426,7 +427,7 @@ Used to trigger the initial handshake with the gateway.
 | shard?               | array of two integers (shard_id, num_shards)               | used for [Guild Sharding](#DOCS_TOPICS_GATEWAY/sharding)                                                                       | -       |
 | presence?            | [update status](#DOCS_TOPICS_GATEWAY/update-status) object | presence structure for initial presence information                                                                            | -       |
 | guild_subscriptions? | boolean                                                    | enables dispatching of guild subscription events (presence and typing events)                                                  | true    |
-| intents?             | integer                                                    | the [Gateway Intents](#DOCS_TOPICS_GATEWAY/gateway-intents) you wish to receive                                                | -       |
+| intents              | integer                                                    | the [Gateway Intents](#DOCS_TOPICS_GATEWAY/gateway-intents) you wish to receive                                                | -       |
 
 ###### Identify Connection Properties
 
@@ -443,6 +444,7 @@ Used to trigger the initial handshake with the gateway.
   "op": 2,
   "d": {
     "token": "my_token",
+    "intents": 513,
     "properties": {
       "$os": "linux",
       "$browser": "disco",


### PR DESCRIPTION
Missed a tiny detail, the gateway doesn't think the intents are optional anymore and will respond with a 4013 close code when omitted.