### PR TITLE
Update changelog and chunking requirements

### DIFF
--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -2,6 +2,11 @@
 
 ## API and Gateway V8
 
+#### October 27, 2020
+
+The v6 gateway now applies the restrictions for gateway intents. This means the new chunking limitations are now in effect, regardless of intents being used. See [Request Guild Members](#DOCS_TOPICS_GATEWAY/request-guild-members) for further details.
+Additionally, if privileged intents are not enabled in the application dashboard the bot will not receive the events for those intents. All other intents are always enabled by default unless specified otherwise by the identify payload.
+
 #### September 24, 2020
 
 We've introduced API and Gateway v8! Changes are noted throughout the documentation, and you can also read [this commit in our docs repo](https://github.com/discord/discord-api-docs/commit/545ff4a7883e5eee7ee91d19a5e5d760a0730033) for a full diff.

--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -5,7 +5,9 @@
 #### October 27, 2020
 
 The v6 gateway now applies the restrictions for gateway intents. This means the new chunking limitations are now in effect, regardless of intents being used. See [Request Guild Members](#DOCS_TOPICS_GATEWAY/request-guild-members) for further details.
-Additionally, if privileged intents are not enabled in the application dashboard the bot will not receive the events for those intents. All other intents are always enabled by default unless specified otherwise by the identify payload.
+Additionally, if privileged intents are not enabled in the application dashboard the bot will not receive the events for those intents.
+
+All other intents are always enabled by default unless specified otherwise by the identify payload. We have made a support article to explain some of the changes and resulting issues with more details: [Gateway Update FAQ](https://dis.gd/gwupdate)
 
 #### September 24, 2020
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -514,19 +514,19 @@ Used to maintain an active gateway connection. Must be sent every `heartbeat_int
 
 Used to request all members for a guild or a list of guilds. When initially connecting, the gateway will only send offline members if a guild has less than the `large_threshold` members (value in the [Gateway Identify](#DOCS_TOPICS_GATEWAY/identify)). If a client wishes to receive additional members, they need to explicitly request them via this operation. The server will send [Guild Members Chunk](#DOCS_TOPICS_GATEWAY/guild-members-chunk) events in response with up to 1000 members per chunk until all members that match the request have been sent.
 
-If you are using [Gateway Intents](#DOCS_TOPICS_GATEWAY/gateway-intents), there are some significant changes to this command to be mindful of:
+Due to our privacy and infrastructural concerns with this feature, there are some limitations that apply:
 
 - `GUILD_PRESENCES` intent is required to set `presences = true`. Otherwise, it will always be false
 - `GUILD_MEMBERS` intent is required to request the entire member list—`(query=‘’, limit=0<=n)`
-- You will be limited to requesting 1 `guild_id`
-- Requesting a prefix will return a maximum of 100 members
+- You will be limited to requesting 1 `guild_id` per request
+- Requesting a prefix (`query` parameter) will return a maximum of 100 members
 - Requesting `user_ids` will continue to be limited to returning 100 members
 
 ###### Guild Request Members Structure
 
 | Field      | Type                             | Description                                                                                                                           | Required                   |
 |------------|----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|----------------------------|
-| guild_id   | snowflake or array of snowflakes | id of the guild(s) to get members for                                                                                                 | true                       |
+| guild_id   | snowflake                        | id of the guild to get members for                                                                                                    | true                       |
 | query?     | string                           | string that username starts with, or an empty string to return all members                                                            | one of query or user_ids   |
 | limit      | integer                          | maximum number of members to send matching the `query`; a limit of `0` can be used with an empty string `query` to return all members | true when specifying query |
 | presences? | boolean                          | used to specify if we want the presences of the matched members                                                                       | false                      |


### PR DESCRIPTION
The chunking requirements always apply now that intents are enabled by default in v6. I've also updated the changelog because this is a breaking change to v6.