### PR TITLE
Add slash-create to community resources

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -45,6 +45,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 
 - [discord-interactions-js](https://github.com/discord/discord-interactions-js)
 - [discord-interactions-python](https://github.com/discord/discord-interactions-python)
+- [slash-create](https://github.com/Snazzah/slash-create)
 
 ## Game SDK Tools
 


### PR DESCRIPTION
`slash-create` is a node module that helps manage commands within a folder and sync them to Discord. It includes typings for TypeScript and automatic security validation for webservers.

Website/Documentation: https://slash-create.js.org/
GitHub Repository: https://github.com/Snazzah/slash-create
NPM: https://www.npmjs.com/package/slash-create