### PR TITLE
Update followup and webhook endpoint docs, and document error 50027

### DIFF
--- a/docs/interactions/Slash_Commands.md
+++ b/docs/interactions/Slash_Commands.md
@@ -717,7 +717,7 @@ Deletes the initial Interaction response. Returns `204` on success.
 
 ## Create Followup Message % POST /webhooks/{application.id#DOCS_TOPICS_OAUTH2/application-object}/{interaction.token#DOCS_INTERACTIONS_SLASH_COMMANDS/interaction}
 
-Create a followup message for an Interaction. Functions the same as [Execute Webhook](#DOCS_RESOURCES_WEBHOOK/execute-webhook)
+Create a followup message for an Interaction. Functions the same as [Execute Webhook](#DOCS_RESOURCES_WEBHOOK/execute-webhook), but `wait` is always true.
 
 ## Edit Followup Message % PATCH /webhooks/{application.id#DOCS_TOPICS_OAUTH2/application-object}/{interaction.token#DOCS_INTERACTIONS_SLASH_COMMANDS/interaction}/messages/{message.id#DOCS_RESOURCES_CHANNEL/message-object}
 

--- a/docs/resources/Webhook.md
+++ b/docs/resources/Webhook.md
@@ -152,7 +152,7 @@ Add a new webhook to your GitHub repo (in the repo's settings), and use this end
 
 ## Edit Webhook Message % PATCH /webhooks/{webhook.id#DOCS_RESOURCES_WEBHOOK/webhook-object}/{webhook.token#DOCS_RESOURCES_WEBHOOK/webhook-object}/messages/{message.id#DOCS_RESOURCES_CHANNEL/message-object}
 
-Edits a previously-sent webhook message from the same token.
+Edits a previously-sent webhook message from the same token. Returns a [message](#DOCS_RESOURCES_CHANNEL/message-object) object on success.
 
 > info
 > All parameters to this endpoint are optional and nullable.

--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -171,6 +171,7 @@ Along with the HTTP error code, our API can also return more detailed error code
 | 50021  | Cannot execute action on a system message                                                                                     |
 | 50024  | Cannot execute action on this channel type                                                                                    |
 | 50025  | Invalid OAuth2 access token provided                                                                                          |
+| 50027  | Invalid webhook token provided                                                                                                |
 | 50033  | "Invalid Recipient(s)"                                                                                                        |
 | 50034  | A message provided was too old to bulk delete                                                                                 |
 | 50035  | Invalid form body (returned for both `application/json` and `multipart/form-data` bodies), or invalid `Content-Type` provided |


### PR DESCRIPTION
- document that `wait` is always true in Create Followup Message (always returns a message object)
- document that Edit Webhook Message (and by extension, Edit Original Interaction Response and Edit Followup Message) returns a message object
- Documents JSON error code 50027 Invalid Webhook Token*

\* This seems to 500 instead sometimes but I can't figure out what exactly causes it