### PR TITLE
Add elixir libs to community libraries

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -19,6 +19,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [DSharpPlus](https://github.com/DSharpPlus/DSharpPlus)       | C#         |
 | [dscord](https://github.com/b1naryth1ef/dscord)              | D          |
 | [coxir](https://github.com/satom99/coxir)                    | Elixir     |
+| [Nostrum](https://github.com/Kraigie/nostrum)                | Elixir     |
 | [DiscordGo](https://github.com/bwmarrin/discordgo)           | Go         |
 | [DisGord](https://github.com/andersfylling/disgord)          | Go         |
 | [catnip](https://github.com/mewna/catnip)                    | Java       |

--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -18,6 +18,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [Discord.Net](https://github.com/RogueException/Discord.Net) | C#         |
 | [DSharpPlus](https://github.com/DSharpPlus/DSharpPlus)       | C#         |
 | [dscord](https://github.com/b1naryth1ef/dscord)              | D          |
+| [coxir](https://github.com/satom99/coxir)                    | Elixir     |
 | [DiscordGo](https://github.com/bwmarrin/discordgo)           | Go         |
 | [DisGord](https://github.com/andersfylling/disgord)          | Go         |
 | [catnip](https://github.com/mewna/catnip)                    | Java       |


### PR DESCRIPTION
Both [coxir](https://github.com/satom99/coxir) and [Nostrum](https://github.com/Kraigie/nostrum) have been accepted on the unofficial discord api guild for quite a while and should probably be included in the list with the other libs.