### PR TITLE
Add Detritus to the library list

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -48,6 +48,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [Twilight](https://github.com/twilight-rs/twilight)          | Rust       |
 | [AckCord](https://github.com/Katrix/AckCord)                 | Scala      |
 | [Sword](https://github.com/Azoy/Sword)                       | Swift      |
+| [Detritus](https://github.com/detritusjs/client)             | TypeScript |
 | [discordeno](https://github.com/discordeno/discordeno)       | TypeScript |
 | [Harmony](https://github.com/harmonyland/harmony)            | TypeScript |
 


### PR DESCRIPTION
[Github Link](https://github.com/detritusjs/client)

It's confirmed that the library
- Handles ratelimits correctly (with most sub-ratelimits supported as well)
- All of the REST endpoints are supported
- All of the websocket events are supported

Currently been using it for about a year with one of my bots that's in 500k+ servers.

The library is split up into three components

- [REST Client](https://github.com/detritusjs/client-rest)
  - Just a rest client that implements all of Discord's rest endpoints, just gives you the raw responses from Discord
- [Socket Client](https://github.com/detritusjs/client-socket)
  - Just the socket connection, no rest whatsoever
- [Client](https://github.com/detritusjs/client)
  - This is the main library that wraps all of Discord's objects and implements both the REST client and Socket client.
  - Also allows you to easily shard w/ full control over what should be cached.
  