### PR TITLE
chore: correct `Type` column for `activities` in OP 3

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -671,12 +671,12 @@ Sent by the client to indicate a presence or status update.
 
 ###### Gateway Presence Update Structure
 
-| Field      | Type                                                               | Description                                                                                 |
-|------------|--------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| since      | ?integer                                                           | unix time (in milliseconds) of when the client went idle, or null if the client is not idle |
-| activities | array of [activity](#DOCS_TOPICS_GATEWAY/activity-object) objects  | the user's activities                                                                       |
-| status     | string                                                             | the user's new [status](#DOCS_TOPICS_GATEWAY/update-status-status-types)                    |
-| afk        | boolean                                                            | whether or not the client is afk                                                            |
+| Field      | Type                                                              | Description                                                                                 |
+|------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
+| since      | ?integer                                                          | unix time (in milliseconds) of when the client went idle, or null if the client is not idle |
+| activities | array of [activity](#DOCS_TOPICS_GATEWAY/activity-object) objects | the user's activities                                                                       |
+| status     | string                                                            | the user's new [status](#DOCS_TOPICS_GATEWAY/update-status-status-types)                    |
+| afk        | boolean                                                           | whether or not the client is afk                                                            |
 
 ###### Status Types
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -674,7 +674,7 @@ Sent by the client to indicate a presence or status update.
 | Field      | Type                                                               | Description                                                                                 |
 |------------|--------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
 | since      | ?integer                                                           | unix time (in milliseconds) of when the client went idle, or null if the client is not idle |
-| activities | ?array of [activity](#DOCS_TOPICS_GATEWAY/activity-object) objects | the user's activities                                                              |
+| activities | array of [activity](#DOCS_TOPICS_GATEWAY/activity-object) objects  | the user's activities                                                                       |
 | status     | string                                                             | the user's new [status](#DOCS_TOPICS_GATEWAY/update-status-status-types)                    |
 | afk        | boolean                                                            | whether or not the client is afk                                                            |
 


### PR DESCRIPTION
Per commit https://github.com/discord/discord-api-docs/commit/5bf598b864fb89262fce07137f68ce6e7e583432, `activities` cannot be null, yet the column for type said otherwise.