### PR TITLE
Add Deno Discord Slash Commands to the Community Resources

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -50,9 +50,8 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 
 - Javascript
   - [discord-interactions-js](https://github.com/discord/discord-interactions-js)
+  - [discord-slash-commands](https://github.com/MeguminSama/discord-slash-commands) [Deno fork](https://deno.land/x/discord_slash_commands)
   - [slash-create](https://github.com/Snazzah/slash-create)
-  - [discord-slash-commands](https://github.com/MeguminSama/discord-slash-commands)
-  - [deno-discord-slash-commands](https://deno.land/x/discord_slash_commands)
 - Python
   - [discord-py-slash-command](https://github.com/eunwoo1104/discord-py-slash-command)
   - [discord-interactions-python](https://github.com/discord/discord-interactions-python)

--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -52,6 +52,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
   - [discord-interactions-js](https://github.com/discord/discord-interactions-js)
   - [slash-create](https://github.com/Snazzah/slash-create)
   - [discord-slash-commands](https://github.com/MeguminSama/discord-slash-commands)
+  - [deno-discord-slash-commands](https://deno.land/x/discord_slash_commands)
 - Python
   - [discord-py-slash-command](https://github.com/eunwoo1104/discord-py-slash-command)
   - [discord-interactions-python](https://github.com/discord/discord-interactions-python)


### PR DESCRIPTION
[Deno-Discord-Slash-Commands](https://github.com/Redstoneguy129/Deno-Discord-Slash-Commands) is a simple Deno wrapper for slash commands. It provides get/send/edit/delete methods for handling responses/follow up messages, as well as a verify signature function for receiving slash command requests from discord.