### PR TITLE
Update the warning below the URL tables, to reference the token revocation URL

### DIFF
--- a/docs/topics/OAuth2.md
+++ b/docs/topics/OAuth2.md
@@ -15,7 +15,7 @@ The first step in implementing OAuth2 is [registering a developer application](#
 | https://discord.com/api/oauth2/token/revoke | [Token Revocation](https://tools.ietf.org/html/rfc7009) URL |
 
 > warn
-> In accordance with [RFC 6749](https://tools.ietf.org/html/rfc6749), the [token URL](#DOCS_TOPICS_OAUTH2/shared-resources-oauth2-urls) **only** accepts a content type of `x-www-form-urlencoded`. JSON content is not permitted and will return an error.
+> In accordance with the relevant RFCs, the token and token revocation URLs will **only** accept a content type of `x-www-form-urlencoded`. JSON content is not permitted and will return an error.
 
 ###### OAuth2 Scopes
 


### PR DESCRIPTION
Hi! This is a small change that I was going to make over at #2194, however the PR was merged before I could make it. So it's going in its own PR.

I opted to remove the URL to the URLs table, as this warning is right below it. I also removed the references to specific RFCs, as we are now referencing URLs that are from two different RFCs (and it'd be a little awkward to change that warning every time a new OAuth2 endpoint is added from other RFCs).