### PR TITLE
Invert pending member description

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -260,7 +260,7 @@ A partial [guild](#DOCS_RESOURCES_GUILD/guild-object) object. Represents an Offl
 | premium_since? | ?ISO8601 timestamp                              | when the user started [boosting](https://support.discord.com/hc/en-us/articles/360028038352-Server-Boosting-) the guild |
 | deaf           | boolean                                         | whether the user is deafened in voice channels                                                                             |
 | mute           | boolean                                         | whether the user is muted in voice channels                                                                               |
-| pending?       | boolean                                         | whether the user has passed the guild's Membership Screening requirements                                                 |
+| pending?       | boolean                                         | whether the user has not yet passed the guild's Membership Screening requirements                                         |
 
 > info
 > The field `user` won't be included in the member object attached to `MESSAGE_CREATE` and `MESSAGE_UPDATE` gateway events.


### PR DESCRIPTION
It seems the description for this field added in #2299 was inverted, or the name of this field is very confusing.
