### PR TITLE
Added DiscordPHP and DiscordPHP-Slash to community resources

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -33,7 +33,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [Dimscord](https://github.com/krisppurg/dimscord)            | Nim        |
 | [discordnim](https://github.com/Krognol/discordnim)          | Nim        |
 | [RestCord](https://www.restcord.com/)                        | PHP        |
-| [DiscordPHP](https://github.com/teamreflex/DiscordPHP)       | PHP        |
+| [DiscordPHP](https://github.com/discord-php/DiscordPHP)      | PHP        |
 | [discord.py](https://github.com/Rapptz/discord.py)           | Python     |
 | [disco](https://github.com/b1naryth1ef/disco)                | Python     |
 | [discordrb](https://github.com/shardlab/discordrb)           | Ruby       |
@@ -54,7 +54,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 - [discord-slash-commands](https://github.com/MeguminSama/discord-slash-commands)
 - [slash-create](https://github.com/Snazzah/slash-create)
 - [caddy-discord-interactions-verifier](https://github.com/CarsonHoffman/caddy-discord-interactions-verifier)
-- [DiscordPHP-Slash](https://github.com/davidcole1340/DiscordPHP-Slash)
+- [DiscordPHP-Slash](https://github.com/discord-php/DiscordPHP-Slash)
 
 ## Game SDK Tools
 

--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -33,6 +33,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [Dimscord](https://github.com/krisppurg/dimscord)            | Nim        |
 | [discordnim](https://github.com/Krognol/discordnim)          | Nim        |
 | [RestCord](https://www.restcord.com/)                        | PHP        |
+| [DiscordPHP](https://github.com/teamreflex/DiscordPHP)       | PHP        |
 | [discord.py](https://github.com/Rapptz/discord.py)           | Python     |
 | [disco](https://github.com/b1naryth1ef/disco)                | Python     |
 | [discordrb](https://github.com/shardlab/discordrb)           | Ruby       |
@@ -53,6 +54,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 - [discord-slash-commands](https://github.com/MeguminSama/discord-slash-commands)
 - [slash-create](https://github.com/Snazzah/slash-create)
 - [caddy-discord-interactions-verifier](https://github.com/CarsonHoffman/caddy-discord-interactions-verifier)
+- [DiscordPHP-Slash](https://github.com/davidcole1340/DiscordPHP-Slash)
 
 ## Game SDK Tools
 

--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -32,8 +32,8 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [Discordia](https://github.com/SinisterRectus/Discordia)     | Lua        |
 | [Dimscord](https://github.com/krisppurg/dimscord)            | Nim        |
 | [discordnim](https://github.com/Krognol/discordnim)          | Nim        |
-| [RestCord](https://www.restcord.com/)                        | PHP        |
 | [DiscordPHP](https://github.com/discord-php/DiscordPHP)      | PHP        |
+| [RestCord](https://www.restcord.com/)                        | PHP        |
 | [discord.py](https://github.com/Rapptz/discord.py)           | Python     |
 | [disco](https://github.com/b1naryth1ef/disco)                | Python     |
 | [discordrb](https://github.com/shardlab/discordrb)           | Ruby       |


### PR DESCRIPTION
DiscordPHP has returned from the dead and most (all?) of the latest features have been implemented.

The rate-limit system was approved [back in 2016](https://github.com/discord/discord-api-docs/issues/108#issuecomment-233491404) but has been revamped to handle rate-limit buckets which were not present back then. This includes halting all requests on a 429 and attempting to bundle requests together to predict rate-limits.

The current rate-limit handling can be found here:
- https://github.com/discord-php/DiscordPHP/blob/master/src/Discord/Http/Bucket.php#L144-L188
- https://github.com/discord-php/DiscordPHP/blob/master/src/Discord/Http/Http.php#L263-L282

All notable features are implemented including the REST and WebSocket APIs as well as sending/receiving voice.

--

Also added the DiscordPHP-Slash library to community resources. Allows users to register commands with the Discord servers as well as a script that can be served to listen for interactions sent to the endpoint.

Rate-limiting logic for DiscordPHP-Slash is limited to halting all requests on a 429 response:
- https://github.com/discord-php/DiscordPHP-Slash/blob/master/src/Discord/RegisterClient.php#L296-L303

Since all HTTP requests are related to registering commands I don't forsee any rate-limit issues because the library is synchronous.
