### PR TITLE
Add warning about interaction response pings

### DIFF
--- a/docs/interactions/Slash_Commands.md
+++ b/docs/interactions/Slash_Commands.md
@@ -237,7 +237,7 @@ Now that you've gotten the data from the user, it's time to respond to them.
 Interactions--both receiving and responding--are webhooks under the hood. So responding to an Interaction is just like sending a webhook request!
 
 > warn
-> Because interaction responses and followups are webhooks, there are some differences between their behavior and that of normal bot-sent messages. Most importantly, **they can ping @everyone, @here, and all roles without the bot having the permission**. If your application responds with user data, you should use [`allowed_mentions`](#DOCS_RESOURCES_CHANNEL/allowed-mentions-object) to filter what mentions ping. Other differences include the ability to send named links in the message content (`[text](url)`) and the ability to include up to 10 embeds.
+> Because interaction responses and followups are webhooks, there are some differences between their behavior and that of normal bot-sent messages. Most importantly, **they can ping @everyone, @here, and all roles without the bot having the permission**. If your application responds with user data, you should use [`allowed_mentions`](#DOCS_RESOURCES_CHANNEL/allowed-mentions-object) to filter which mentions in the content actually ping. Other differences include the ability to send named links in the message content (`[text](url)`) and the ability to include up to 10 embeds.
 
 When responding to an interaction received **via webhook**, your server can simply respond to the received `POST` request. You'll want to respond with a `200` status code (if everything went well), as well as specifying a `type` and `data`, which is an [Interaction Response](#DOCS_INTERACTIONS_SLASH_COMMANDS/interaction-response) object:
 

--- a/docs/interactions/Slash_Commands.md
+++ b/docs/interactions/Slash_Commands.md
@@ -236,6 +236,9 @@ Now that you've gotten the data from the user, it's time to respond to them.
 
 Interactions--both receiving and responding--are webhooks under the hood. So responding to an Interaction is just like sending a webhook request!
 
+> warn
+> Because interaction responses and followups are webhooks, there are some differences between their behavior and that of normal bot-sent messages. Most importantly, **they can ping @everyone, @here, and all roles without the bot having the permission**. If your application responds with user data, you should use [`allowed_mentions`](#DOCS_RESOURCES_CHANNEL/allowed-mentions-object) to filter what mentions ping. Other differences include the ability to send named links in the message content (`[text](url)`) and the ability to include up to 10 embeds.
+
 When responding to an interaction received **via webhook**, your server can simply respond to the received `POST` request. You'll want to respond with a `200` status code (if everything went well), as well as specifying a `type` and `data`, which is an [Interaction Response](#DOCS_INTERACTIONS_SLASH_COMMANDS/interaction-response) object:
 
 ```py


### PR DESCRIPTION
An interaction response pinging everyone will definitely be a problem eventually; this definitely should be documented to protect against it.

I put this as a warn block but I'm on the fence between a warn block and a danger block