### PR TITLE
Rename Verified Bot Developer to Early Verified Bot Developer

### DIFF
--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -58,22 +58,22 @@ There are other rules and restrictions not shared here for the sake of spam and 
 
 ###### User Flags
 
-| Value   | Description            |
-| ------- | ---------------------- |
-| 0       | None                   |
-| 1 << 0  | Discord Employee       |
-| 1 << 1  | Discord Partner        |
-| 1 << 2  | HypeSquad Events       |
-| 1 << 3  | Bug Hunter Level 1     |
-| 1 << 6  | House Bravery          |
-| 1 << 7  | House Brilliance       |
-| 1 << 8  | House Balance          |
-| 1 << 9  | Early Supporter        |
-| 1 << 10 | Team User              |
-| 1 << 12 | System                 |
-| 1 << 14 | Bug Hunter Level 2     |
-| 1 << 16 | Verified Bot           |
-| 1 << 17 | Verified Bot Developer |
+| Value   | Description                  |
+| ------- | ---------------------------- |
+| 0       | None                         |
+| 1 << 0  | Discord Employee             |
+| 1 << 1  | Discord Partner              |
+| 1 << 2  | HypeSquad Events             |
+| 1 << 3  | Bug Hunter Level 1           |
+| 1 << 6  | House Bravery                |
+| 1 << 7  | House Brilliance             |
+| 1 << 8  | House Balance                |
+| 1 << 9  | Early Supporter              |
+| 1 << 10 | Team User                    |
+| 1 << 12 | System                       |
+| 1 << 14 | Bug Hunter Level 2           |
+| 1 << 16 | Verified Bot                 |
+| 1 << 17 | Early Verified Bot Developer |
 
 ###### Premium Types
 


### PR DESCRIPTION
Verified Bot Developer was renamed to Early Verified Bot Developer (or at least the badge description was)
This reflects the change in the documentation of the public user flags in the api docs.