### PR TITLE
Remove Use VAD permission from Stage channels.

### DIFF
--- a/docs/topics/Permissions.md
+++ b/docs/topics/Permissions.md
@@ -53,7 +53,7 @@ Below is a table of all current permissions, their integer values in hexadecimal
 | MUTE_MEMBERS          | `0x0000400000` `(1 << 22)` | Allows for muting members in a voice channel                                                                                       | V, S         |
 | DEAFEN_MEMBERS        | `0x0000800000` `(1 << 23)` | Allows for deafening of members in a voice channel                                                                                 | V, S         |
 | MOVE_MEMBERS          | `0x0001000000` `(1 << 24)` | Allows for moving of members between voice channels                                                                                | V, S         |
-| USE_VAD               | `0x0002000000` `(1 << 25)` | Allows for using voice-activity-detection in a voice channel                                                                       | V, S         |
+| USE_VAD               | `0x0002000000` `(1 << 25)` | Allows for using voice-activity-detection in a voice channel                                                                       | V            |
 | CHANGE_NICKNAME       | `0x0004000000` `(1 << 26)` | Allows for modification of own nickname                                                                                            |              |
 | MANAGE_NICKNAMES      | `0x0008000000` `(1 << 27)` | Allows for modification of other users nicknames                                                                                   |              |
 | MANAGE_ROLES \*       | `0x0010000000` `(1 << 28)` | Allows management and editing of roles                                                                                             | T, V, S      |


### PR DESCRIPTION
**Status**: Client changes will be rolling out. Nevertheless feel free to share a substantial use-case if anyone has one.

# Summary

TL; DR: We want to reduce some footguns we noticed when people become a speaker in stage channels.

We have observed many times for users where they:

1. Join a stage channel as an audience.
2. Raise their hand.
3. Get invited to speak.
4. Find themselves still muted because `Use VAD` was turned off for the voice channel.
5. ...
6. Awkward silence while people figure things out.

To avoid this situation, we are planning to ignore the Use VAD permission for stage channels on all platforms. We feel that this is ok because the original intention of Use VAD was to provide some from of "noise control" in large voice channels. Stage channels already have "noise control" through its speaker-listener paradigm.

Making this PR in case anyone has any concerns or use-cases that would break as a result of this change.