### PR TITLE
Add https://rauf.wtf/slash to the Community Resources

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -61,6 +61,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
   - [DiscordPHP-Slash](https://github.com/discord-php/DiscordPHP-Slash)
 - Other
   - [caddy-discord-interactions-verifier](https://github.com/CarsonHoffman/caddy-discord-interactions-verifier)
+  - [Rauf's Slash Command Generator](https://rauf.wtf/slash)
 
 
 ## Game SDK Tools


### PR DESCRIPTION
[Rauf's Slash Command Generator](https://rauf.wtf/slash) is a JSON payload generator for easily creating slash commands.