### PR TITLE
Document the need to pass required command options before optional ones.

### DIFF
--- a/docs/interactions/Slash_Commands.md
+++ b/docs/interactions/Slash_Commands.md
@@ -883,6 +883,9 @@ An application command is the base "command" model that belongs to an applicatio
 | options?       | array of [ApplicationCommandOption](#DOCS_INTERACTIONS_SLASH_COMMANDS/applicationcommandoption) | the parameters for the command               |
 | default_permission? | boolean (default `true`) | whether the command is enabled by default when the app is added to a guild |
 
+> warn
+> You need to pass required options before optional ones, otherwise it will return an error.
+
 ## ApplicationCommandOption
 
 > info

--- a/docs/interactions/Slash_Commands.md
+++ b/docs/interactions/Slash_Commands.md
@@ -884,7 +884,7 @@ An application command is the base "command" model that belongs to an applicatio
 | default_permission? | boolean (default `true`) | whether the command is enabled by default when the app is added to a guild |
 
 > warn
-> Required options must be before optional options
+> Required `options` must be listed before optional options
 
 ## ApplicationCommandOption
 

--- a/docs/interactions/Slash_Commands.md
+++ b/docs/interactions/Slash_Commands.md
@@ -884,7 +884,7 @@ An application command is the base "command" model that belongs to an applicatio
 | default_permission? | boolean (default `true`) | whether the command is enabled by default when the app is added to a guild |
 
 > warn
-> You need to pass required options before optional ones, otherwise it will return an error.
+> Required options must be before optional options
 
 ## ApplicationCommandOption
 


### PR DESCRIPTION
This PR documents the fact that when passing `options` to an `ApplicationCommand`, it is needed to put required options before optional ones.