### PR TITLE
Fix broken image links

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -127,7 +127,7 @@ Discord utilizes Twitter's [snowflake](https://github.com/twitter/snowflake/tree
 
 ### Convert Snowflake to DateTime
 
-![Graphical representation of how a Snowflake is constructed](snowflake.png)
+![Graphical representation of how a Snowflake is constructed](../../images/snowflake.png)
 
 ### Snowflake IDs in Pagination
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -127,7 +127,7 @@ Discord utilizes Twitter's [snowflake](https://github.com/twitter/snowflake/tree
 
 ### Convert Snowflake to DateTime
 
-![Graphical representation of how a Snowflake is constructed](../../images/snowflake.png)
+![Graphical representation of how a Snowflake is constructed](../images/snowflake.png)
 
 ### Snowflake IDs in Pagination
 

--- a/docs/game_and_server_management/Alpha_and_Beta_Testing.md
+++ b/docs/game_and_server_management/Alpha_and_Beta_Testing.md
@@ -37,7 +37,7 @@ Note that the `VALID UNTIL` date will not remove the game from the user's librar
 
 Up to 25,000 gift codes can be created at a time. When you go to create gift codes, you'll notice there are a few fields for you to fill out. Here's what they mean:
 
-![Screenshot of the modal to create gift codes with on the developer dashboard](gift-code-creation.png)
+![Screenshot of the modal to create gift codes with on the developer dashboard](../../images/gift-code-creation.png)
 
 - SKU: the SKU that you want the user to get
 - Branch: the branch of your game you want the user to get

--- a/docs/game_and_server_management/How_to_Get_Your_Game_on_Discord.md
+++ b/docs/game_and_server_management/How_to_Get_Your_Game_on_Discord.md
@@ -78,7 +78,7 @@ If we need to see some changes, you'll receive an email directing you on your st
 
 Now that you've been approved, there's a couple new toggles to flip in the Developer Portal: `Available`, and `Store Page Published`.
 
-![Screenshot of the SKU information page with the "available" and "store page published" switches highlighted](available-published.png)
+![Screenshot of the SKU information page with the "available" and "store page published" switches highlighted](../../images/available-published.png)
 
 `Available` means that your game is now available for normal purchase/distribution; your non-beta store channel will no longer say `Coming soon!` when this is toggled, and users will be able to get your game.
 

--- a/docs/game_and_server_management/Special_Channels.md
+++ b/docs/game_and_server_management/Special_Channels.md
@@ -4,13 +4,13 @@ One of the new flagship features of Verified Servers and Game Servers are the ab
 
 In order to create a store channel for your game, you'll need to make sure you've followed [the Walkthrough](#DOCS_GAME_AND_SERVER_MANAGEMENT_HOW_TO_GET_YOUR_GAME_ON_DISCORD/) up to `Getting Approved`. If you've done that, you'll see in your server that you can create a new channel type: `Store`.
 
-![Screenshot of the modal to create a new Store Channel](create-store-channel.png)
+![Screenshot of the modal to create a new Store Channel](../../images/create-store-channel.png)
 
 Along with entering a name for your new channel, you'll be prompted to select an application. This should be the app you created when you started; it's the one linked to your server. After selecting your app, you'll be prompted to select a SKU. What's a SKU? A SKU is simply a thing that a user can buy. This is most likely your game (a SKU of type `Game`), but could also be `IAP`, `DLC`, or a `Bundle`.
 
 You can create SKUs to put up for sale by going to your app and selecting `SKU Management`.
 
-![Screenshot of the SKU Management dashboard](sku-management.png)
+![Screenshot of the SKU Management dashboard](../../images/sku-management.png)
 
 Once you select your SKU and create your channel...it's there! You now have a store channel in your server! If you want, you can set permissions on this channel like any channel in a server to restrict who can see it. Learn more about that by reading [Alpha and Beta Testing](#DOCS_GAME_AND_SERVER_MANAGEMENT_ALPHA_AND_BETA_TESTING/).
 

--- a/docs/game_sdk/Overlay.md
+++ b/docs/game_sdk/Overlay.md
@@ -133,11 +133,11 @@ overlayManager.OpenGuildInvite("rjEeUJq", (result) =>
 
 Opens the overlay widget for voice settings for the currently connected application. These settings are unique to each user within the context of your application. That means that a user can have different favorite voice settings for each of their games!
 
-![Screenshot of the Voice Settings modal for an application](game-overlay-sdk-voice-settings.png)
+![Screenshot of the Voice Settings modal for an application](../../images/game-overlay-sdk-voice-settings.png)
 
 Also, when connected to a lobby's voice channel, the overlay will show a widget that allows users to locally mute, deafen, and adjust the volume of others.
 
-![Screenshot of the Voice Widget displayed in an application](game-overlay-sdk-voice-widget.png)
+![Screenshot of the Voice Widget displayed in an application](../../images/game-overlay-sdk-voice-widget.png)
 
 Returns a `Discord.Result` via callback.
 
@@ -189,4 +189,4 @@ overlayManager.OpenActivityInvite(ActivityActionType.Join, (result) =>
 
 And that invite modal looks like this!
 
-![Screenshot of an Invitation Modal in an application](game-overlay-sdk-invite.gif)
+![Screenshot of an Invitation Modal in an application](../../images/game-overlay-sdk-invite.gif)

--- a/docs/rich_presence/Best_Practices.md
+++ b/docs/rich_presence/Best_Practices.md
@@ -44,7 +44,7 @@ For a great real world example, check out [Holodrive](https://store.steampowered
 
 |                                       Bad                                                    |                       Good                                                                          |
 | :------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------: |
-| ![A rich presence string that is too long and does not fit on one line](rp-long-strings.png) | ![Screenshot of a good rich presence string that is concise and easy to read](rp-short-strings.png) |
+| ![A rich presence string that is too long and does not fit on one line](../../images/rp-long-strings.png) | ![Screenshot of a good rich presence string that is concise and easy to read](../../images/rp-short-strings.png) |
 | The data wraps onto multiple lines. It’s repetitive, slower to read, and messy.              | The data all fits on one line per string. Clean!                                                    |
 
 ### Make it Actionable!
@@ -57,7 +57,7 @@ For a great real world example, check out [Holodrive](https://store.steampowered
 
 |                                           Bad                                             |                                          Good                                                                                                     |
 | :---------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------------------------------------------------: |
-| ![Screenshot of a rich presence string reading "Rank 9999"](rp-non-actionable.png)        | ![Screenshot of a good rich presence string shows a game mode of "Ranked: Control Point" and that the user is in a queue](rp-actionable.png)      |
+| ![Screenshot of a rich presence string reading "Rank 9999"](../../images/rp-non-actionable.png)        | ![Screenshot of a good rich presence string shows a game mode of "Ranked: Control Point" and that the user is in a queue](../../images/rp-actionable.png)      |
 | While Rank 9999 is impressive, it doesn’t present any actionable data for their friends.  | This player is in queue for something I want to play. Let's ask to join that open spot!                                                           |
 
 ### Use ALL of the fields (where applicable)!
@@ -70,7 +70,7 @@ For a great real world example, check out [Holodrive](https://store.steampowered
 
 |                                          Bad                                                    |                                                Good                                                                             |
 | :---------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------------------------------: |
-| ![Screenshot of a rich presence string that is hard to read at a glance](rp-not-all-fields.png) | ![Screenshot of a good rich presence that takes advantage of storing less important information in tooltips](rp-all-fields.png) |
+| ![Screenshot of a rich presence string that is hard to read at a glance](../../images/rp-not-all-fields.png) | ![Screenshot of a good rich presence that takes advantage of storing less important information in tooltips](../../images/rp-all-fields.png) |
 | The map name takes up space and makes the player's status harder to read at a glance.           | Moving the name of the map to the tooltip makes the data cleaner and frees up space for the score.                              |
 
 ### Have interesting, expressive art!
@@ -84,5 +84,5 @@ For a great real world example, check out [Holodrive](https://store.steampowered
 
 |                                     Bad                                               |                           Good                                                       |
 | :-----------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------: |
-| ![Screenshot of a rich presence icon that is too dark to see clearly](rp-bad-art.png) | ![Screenshot of a rich presence icon that is clear and detailed](rp-good-art.png)    |
+| ![Screenshot of a rich presence icon that is too dark to see clearly](../../images/rp-bad-art.png) | ![Screenshot of a rich presence icon that is clear and detailed](../../images/rp-good-art.png)    |
 | The image is dark and unfocused. Highly-detailed images can be hard to see.           | This image is bright and matches the details. Let's help!                            |

--- a/docs/rich_presence/How_To.md
+++ b/docs/rich_presence/How_To.md
@@ -153,7 +153,7 @@ typedef struct DiscordRichPresence {
 
 Here's a handy image to see how these fields are actually displayed on a profile:
 
-![Graphical representation of the legend for rich presence details](rp-legend.png)
+![Graphical representation of the legend for rich presence details](../../images/rp-legend.png)
 
 | location                               | field name             | notes                                                                       |
 | -------------------------------------- | ---------------------- | --------------------------------------------------------------------------- |

--- a/docs/topics/Certified_Devices.md
+++ b/docs/topics/Certified_Devices.md
@@ -12,7 +12,7 @@ I'm glad you asked!
 
 Yup, that's it. You give us the real-time info about any connected devices, and we'll handle the rest to make sure that anyone using your device will have an awesome experience. Your device will also have a `CERTIFIED` badge in Discord's audio settings, and really, who doesn't love badges?
 
-![An example of how a certified device may be shown for an example audio input and output device](certified-device.png)
+![An example of how a certified device may be shown for an example audio input and output device](../../images/certified-device.png)
 
 ## Connecting
 

--- a/docs/topics/Teams.md
+++ b/docs/topics/Teams.md
@@ -15,11 +15,11 @@ For game developers, this means that you can get your engineers access to your a
 
 Making a Team is easy! Head on over to our [Team creation](https://discord.com/developers/teams) page and make your own.
 
-![Screenshot of the initial landing page for viewing Teams that you are a part of](team-page.png)
+![Screenshot of the initial landing page for viewing Teams that you are a part of](../../images/team-page.png)
 
 Note that to use Discord Teams, you need to have 2FA enabled on your account. Security is of the utmost importance, especially when it comes to shared resources. If you're developing on your own and don't want to use Teams, you do not need 2FA. But, in order to keep other Team members safe, you'll need to add it to use Teams.
 
-![Screenshot of the 2FA requirement modal](team-2fa.png)
+![Screenshot of the 2FA requirement modal](../../images/team-2fa.png)
 
 Once your team is made, you can start inviting other Discord users to join.
 
@@ -30,11 +30,11 @@ Once your team is made, you can start inviting other Discord users to join.
 
 Now that you've got your Team set up, you can start creating apps under it. Teams can own a maximum of 25 apps. To create a new app under a Team, select the Team in the app creation modal. If you want to keep the app under your own ownership, choose `Personal`:
 
-![Screenshot of the Team Application creation modal](team-make-app.png)
+![Screenshot of the Team Application creation modal](../../images/team-make-app.png)
 
 If you have an existing app that you want to transfer to a Team, you can do that, too! Just go into the app that you want to transfer, hit `Transfer App to Team`, and send the app to its new home.
 
-![Screenshot of where to find the button to transfer an Application to a Team](transfer-app-to-team.png)
+![Screenshot of where to find the button to transfer an Application to a Team](../../images/transfer-app-to-team.png)
 
 > danger
 > Once an app has been transferred to a team, it _cannot_ be transferred back.


### PR DESCRIPTION
When I was looking at the Docs earlier I noticed that all of the images in some files were broken because they had invalid directory links. I fixed all of the ones I found which is hopefully all of them.

Example of Best_Practices.md
Current Version:
![CB75A86A-E9F8-43C7-8407-703866A973C4](https://user-images.githubusercontent.com/46873232/94927680-9d8d0a80-0490-11eb-8739-fc1268db7c15.png)

Updated Version:
![23317BD7-96F2-4126-BC4D-9BA5A52F4EEB](https://user-images.githubusercontent.com/46873232/94927713-a7167280-0490-11eb-9caa-863e1a676387.png)
