### PR TITLE
add 'the' in dispatch/Error_Codes for consistency

### DIFF
--- a/docs/dispatch/Error_Codes.md
+++ b/docs/dispatch/Error_Codes.md
@@ -14,7 +14,7 @@ This page outlines some of the common errors codes that may be encountered when 
 | 2025 | Install Script Failed      | Restart Discord, attempt to uninstall/reinstall the game, ensure script is correct                                                             |
 | 2029 | Build Not Found            | Completely close and re-open Discord                                                                                                           |
 | 2051 | Panic!                     | Escalate in the dev server in #dispatch                                                                                                        |
-| 2058 | Too Many API Retries       | Escalate in dev server in #dispatch                                                                                                            |
+| 2058 | Too Many API Retries       | Escalate in the dev server in #dispatch                                                                                                            |
 | 2059 | Failed to set Registry Key | User most likely denied Windows administrator permissions prompt. Try again, and accept the prompt                                             |
 | 2064 | Failed to Patch File       | Attempted to patch the game while running: ensure the game process is entirely ended, try restarting Discord, try disabling antivirus          |
 | 2065 | No Manifests               | Ensure that your manifests are properly selected in the Developer Portal for your SKU                                                          |


### PR DESCRIPTION
In [the Error Codes section of the documentation for dispatch](https://discord.com/developers/docs/dispatch/error-codes#error-codes), the possible solutions for error code `2051` and `2058` differ by a single word (`the`).

Instead of `Escalate in the dev server in #dispatch`, the error code `2058` uses `Escalate in dev server in #dispatch`.

This PR adds the missing word `the` to error code `2058`.