### PR TITLE
Change information about Get Guild Members endpoint

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -648,7 +648,7 @@ Returns a [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object for t
 Returns a list of [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) objects that are members of the guild.
 
 > warn
-> In the future, this endpoint will be restricted in line with our [Privileged Intents](#DOCS_TOPICS_GATEWAY/privileged-intents)
+> Currently, this endpoint requires the SERVER MEMBERS [Privileged Intent](#DOCS_TOPICS_GATEWAY/privileged-intents)
 
 > info
 > All parameters to this endpoint are optional


### PR DESCRIPTION
### Update information about the `Get Guild Members` endpoint and Privileged Intents.

I believe that the `Get Guild Members` endpoint now requires a privileged intent, so I changed the warning block.