### PR TITLE
Add discord-slash-commands to community resources

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -45,6 +45,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 
 - [discord-interactions-js](https://github.com/discord/discord-interactions-js)
 - [discord-interactions-python](https://github.com/discord/discord-interactions-python)
+- [discord-slash-commands](https://github.com/MeguminSama/discord-slash-commands)
 
 ## Game SDK Tools
 


### PR DESCRIPTION
discord-slash-commands provides methods for creating, editing, and deleting slash commands via the API. It provides typescript typings for everything used in the interactions API, and includes a validation function which can easily be used as middleware in most Node.JS server libraries.

See it here: https://github.com/MeguminSama/discord-slash-commands

And on NPM: https://npmjs.com/package/slash-commands