### PR TITLE
Inline Replies replied_user defaults to true not false

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -563,7 +563,7 @@ The allowed mention field allows for more granular control over mentions without
 | parse        | array of allowed mention types | An array of [allowed mention types](#DOCS_RESOURCES_CHANNEL/allowed-mentions-object-allowed-mention-types) to parse from the content. |
 | roles        | list of snowflakes             | Array of role_ids to mention (Max size of 100)                                                                                        |
 | users        | list of snowflakes             | Array of user_ids to mention (Max size of 100)                                                                                        |
-| replied_user | boolean                        | For replies, whether to mention the author of the message being replied to (default false)                                            |
+| replied_user | boolean                        | For replies, whether to mention the author of the message being replied to (default true)                                             |
 
 ###### Allowed Mentions Reference
 


### PR DESCRIPTION
Upon testing, the behavior of mentions is actually to default to `true`.

```ts
body: {
      content: "Test replies with no replied user",
      allowed_mentions: undefined,
      message_reference: { message_id: "778108418422341652" }
    },
```

![image](https://user-images.githubusercontent.com/23035000/99346294-4dacac00-2862-11eb-96b6-3930c04efb85.png)
