### PR TITLE
JSON body reason overrides `X-Audit-Log-Reason`

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -766,6 +766,9 @@ Returns a [ban](#DOCS_RESOURCES_GUILD/ban-object) object for the given user or a
 
 Create a guild ban, and optionally delete previous messages sent by the banned user. Requires the `BAN_MEMBERS` permission. Returns a 204 empty response on success. Fires a [Guild Ban Add](#DOCS_TOPICS_GATEWAY/guild-ban-add) Gateway event.
 
+> info
+> Supplying a reason in the JSON body will override `X-Audit-Log-Reason` header if both are provided.
+
 ###### JSON Params
 
 | Field                | Type    | Description                                 |
@@ -848,6 +851,9 @@ Begin a prune operation. Requires the `KICK_MEMBERS` permission. Returns an obje
 
 By default, prune will not remove users with roles. You can optionally include specific roles in your prune by providing the `include_roles` parameter. Any inactive user that has a subset of the provided role(s) will be included in the prune and users with additional roles will not.
 
+> info
+> Supplying a reason in the JSON body will override `X-Audit-Log-Reason` header if both are provided.
+
 ###### JSON Params
 
 | Field               | Type                | Description                                                | Default |
@@ -855,6 +861,7 @@ By default, prune will not remove users with roles. You can optionally include s
 | days                | integer             | number of days to prune (1-30)                             | 7       |
 | compute_prune_count | boolean             | whether 'pruned' is returned, discouraged for large guilds | true    |
 | include_roles       | array of snowflakes | role(s) to include                                         | none    |
+| reason?             | string              | reason for the prune                                       |         |
 
 ## Get Guild Voice Regions % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/regions
 


### PR DESCRIPTION
- https://github.com/discord/discord-api-docs/issues/1751
- https://github.com/discord/discord-api-docs/issues/2595

Through a bit of testing, it seems that JSON body reason will override `X-Audit-Log-Reason` header if both are given. Otherwise, they are both functionally the same.

Also expose `reason` in JSON body works in Begin Guild Prune.