### PR TITLE
chore: add discord-api-types as a community resource

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -83,3 +83,9 @@ Using Discord's [Dispatch](#DOCS_DISPATCH_DISPATCH_AND_YOU) tool for game develo
 Webhooks and embeds might seem like black magic. That's because they are, but let us help you demystify them a bit. This sweet embed visualizer lets you play around with JSON data and see exactly how it will look embedded in Discord. It even includes a webhook mode!
 
 - [LeoV's Embed Visualizer](https://leovoel.github.io/embed-visualizer/)
+
+## API Typings
+
+If you're working on a project that interacts with our API, you might find these modules useful, as they provide typings of our API that you can use to enhance your coding experience:
+
+- [vladfrangu's Discord API Typings](https://github.com/discordjs/discord-api-types)

--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -84,8 +84,8 @@ Webhooks and embeds might seem like black magic. That's because they are, but le
 
 - [LeoV's Embed Visualizer](https://leovoel.github.io/embed-visualizer/)
 
-## API Typings
+## API Types
 
-If you're working on a project that interacts with our API, you might find these modules useful, as they provide typings of our API that you can use to enhance your coding experience:
+If you're working on a project that interacts with our API, you might find an API types module useful as it provides type inspection/completion for the Discord API.
 
-- [vladfrangu's Discord API Typings](https://github.com/discordjs/discord-api-types)
+- [discord.js API Types](https://github.com/discordjs/discord-api-types)


### PR DESCRIPTION
[discord-api-types](https://github.com/discordjs/discord-api-types) is a TypeScript/JavaScript (enums work in JS, and types can be used in JSDocs via `@type {import('discord-api-types/v8).APIUser}` as an example) module I created that keeps an up-to-date* representation of Discord's current API, that users can use either in library making, or casually if they ever need to do raw API calls. We are keeping this module up to date, and versioning it by the API version provided by Discord.

The main message might need some improvement, so please suggest if you have any! 😅 
(also, are the names.. Discord names, GitHub names? Which one is it 👀 )

\*: Per our readme, we only document types that have received some form of greenlight to be used, so it may be outdated at times

In the future, we might look into a way to turn the TS types into accurate typings in different languages (say, C#, Rust, Go, etc), which users can then use, should they choose to