### PR TITLE
Fix "animal_cat" typo

### DIFF
--- a/docs/interactions/Slash_Commands.md
+++ b/docs/interactions/Slash_Commands.md
@@ -96,7 +96,7 @@ json = {
                 },
                 {
                     "name": "Cat",
-                    "value": "animal_dog"
+                    "value": "animal_cat"
                 },
                 {
                     "name": "Penguin",


### PR DESCRIPTION
I'm pretty sure that a Cat isn't a `animal_dog`, right? 😋