### PR TITLE
chore: consistency in references to query string

### DIFF
--- a/docs/resources/Audit_Log.md
+++ b/docs/resources/Audit_Log.md
@@ -181,7 +181,7 @@ Whenever an admin action is performed on the API, an entry is added to the respe
 
 Returns an [audit log](#DOCS_RESOURCES_AUDIT_LOG/audit-log-object) object for the guild. Requires the 'VIEW_AUDIT_LOG' permission.
 
-###### Query String Parameters
+###### Query String Params
 
 | Field       | Type      | Description                                                                                      |
 | ----------- | --------- | ------------------------------------------------------------------------------------------------ |

--- a/docs/resources/Invite.md
+++ b/docs/resources/Invite.md
@@ -90,7 +90,7 @@ Extra information about an invite, will extend the [invite](#DOCS_RESOURCES_INVI
 
 Returns an [invite](#DOCS_RESOURCES_INVITE/invite-object) object for the given code.
 
-###### Get Invite URL Parameters
+###### Query String Params
 
 | Field        | Type    | Description                                                 |
 | ------------ | ------- | ----------------------------------------------------------- |

--- a/docs/resources/Webhook.md
+++ b/docs/resources/Webhook.md
@@ -108,7 +108,7 @@ Same as above, except this call does not require authentication.
 > warn
 > This endpoint supports both JSON and form data bodies. It does require multipart/form-data requests instead of the normal JSON request type when uploading files. Make sure you set your `Content-Type` to `multipart/form-data` if you're doing that. Note that in that case, the `embeds` field cannot be used, but you can pass an url-encoded JSON body as a form value for `payload_json`.
 
-###### Querystring Params
+###### Query String Params
 
 | Field | Type    | Description                                                                                                                                                                                  | Required |
 | ----- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
@@ -132,7 +132,7 @@ Same as above, except this call does not require authentication.
 
 ## Execute Slack-Compatible Webhook % POST /webhooks/{webhook.id#DOCS_RESOURCES_WEBHOOK/webhook-object}/{webhook.token#DOCS_RESOURCES_WEBHOOK/webhook-object}/slack
 
-###### Querystring Params
+###### Query String Params
 
 | Field | Type    | Description                                                                                                                                           | Required |
 | ----- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
@@ -142,7 +142,7 @@ Refer to [Slack's documentation](https://api.slack.com/incoming-webhooks) for mo
 
 ## Execute GitHub-Compatible Webhook % POST /webhooks/{webhook.id#DOCS_RESOURCES_WEBHOOK/webhook-object}/{webhook.token#DOCS_RESOURCES_WEBHOOK/webhook-object}/github
 
-###### Querystring Params
+###### Query String Params
 
 | Field | Type    | Description                                                                                                                                           | Required |
 | ----- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |

--- a/docs/topics/Certified_Devices.md
+++ b/docs/topics/Certified_Devices.md
@@ -16,7 +16,7 @@ Yup, that's it. You give us the real-time info about any connected devices, and 
 
 ## Connecting
 
-###### Querystring Parameters
+###### Query String Params
 
 | Name      | Value                | Required  |
 | --------- | -------------------- | --------- |

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -95,7 +95,7 @@ def on_websocket_message(msg):
 
 ### Connecting
 
-###### Gateway URL Params
+###### Gateway URL Query String Params
 
 | Field     | Type    | Description                                   | Accepted Values                                                            |
 |-----------|---------|-----------------------------------------------|----------------------------------------------------------------------------|


### PR DESCRIPTION
`Query String Parameters` -> `Query String Params` (due to `JSON Params`)
`Querystring Params` -> `Query String Params` (prevalence)