### PR TITLE
Add question issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/api-question.md
+++ b/.github/ISSUE_TEMPLATE/api-question.md
@@ -1,5 +1,5 @@
 ---
-name: Question about the Discord's API or SDK's
+name: Question about Discord's API or SDKs
 about: Questions regarding Discord's API, Gateway, OAuth2, SDK, etc.
 labels: question
 ---
@@ -7,5 +7,4 @@ labels: question
 <!--
   Before opening a new issue, please search existing issues:  https://github.com/discord/discord-api-docs/issues
 -->
-
 

--- a/.github/ISSUE_TEMPLATE/api-question.md
+++ b/.github/ISSUE_TEMPLATE/api-question.md
@@ -1,0 +1,11 @@
+---
+name: Question about the Discord's API or SDK's
+about: Questions regarding Discord's API, Gateway, OAuth2, SDK, etc.
+labels: question
+---
+
+<!--
+  Before opening a new issue, please search existing issues:  https://github.com/discord/discord-api-docs/issues
+-->
+
+


### PR DESCRIPTION
Not every issue is a feature request or bug report. Some issues like #2121 is neither and should have a question label if anything. Maybe allowing blank issues instead is better? I'm not really sure what you can really put here for a template.