### PR TITLE
Fix Edit Application Command Permissions json-params section

### DIFF
--- a/docs/interactions/Slash_Commands.md
+++ b/docs/interactions/Slash_Commands.md
@@ -815,9 +815,9 @@ Edits command permissions for a specific command for your application in a guild
 
 ###### JSON Params
 
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| permissions | array of [ApplicationCommandPermissions] |
+| Field       | Type                                                                                                      | Description                                  |
+| ----------- | --------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| permissions | array of [ApplicationCommandPermissions](#DOCS_INTERACTIONS_SLASH_COMMANDS/applicationcommandpermissions) | the permissions for the command in the guild |
 
 ## Batch Edit Application Command Permissions % PUT /applications/{application.id#DOCS_TOPICS_OAUTH2/application-object}/guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/commands/permissions
 


### PR DESCRIPTION
Fix https://discord.com/developers/docs/interactions/slash-commands#edit-application-command-permissions-json-params not having description nor link