### PR TITLE
MANAGE_WEBHOOKS doesn't apply to voice channels?

### DIFF
--- a/docs/topics/Permissions.md
+++ b/docs/topics/Permissions.md
@@ -57,7 +57,7 @@ Below is a table of all current permissions, their integer values in hexadecimal
 | CHANGE_NICKNAME       | `0x04000000` | Allows for modification of own nickname                                                                                            |              |
 | MANAGE_NICKNAMES      | `0x08000000` | Allows for modification of other users nicknames                                                                                   |              |
 | MANAGE_ROLES \*       | `0x10000000` | Allows management and editing of roles                                                                                             | T, V         |
-| MANAGE_WEBHOOKS \*    | `0x20000000` | Allows management and editing of webhooks                                                                                          | T, V         |
+| MANAGE_WEBHOOKS \*    | `0x20000000` | Allows management and editing of webhooks                                                                                          | T            |
 | MANAGE_EMOJIS \*      | `0x40000000` | Allows management and editing of emojis                                                                                            |              |
 
 **\* These permissions require the owner account to use [two-factor authentication](#DOCS_TOPICS_OAUTH2/twofactor-authentication-requirement) when used on a guild that has server-wide 2FA enabled.**


### PR DESCRIPTION
I might be missing something but last I checked MANAGE_WEBHOOKS isn't applicable to voice channels and therefore should not be marked as being a voice channel permission, too.