### PR TITLE
Document Attachment dimensions being optional

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -495,8 +495,8 @@ Embed types are "loosely defined" and, for the most part, are not used by our cl
 | size      | integer   | size of file in bytes     |
 | url       | string    | source url of file        |
 | proxy_url | string    | a proxied url of file     |
-| height    | ?integer  | height of file (if image) |
-| width     | ?integer  | width of file (if image)  |
+| height?   | ?integer  | height of file (if image) |
+| width?    | ?integer  | width of file (if image)  |
 
 ### Channel Mention Object
 


### PR DESCRIPTION
This PR marks `height` and `width` in a message's attachment as being optional in addition to only nullable.

Creating a message with a file that is not interpreted as an image (e.g. a txt file) results in a message response with an attachment that does not contain the `height` and `width` fields.