### PR TITLE
Update Community_Resources.md to include D++ library

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -18,6 +18,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | ------------------------------------------------------------ | ---------- |
 | [discljord](https://github.com/igjoshua/discljord)           | Clojure    |
 | [aegis.cpp](https://github.com/zeroxs/aegis.cpp)             | C++        |
+| [D++](https://github.com/brainboxdotcc/DPP)                  | C++        |
 | [Sleepy Discord](https://github.com/yourWaifu/sleepy-discord)| C++        |
 | [discordcr](https://github.com/shardlab/discordcr)           | Crystal    |
 | [Discord.Net](https://github.com/RogueException/Discord.Net) | C#         |


### PR DESCRIPTION
I've added D++ (DPP) here.
This is my C++ library which is open source and intended to replace aegis in my own bots.

You can find **examples of rate limit code** here: https://github.com/brainboxdotcc/DPP/blob/master/src/dpp/queues.cpp#L226
This library respects all rate limits from the X-RateLimit headers including special case for global rate limiting.

You can find examples of **slash command/interaction** code here: https://github.com/brainboxdotcc/DPP/blob/master/src/dpp/slashcommand.cpp
Here is an example of how it's used: https://dpp.brainbox.cc/a00014.html

**Intents are fully supported** (this is required for my own bots to identify). Examples of this code can be found here: https://github.com/brainboxdotcc/DPP/blob/master/src/dpp/discordclient.cpp#L247
The user sets the intents from the constructor of the main object of the library. e.g. `dpp::cluster bot("token", intents);`

The design ideal of this library differs from aegis and sleepy_discord by intending to be as *lightweight as possible for larger bots*. Please consider for addition at your leisure.

__**I WELCOME CONSTRUCTIVE FEEDBACK**__ on my library implementation!