### PR TITLE
In the Identify example, "intents" is listed twice.

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -446,7 +446,6 @@ Used to trigger the initial handshake with the gateway.
   "op": 2,
   "d": {
     "token": "my_token",
-    "intents": 513,
     "properties": {
       "$os": "linux",
       "$browser": "disco",


### PR DESCRIPTION
This would cause an error (I think?) and may cause confusion in new users (developers).