### PR TITLE
Add Harmony

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -42,7 +42,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [AckCord](https://github.com/Katrix/AckCord)                 | Scala      |
 | [Sword](https://github.com/Azoy/Sword)                       | Swift      |
 | [discordeno](https://github.com/discordeno/discordeno)       | TypeScript |
-| [Harmony](https://github.com/harmony-org/harmony)            | TypeScript |
+| [Harmony](https://github.com/harmonyland/harmony)            | TypeScript |
 
 ## Interactions
 

--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -42,6 +42,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [AckCord](https://github.com/Katrix/AckCord)                 | Scala      |
 | [Sword](https://github.com/Azoy/Sword)                       | Swift      |
 | [discordeno](https://github.com/discordeno/discordeno)       | TypeScript |
+| [Harmony](https://github.com/harmony-org/harmony)            | TypeScript |
 
 ## Interactions
 


### PR DESCRIPTION
# [Harmony](https://github.com/harmonyland/harmony)

An easy to use Discord API Library, for Deno.

Before adding it here, we've confirmed that
- Library handles rate limits correctly.
- Majority of API is supported.

Only voice is not supported yet, as UDP in Deno is unstable.