### PR TITLE
Fix member nick

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -254,7 +254,7 @@ A partial [guild](#DOCS_RESOURCES_GUILD/guild-object) object. Represents an Offl
 | Field          | Type                                            | Description                                                                                                                |
 | -------------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | user?          | [user](#DOCS_RESOURCES_USER/user-object) object | the user this guild member represents                                                                                      |
-| nick           | ?string                                         | this users guild nickname                                                                                                  |
+| nick?           | ?string                                         | this users guild nickname                                                                                                  |
 | roles          | array of snowflakes                             | array of [role](#DOCS_TOPICS_PERMISSIONS/role-object) object ids                                                           |
 | joined_at      | ISO8601 timestamp                               | when the user joined the guild                                                                                             |
 | premium_since? | ?ISO8601 timestamp                              | when the user started [boosting](https://support.discord.com/hc/en-us/articles/360028038352-Server-Boosting-) the guild |


### PR DESCRIPTION
It may or may not be nullable so I didn't change that, but it is **definitely** optional.

The `GUILD_CREATE` gateway event is one obvious example of this.