### PR TITLE
Add discord-ext-slash to the Community Resources

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -56,6 +56,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
   - [discord-py-slash-command](https://github.com/eunwoo1104/discord-py-slash-command)
   - [discord-interactions-python](https://github.com/discord/discord-interactions-python)
   - [dispike](https://github.com/ms7m/dispike)
+  - [discord-ext-slash](https://github.com/Kenny2github/discord-ext-slash)
 - PHP
   - [discord-interactions-php](https://github.com/discord/discord-interactions-php)
   - [DiscordPHP-Slash](https://github.com/discord-php/DiscordPHP-Slash)


### PR DESCRIPTION
[discord-ext-slash](https://github.com/Kenny2github/discord-ext-slash) is an extension that adds `discord.ext.slash` to [discord.py](https://github.com/Rapptz/discord.py) in the same manner as the built-in `discord.ext.commands`.