### PR TITLE
Make slash command limits consistent between limits and registering sections

### DIFF
--- a/docs/interactions/Slash_Commands.md
+++ b/docs/interactions/Slash_Commands.md
@@ -77,7 +77,7 @@ Guild commands are specific to the guild you specify when making them. Guild com
 - Multiple apps **can** have commands with the same names
 
 > info
-> Apps can have a maximum of 50 global commands, and an additional 50 guild-specific commands per guild
+> Apps can have a maximum of 100 global commands, and an additional 100 guild-specific commands per guild
 
 To make a **global** Slash Command, make an HTTP POST call like this:
 


### PR DESCRIPTION
Currently the Limits section details the ability to create 100 global and 100 per-guild commands, but in the Registering a Command section it says 50 of each, this PR changes the Register section to 100/100 rather than 50/50