### PR TITLE
Document proper ways to pass boolean query strings

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -218,6 +218,10 @@ Clients may append more information and metadata to the _end_ of this string as 
 
 The HTTP API implements a process for limiting and preventing excessive requests in accordance with [RFC 6585](https://tools.ietf.org/html/rfc6585#section-4). API users that regularly hit and ignore rate limits will have their API keys revoked, and be blocked from the platform. For more information on rate limiting of requests, please see the [Rate Limits](#DOCS_TOPICS_RATE_LIMITS/rate-limits) section.
 
+### Boolean Query Strings
+
+Certain endpoints in the API are documented to accept booleans for their query string parameters. While there is no standard system for boolean representation in query string parameters, Discord represents such cases using `True`, `true`, or `1` for true and `False`, `false` or `0` for false.
+
 ## Gateway (WebSocket) API
 
 Discord's Gateway API is used for maintaining persistent, stateful websocket connections between your client and our servers. These connections are used for sending and receiving real-time events your client can use to track and update local state. The Gateway API uses secure websocket connections as specified in [RFC 6455](https://tools.ietf.org/html/rfc6455). For information on opening Gateway connections, please see the [Gateway API](#DOCS_TOPICS_GATEWAY/gateways) section.


### PR DESCRIPTION
There is no standardised way to pass boolean query string parameters. While to some people the value might be obvious, I think it's good to document what is considered valid as a boolean parameter. That way there's no ambiguity. Some libraries such as [yarl](https://yarl.readthedocs.io/en/latest/index.html#yarl-bools-support) don't support booleans and their encoding must be explicitly done by the API consumer. This confusion is also present in some StackOverflow questions ([1](https://stackoverflow.com/questions/29739970/how-to-pass-boolean-variable-of-false-in-a-url), [2](https://stackoverflow.com/questions/48550145/what-is-the-standard-way-to-pass-a-boolean-value-through-a-query-string), [3](https://stackoverflow.com/questions/39979533/how-should-rest-api-accept-boolean-values)) and all the answers mainly point to how it depends on how the server is designed to accept such things.