### PR TITLE
Document cover_image on application integration

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -330,14 +330,15 @@ A partial [guild](#DOCS_RESOURCES_GUILD/guild-object) object. Represents an Offl
 
 ###### Integration Application Structure
 
-| Field       | Type                                            | Description                                                  |
-| -----       | ----------------------------------------------- | ------------------------------------------------------------ |
-| id          | snowflake                                       | the id of the app                                            |
-| name        | string                                          | the name of the app                                          |
-| icon        | ?string                                         | the [icon hash](#DOCS_REFERENCE/image-formatting) of the app |
-| description | string                                          | the description of the app                                   |
-| summary     | string                                          | the description of the app                                   |
-| bot?        | [user](#DOCS_RESOURCES_USER/user-object) object | the bot associated with this application                     |
+| Field        | Type                                            | Description                                                                                             |
+| ------------ | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| id           | snowflake                                       | the id of the app                                                                                       |
+| name         | string                                          | the name of the app                                                                                     |
+| icon         | ?string                                         | the [icon hash](#DOCS_REFERENCE/image-formatting) of the app                                            |
+| description  | string                                          | the description of the app                                                                              |
+| summary      | string                                          | the description of the app                                                                              |
+| cover_image? | string                                          | if this application is a game sold on Discord, this field will be the hash of the image on store embeds |
+| bot?         | [user](#DOCS_RESOURCES_USER/user-object) object | the bot associated with this application                                                                |
 
 ### Ban Object
 


### PR DESCRIPTION
Documents the `cover_image` property on the guild application integration structure.

Got the description from https://github.com/discord/discord-api-docs/blob/6164ed3565f11dc7df7216749ef0014c18c72939/docs/topics/OAuth2.md#application-object