### PR TITLE
DM Slash Commands

### DIFF
--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -1,5 +1,9 @@
 # Change Log
 
+#### February XX, 2021
+
+Slash Commands are now supported in DMs with bots. Due to this change, some of the fields on the [Interaction object](#DOCS_INTERACTIONS_SLASH_COMMANDS/interaction) have been made optional. Newly optional fields don't reflect any behavior changes in Slash Commands within guilds; they are to support commands in the context of a DM only.
+
 #### January 22, 2021
 
 Permission overwrites in the guild channel creation endpoint are now validated against the permissions your bot has in the guild. Permission overwrites specified in the request body when creating guild channels will now require your bot to also have the permissions being applied. Setting `MANAGE_ROLES` permission in channel overwrites is only possible for guild administrators or users with `MANAGE_ROLES` as a permission overwrite in the channel.

--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -1,8 +1,12 @@
 # Change Log
 
-#### February XX, 2021
+## Slash Commands in DMs
+
+#### February 9, 2021
 
 Slash Commands are now supported in DMs with bots. Due to this change, some of the fields on the [Interaction object](#DOCS_INTERACTIONS_SLASH_COMMANDS/interaction) have been made optional. Newly optional fields don't reflect any behavior changes in Slash Commands within guilds; they are to support commands in the context of a DM only.
+
+## Change to Permission Checking when Creating Channels
 
 #### January 22, 2021
 
@@ -38,7 +42,7 @@ Inline Replies have been added to our documentation. They behave differently in 
 
 Stickers are now documented as part of the [message](#DOCS_RESOURCES_CHANNEL/message-object) object. 
 
-## API and Gateway V8
+## Gateway v6 Intent Restrictions
 
 #### October 27, 2020
 
@@ -46,6 +50,8 @@ The v6 gateway now applies the restrictions for gateway intents. This means the 
 Additionally, if privileged intents are not enabled in the application dashboard the bot will not receive the events for those intents.
 
 All other intents are always enabled by default unless specified otherwise by the identify payload. We have made a support article to explain some of the changes and resulting issues with more details: [Gateway Update FAQ](https://dis.gd/gwupdate)
+
+## API and Gateway V8
 
 #### September 24, 2020
 

--- a/docs/interactions/Slash_Commands.md
+++ b/docs/interactions/Slash_Commands.md
@@ -62,7 +62,9 @@ Who knows, maybe in the future, Interactions tokens will become even smarter.
 > info
 > Currently, Slash Commands can only be registered via HTTP endpoint.
 
-There are two kinds of Slash Commands: global commands and guild commands. Global commands are available for every guild that adds your app; guild commands are specific to the guild you specify when making them. Command names are unique per application within each scope (global and guild). That means:
+There are two kinds of Slash Commands: global commands and guild commands. Global commands are available for every guild that adds your app. An individual app's global commands are also available in DMs if that app has a bot that shares a mutual guild with the user.
+
+Guild commands are specific to the guild you specify when making them. Guild commands are not available in DMs. Command names are unique per application within each scope (global and guild). That means:
 
 - Your app **cannot** have two global commands with the same name
 - Your app **cannot** have two guild commands within the same name **on the same guild**
@@ -790,20 +792,23 @@ If you specify `choices` for an option, they are the **only** valid values for a
 
 ## Interaction
 
-An interaction is the base "thing" that is sent when a user invokes a command, and is the same for Slash Commands and other future interaction types
+An interaction is the base "thing" that is sent when a user invokes a command, and is the same for Slash Commands and other future interaction types.
 
-| Field      | Type                                                             | Description                                                    |
-|------------|------------------------------------------------------------------|----------------------------------------------------------------|
-| id         | snowflake                                                        | id of the interaction                                          |
-| type       | InteractionType                                                  | the type of interaction                                        |
-| data?\*    | ApplicationCommandInteractionData                                | the command data payload                                       |
-| guild_id   | snowflake                                                        | the guild it was sent from                                     |
-| channel_id | snowflake                                                        | the channel it was sent from                                   |
-| member     | [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object | guild member data for the invoking user, including permissions |
-| token      | string                                                           | a continuation token for responding to the interaction         |
-| version    | int                                                              | read-only property, always `1`                                 |
+| Field        | Type                                                             | Description                                                    |
+|--------------|------------------------------------------------------------------|----------------------------------------------------------------|
+| id           | snowflake                                                        | id of the interaction                                          |
+| type         | InteractionType                                                  | the type of interaction                                        |
+| data?\*      | ApplicationCommandInteractionData                                | the command data payload                                       |
+| guild_id?    | snowflake                                                        | the guild it was sent from                                     |
+| channel_id?  | snowflake                                                        | the channel it was sent from                                   |
+| member?\*\*  | [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object | guild member data for the invoking user, including permissions |
+| user?        | [user](#DOCS_RESOURCES_USER/user-object) object                  | user object for the invoking user, if invoked in a DM          |
+| token        | string                                                           | a continuation token for responding to the interaction         |
+| version      | int                                                              | read-only property, always `1`                                 |
 
 \* This is always present on `ApplicationCommand` interaction types. It is optional for future-proofing against new interaction types
+
+\*\* `member` is sent when the command is invoked in a guild, and `user` is sent when invoked in a DM
 
 ###### InteractionType
 


### PR DESCRIPTION
These changes are not yet deployed, so this PR is intended as a heads up!

Soon we'll be adding the ability for users to invoke your bot's global slash commands within a DM. Due to that change, some of the fields on the interaction object have been made optional. For example, `guild_id` is optional because you would not receive one in a DM interaction.

However, the behavior of slash commands within guilds today remains unchanged.

We've also added a `user` object to the interaction payload. When a command is invoked from a DM, you will receive the `user` and not the guild member. When invoked in a guild, you will receive a `member` and not a `user`.

Quick note--these fields are not necessarily mutually exclusive. We are exploring ideas like always sending the user object, but that's not included in this change. So, you can write your code assuming that you should check `member` and `user` in certain cases, but do not assume they will always be mutually exclusive.