### PR TITLE
Link to slash commands in Intro page

### DIFF
--- a/docs/Intro.md
+++ b/docs/Intro.md
@@ -12,7 +12,7 @@ If you believe you're experiencing a bug with our API or want to report incorrec
 
 Bots and apps are the lifeblood of the Discord development community. They come in all shapes and sizes, from small hobby projects for your server with friends, to huge projects that live in hundreds of thousands of servers. We love seeing the unique, fun, and sometimes downright strange (in a good way) creations that come from our community.
 
-Discord offers an open API to serve requests for both bots and OAuth2 integrations. So whether you’re making your own [`/wumpus` commands](https://discord.com/developers/docs/interactions/slash-commands) or looking to `Log In With Discord`, we’ve got you covered.
+Discord offers an open API to serve requests for both bots and OAuth2 integrations. So whether you’re making your own [`/wumpus` commands](#DOCS_INTERACTIONS_SLASH_COMMANDS/) or looking to `Log In With Discord`, we’ve got you covered.
 
 So go do it! Go! Go [make an app](https://discord.com/developers/applications) and create something awesome.
 

--- a/docs/Intro.md
+++ b/docs/Intro.md
@@ -12,7 +12,7 @@ If you believe you're experiencing a bug with our API or want to report incorrec
 
 Bots and apps are the lifeblood of the Discord development community. They come in all shapes and sizes, from small hobby projects for your server with friends, to huge projects that live in hundreds of thousands of servers. We love seeing the unique, fun, and sometimes downright strange (in a good way) creations that come from our community.
 
-Discord offers an open API to serve requests for both bots and OAuth2 integrations. So whether you’re making your own `!wumpus` commands or looking to `Log In With Discord`, we’ve got you covered.
+Discord offers an open API to serve requests for both bots and OAuth2 integrations. So whether you’re making your own [`/wumpus` commands](https://discord.com/developers/docs/interactions/slash-commands) or looking to `Log In With Discord`, we’ve got you covered.
 
 So go do it! Go! Go [make an app](https://discord.com/developers/applications) and create something awesome.
 


### PR DESCRIPTION
Hello,

This patch updates the Intro doc to reference `/slash` commands instead of  `!bang` commands, now that Discord supports custom slash commands. I've also linked to that documentation for good measure.

I did a quick check, and didn't find any similar references:
```
$ rg -o '.{0,4}!\w.{0,4}'
docs/Intro.md
15:wn `!wumpu

docs/Reference.md
237:| <@!USER_
237:| <@!80351

docs/game_sdk/Overlay.md
37:if (!overl

docs/interactions/Slash_Commands.md
332:if (!isVer

docs/game_sdk/Storage.md
201:if (!highS

docs/game_sdk/Discord_Voice.md
244:if (!voice

docs/game_sdk/SDK_Starter_Guide.md
49:gain!_ The
```

Thanks!