### PR TITLE
Update the slash commands reference.

### DIFF
--- a/docs/interactions/Slash_Commands.md
+++ b/docs/interactions/Slash_Commands.md
@@ -165,7 +165,7 @@ When a user uses a Slash Command, your app will receive an **Interaction**. Your
 - Via gateway event, `INTERACTION_CREATE` <docs>
 - Via outgoing webhook
 
-These two methods are **mutually exclusive**; you can _only_ receive Interactions one of the two ways. The `INTERACTION_CREATE` gateway event will be handled by the library you are using, so we'll just cover outgoing webhooks.
+These two methods are **mutually exclusive**; you can _only_ receive Interactions one of the two ways. The `INTERACTION_CREATE` [Gateway Event](#DOCS_TOPICS_GATEWAY/interaction-create) may be handled by connected clients, while the webhook method detailed below does not require a connected client.
 
 In your application in the Developer Portal, there is a field on the main page called "Interactions Endpoint URL". If you want to receive Interactions via outgoing webhook, you can set your URL in this field. In order for the URL to be valid, you must be prepared for two things ahead of time:
 


### PR DESCRIPTION
- References the gateway event rather than saying a library will handle it
- No longer presumes that the docs are not also for library devs.
- No longer presumes that every given library has implemented support for this, only indicating that it is possible to support it.
