### PR TITLE
Add caddy-discord-interactions-verifier to Community Resources

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -52,6 +52,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 - [discord-interactions-php](https://github.com/discord/discord-interactions-php)
 - [discord-slash-commands](https://github.com/MeguminSama/discord-slash-commands)
 - [slash-create](https://github.com/Snazzah/slash-create)
+- [caddy-discord-interactions-verifier](https://github.com/CarsonHoffman/caddy-discord-interactions-verifier)
 
 ## Game SDK Tools
 


### PR DESCRIPTION
This PR adds a link to [caddy-discord-interactions-verifier](https://github.com/CarsonHoffman/caddy-discord-interactions-verifier) in the community resources. This module is a fully functional, installable extension to the Caddy web server that performs verification of webhook requests at the edge server, requiring a single line of configuration and zero application-level logic related to verification. Given that many endpoints are fronted by a server like Nginx or Caddy to terminate TLS (which Caddy does very well!), I think that this may be a helpful drop-in module for anyone having trouble handling Ed25519 signature verification at the application level.