### PR TITLE
Remove guild_subscriptions from docs

### DIFF
--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -10,6 +10,7 @@ The changes are:
 
 - API and Gateway v8 are now available. v6 is still the default for the time being.
 - [Gateway Intents](#DOCS_TOPICS_GATEWAY/gateway-intents) are now required
+- Removed `guild_subscriptions` in identify in favor of [Gateway Intents](#DOCS_TOPICS_GATEWAY/gateway-intents).
 - All permissions have been converted to strings-serialized numbers. As such, `permissions_new`, `allow_new`, and `deny_new` have been removed
 - The `game` field has been removed. If you need a direct replacement, you can instead reference the first element of `activities`
 - Channel Permission Overwrite `type`s are now numbers (0 and 1) instead of strings ("role" and "member"). However due to a current technical constraint, they are string-serialized numbers in audit log `options`.

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -317,7 +317,7 @@ For larger bots, client state can grow to be quite large. We recommend only stor
 ## Guild Subscriptions
 
 > info
-> While not deprecated, Guild Subscriptions have been superceded by [Gateway Intents](#DOCS_TOPICS_GATEWAY/gateway-intents). You may continue to use guild subscriptions, but we recommend migrating to intents for even better results.
+> Guild subscriptions are no longer available in gateway v8. It is recommended to use [Gateway Intents](#DOCS_TOPICS_GATEWAY/gateway-intents) instead.
 
 Presence and typing events get dispatched from guilds that your bot is a member of. For many bots, these events are not useful and can be frequent and expensive to process at scale. Because of this, we allow bots to opt out of guild subscriptions by setting `guild_subscriptions` to `false` when [Identify](#DOCS_TOPICS_GATEWAY/identify)ing.
 
@@ -428,8 +428,12 @@ Used to trigger the initial handshake with the gateway.
 | large_threshold?     | integer                                                    | value between 50 and 250, total number of members where the gateway will stop sending offline members in the guild member list | 50      |
 | shard?               | array of two integers (shard_id, num_shards)               | used for [Guild Sharding](#DOCS_TOPICS_GATEWAY/sharding)                                                                       | -       |
 | presence?            | [update status](#DOCS_TOPICS_GATEWAY/update-status) object | presence structure for initial presence information                                                                            | -       |
-| guild_subscriptions? | boolean                                                    | enables dispatching of guild subscription events (presence and typing events)                                                  | true    |
+| guild_subscriptions? | boolean                                                    | enables dispatching of guild subscription events (presence and typing events)*                                         | true    |
 | intents              | integer                                                    | the [Gateway Intents](#DOCS_TOPICS_GATEWAY/gateway-intents) you wish to receive                                                | -       |
+
+
+> info
+> * If  `intents` are specified in your identify payload, `guild_subscriptions` will not have any effect.
 
 ###### Identify Connection Properties
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -314,13 +314,6 @@ An example of state tracking can be found with member status caching. When initi
 
 For larger bots, client state can grow to be quite large. We recommend only storing objects in memory that are needed for a bot's operation. Many bots, for example, just respond to user input through chat commands. These bots may only need to keep guild information (like guild/channel roles and permissions) in memory, since [MESSAGE_CREATE](#DOCS_TOPICS_GATEWAY/message-create) and [MESSAGE_UPDATE](#DOCS_TOPICS_GATEWAY/message-update) events have the full member object available.
 
-## Guild Subscriptions
-
-> info
-> Guild subscriptions are no longer available in gateway v8. It is recommended to use [Gateway Intents](#DOCS_TOPICS_GATEWAY/gateway-intents) instead.
-
-Presence and typing events get dispatched from guilds that your bot is a member of. For many bots, these events are not useful and can be frequent and expensive to process at scale. Because of this, we allow bots to opt out of guild subscriptions by setting `guild_subscriptions` to `false` when [Identify](#DOCS_TOPICS_GATEWAY/identify)ing.
-
 ## Guild Availability
 
 When connecting to the gateway as a bot user, guilds that the bot is a part of will start out as unavailable. Don't fret! The gateway will automatically attempt to reconnect on your behalf. As guilds become available to you, you will receive [Guild Create](#DOCS_TOPICS_GATEWAY/guild-create) events.
@@ -427,13 +420,8 @@ Used to trigger the initial handshake with the gateway.
 | compress?            | boolean                                                    | whether this connection supports compression of packets                                                                        | false   |
 | large_threshold?     | integer                                                    | value between 50 and 250, total number of members where the gateway will stop sending offline members in the guild member list | 50      |
 | shard?               | array of two integers (shard_id, num_shards)               | used for [Guild Sharding](#DOCS_TOPICS_GATEWAY/sharding)                                                                       | -       |
-| presence?            | [update status](#DOCS_TOPICS_GATEWAY/update-status) object | presence structure for initial presence information                                                                            | -       |
-| guild_subscriptions? | boolean                                                    | enables dispatching of guild subscription events (presence and typing events)*                                         | true    |
+| presence?            | [update status](#DOCS_TOPICS_GATEWAY/update-status) object | presence structure for initial presence information                                                                            | -
 | intents              | integer                                                    | the [Gateway Intents](#DOCS_TOPICS_GATEWAY/gateway-intents) you wish to receive                                                | -       |
-
-
-> info
-> * If  `intents` are specified in your identify payload, `guild_subscriptions` will not have any effect.
 
 ###### Identify Connection Properties
 
@@ -458,7 +446,6 @@ Used to trigger the initial handshake with the gateway.
     },
     "compress": true,
     "large_threshold": 250,
-    "guild_subscriptions": false,
     "shard": [0, 1],
     "presence": {
       "activities": [{

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -420,7 +420,7 @@ Used to trigger the initial handshake with the gateway.
 | compress?            | boolean                                                    | whether this connection supports compression of packets                                                                        | false   |
 | large_threshold?     | integer                                                    | value between 50 and 250, total number of members where the gateway will stop sending offline members in the guild member list | 50      |
 | shard?               | array of two integers (shard_id, num_shards)               | used for [Guild Sharding](#DOCS_TOPICS_GATEWAY/sharding)                                                                       | -       |
-| presence?            | [update status](#DOCS_TOPICS_GATEWAY/update-status) object | presence structure for initial presence information                                                                            | -
+| presence?            | [update status](#DOCS_TOPICS_GATEWAY/update-status) object | presence structure for initial presence information                                                                            | -       |
 | intents              | integer                                                    | the [Gateway Intents](#DOCS_TOPICS_GATEWAY/gateway-intents) you wish to receive                                                | -       |
 
 ###### Identify Connection Properties


### PR DESCRIPTION
This PR removes the guild subscriptions feature from the docs as setting `guild_subscriptions` does not have any effect on whether typing and presence events are sent, or not.

Tested combinations:
| Gateway version | Intents | `guild_subscriptions` | Result |
| --- | --- | --- | --- |
| v6 | None | `true` | Receives `TYPING_START` and `PRESENCE_UPDATE` event |
| v6 | None | `false` | No `TYPING_START` and `PRESENCE_UPDATE` event |
| v6 |  `GUILD_MESSAGE_TYPING`/`GUILD_PRESENCES` | `false` | Receives `TYPING_START` and `PRESENCE_UPDATE` event, ignores `guild_subscriptions` |
| v8 | `GUILD_MESSAGE_TYPING`/`GUILD_PRESENCES` | `false` | Receives `TYPING_START` and `PRESENCE_UPDATE` event, ignores `guild_subscriptions` |
| v8  | `GUILDS` | `true` | Receives `GUILD_CREATE` event, ignores `guild_subscriptions` |