### PR TITLE
Audit Log: use new overwrite string in role_name description

### DIFF
--- a/docs/resources/Audit_Log.md
+++ b/docs/resources/Audit_Log.md
@@ -86,16 +86,16 @@ Whenever an admin action is performed on the API, an entry is added to the respe
 
 ###### Optional Audit Entry Info
 
-| Field              | Type      | Description                                                 | Action Type                                                                    |
-|--------------------|-----------|-------------------------------------------------------------|--------------------------------------------------------------------------------|
-| delete_member_days | string    | number of days after which inactive members were kicked     | MEMBER_PRUNE                                                                   |
-| members_removed    | string    | number of members removed by the prune                      | MEMBER_PRUNE                                                                   |
-| channel_id         | snowflake | channel in which the entities were targeted                 | MEMBER_MOVE & MESSAGE_PIN & MESSAGE_UNPIN & MESSAGE_DELETE                     |
-| message_id         | snowflake | id of the message that was targeted                         | MESSAGE_PIN & MESSAGE_UNPIN                                                    |
-| count              | string    | number of entities that were targeted                       | MESSAGE_DELETE & MESSAGE_BULK_DELETE & MEMBER_DISCONNECT & MEMBER_MOVE         |
-| id                 | snowflake | id of the overwritten entity                                | CHANNEL_OVERWRITE_CREATE & CHANNEL_OVERWRITE_UPDATE & CHANNEL_OVERWRITE_DELETE |
+| Field              | Type      | Description                                                     | Action Type                                                                    |
+|--------------------|-----------|-----------------------------------------------------------------|--------------------------------------------------------------------------------|
+| delete_member_days | string    | number of days after which inactive members were kicked         | MEMBER_PRUNE                                                                   |
+| members_removed    | string    | number of members removed by the prune                          | MEMBER_PRUNE                                                                   |
+| channel_id         | snowflake | channel in which the entities were targeted                     | MEMBER_MOVE & MESSAGE_PIN & MESSAGE_UNPIN & MESSAGE_DELETE                     |
+| message_id         | snowflake | id of the message that was targeted                             | MESSAGE_PIN & MESSAGE_UNPIN                                                    |
+| count              | string    | number of entities that were targeted                           | MESSAGE_DELETE & MESSAGE_BULK_DELETE & MEMBER_DISCONNECT & MEMBER_MOVE         |
+| id                 | snowflake | id of the overwritten entity                                    | CHANNEL_OVERWRITE_CREATE & CHANNEL_OVERWRITE_UPDATE & CHANNEL_OVERWRITE_DELETE |
 | type               | string    | type of overwritten entity - "0" for "role" or "1" for "member" | CHANNEL_OVERWRITE_CREATE & CHANNEL_OVERWRITE_UPDATE & CHANNEL_OVERWRITE_DELETE |
-| role_name          | string    | name of the role if type is "role"                          | CHANNEL_OVERWRITE_CREATE & CHANNEL_OVERWRITE_UPDATE & CHANNEL_OVERWRITE_DELETE |
+| role_name          | string    | name of the role if type is "0"                                 | CHANNEL_OVERWRITE_CREATE & CHANNEL_OVERWRITE_UPDATE & CHANNEL_OVERWRITE_DELETE |
 
 ### Audit Log Change Object
 

--- a/docs/resources/Audit_Log.md
+++ b/docs/resources/Audit_Log.md
@@ -95,7 +95,7 @@ Whenever an admin action is performed on the API, an entry is added to the respe
 | count              | string    | number of entities that were targeted                           | MESSAGE_DELETE & MESSAGE_BULK_DELETE & MEMBER_DISCONNECT & MEMBER_MOVE         |
 | id                 | snowflake | id of the overwritten entity                                    | CHANNEL_OVERWRITE_CREATE & CHANNEL_OVERWRITE_UPDATE & CHANNEL_OVERWRITE_DELETE |
 | type               | string    | type of overwritten entity - "0" for "role" or "1" for "member" | CHANNEL_OVERWRITE_CREATE & CHANNEL_OVERWRITE_UPDATE & CHANNEL_OVERWRITE_DELETE |
-| role_name          | string    | name of the role if type is "0"                                 | CHANNEL_OVERWRITE_CREATE & CHANNEL_OVERWRITE_UPDATE & CHANNEL_OVERWRITE_DELETE |
+| role_name          | string    | name of the role if type is "0" (not present if type is "1")    | CHANNEL_OVERWRITE_CREATE & CHANNEL_OVERWRITE_UPDATE & CHANNEL_OVERWRITE_DELETE |
 
 ### Audit Log Change Object
 


### PR DESCRIPTION
This changes `name of the role if type is "role"` to `name of the role if type is "0"` in `role_name` in the optional audit log info.