### PR TITLE
Fix type of `PercentComplete` for achievements

### DIFF
--- a/docs/game_sdk/Achievements.md
+++ b/docs/game_sdk/Achievements.md
@@ -41,7 +41,7 @@ You can also mark achievements as `secret` and `secure`. "Secret" achievements w
 | --------------- | ------ | ------------------------------------------------------------------------------------------ |
 | UserId          | Int64  | the unique id of the user working on the achievement                                       |
 | AchievementId   | Int64  | the unique id of the achievement                                                           |
-| PercentComplete | Int64  | how far along the user is to completing the achievement (0-100)                            |
+| PercentComplete | UInt8  | how far along the user is to completing the achievement (0-100)                            |
 | UnlockedAt      | string | the timestamp at which the user completed the achievement (PercentComplete was set to 100) |
 
 ## SetUserAchievement
@@ -55,7 +55,7 @@ Returns `Discord.Result` via callback.
 | name            | type  | description                            |
 | --------------- | ----- | -------------------------------------- |
 | achievementId   | Int64 | the id of the achievement to update    |
-| percentComplete | Int64 | the user's updated percentage progress |
+| percentComplete | UInt8 | the user's updated percentage progress |
 
 ###### Example
 


### PR DESCRIPTION
Looking at the GameSDK source code these should be `UInt8`s:
```cpp
struct DiscordUserAchievement {
    DiscordSnowflake user_id;
    DiscordSnowflake achievement_id;
    uint8_t percent_complete;
    DiscordDateTime unlocked_at;
};

struct IDiscordAchievementManager {
    void (*set_user_achievement)(struct IDiscordAchievementManager* manager, DiscordSnowflake achievement_id, uint8_t percent_complete, void* callback_data, void (*callback)(void* callback_data, enum EDiscordResult result));
    // ...
};
```