### PR TITLE
Authorization Code token exchange ignores `scope` parameter; also clarify `scope` when refreshing a token

### DIFF
--- a/docs/topics/OAuth2.md
+++ b/docs/topics/OAuth2.md
@@ -129,7 +129,7 @@ Having the user's access token allows your application to make certain requests 
 - `grant_type` - must be set to `refresh_token`
 - `refresh_token` - the user's refresh token
 - `redirect_uri` - your `redirect_uri`
-- `scope` - one or more scopes requested in your authorization url, space-delimited (optional, will be treated as equal to all previously allowed scopes if omitted)
+- `scope` - one or more scopes requested in your authorization url, space-delimited (optional, will be treated as equal to all previously allowed scopes if empty or omitted)
 
 ###### Refresh Token Exchange Example
 

--- a/docs/topics/OAuth2.md
+++ b/docs/topics/OAuth2.md
@@ -129,7 +129,7 @@ Having the user's access token allows your application to make certain requests 
 - `grant_type` - must be set to `refresh_token`
 - `refresh_token` - the user's refresh token
 - `redirect_uri` - your `redirect_uri`
-- `scope` - one or more scopes requested in your authorization url, space-delimited (optional, will be treated as equal to all previously allowed scopes if empty or omitted)
+- `scope` - one or more scopes requested in your authorization url, space-delimited (optional, will be treated as equal to all granted scopes if empty or omitted)
 
 ###### Refresh Token Exchange Example
 

--- a/docs/topics/OAuth2.md
+++ b/docs/topics/OAuth2.md
@@ -83,7 +83,6 @@ https://nicememe.website/?code=NhhvTDYsFcdgNLnnLijcl7Ku7bEEeee&state=15773059ghq
 - `grant_type` - must be set to `authorization_code`
 - `code` - the code from the querystring
 - `redirect_uri` - your `redirect_uri`
-- `scope` - the scopes requested in your authorization url, space-delimited
 
 ###### Access Token Exchange Example
 
@@ -99,8 +98,7 @@ def exchange_code(code):
     'client_secret': CLIENT_SECRET,
     'grant_type': 'authorization_code',
     'code': code,
-    'redirect_uri': REDIRECT_URI,
-    'scope': 'identify email connections'
+    'redirect_uri': REDIRECT_URI
   }
   headers = {
     'Content-Type': 'application/x-www-form-urlencoded'
@@ -131,7 +129,7 @@ Having the user's access token allows your application to make certain requests 
 - `grant_type` - must be set to `refresh_token`
 - `refresh_token` - the user's refresh token
 - `redirect_uri` - your `redirect_uri`
-- `scope` - the scopes requested in your authorization url, space-delimited
+- `scope` - one or more scopes requested in your authorization url, space-delimited (optional, will be treated as equal to all previously allowed scopes if omitted)
 
 ###### Refresh Token Exchange Example
 


### PR DESCRIPTION
Hi!

While chatting within the Discord API server, it was noted that the Token Exchange step requires a `scope` parameter, though the [RFC does not specify a scope parameter as needed during the token exchange](https://tools.ietf.org/html/rfc6749#section-4.1.3). After doing some testing, I found that the Token Exchange step outright ignores the `scope` parameter. I have thus removed the `scope` parameter from the Token Exchange documentation.

I've also taken this opportunity to update the `scope` parameter in regards to the Refresh Token Exchange. Within [RFC6749, section 6](https://tools.ietf.org/html/rfc6749#section-6), the `scope` parameter is listed as follows:

> OPTIONAL.  The scope of the access request as described by [Section 3.3](https://tools.ietf.org/html/rfc6749#section-3.3).  The requested scope MUST NOT include any scope not originally granted by the resource owner, and if omitted is treated as equal to the scope originally granted by the resource owner.

and the Refresh Token Exchange appears to follow these rules:

* If the parameter is omitted, or the parameter is specified but empty, the new token will have all possible scopes.
* If one/multiple/all scopes are specified, and all listed scopes are allowed, the new token will only have those scopes.
* If one/multiple/all scopes are specified, and any listed scope was not allowed, the endpoint will return an error.
* Even if a previous access token was locked to certain scopes, you can specify no scopes/omit the `scope` parameter to get a access token with all possible scopes again.

so I've updated the `scope` parameter's description to (mostly) match. I'm not sure if the new description is that great, but it's definitely more accurate..