### PR TITLE
Document `MANAGE_EVENTS` permission

### DIFF
--- a/docs/topics/Permissions.md
+++ b/docs/topics/Permissions.md
@@ -61,6 +61,7 @@ Below is a table of all current permissions, their integer values in hexadecimal
 | MANAGE_EMOJIS \*      | `0x0040000000` `(1 << 30)` | Allows management and editing of emojis                                                                                            |              |
 | USE_SLASH_COMMANDS    | `0x0080000000` `(1 << 31)` | Allows members to use slash commands in text channels                                                                              | T            |
 | REQUEST_TO_SPEAK      | `0x0100000000` `(1 << 32)` | Allows for requesting to speak in stage channels. (_This permission is under active development and may be changed or removed._)   | S            |
+| MANAGE_EVENTS         | `0x0200000000` `(1 << 33)` | Allows the user to manage guild events                                                       | S            |
 | MANAGE_THREADS \*     | `0x0400000000` `(1 << 34)` | Allows for deleting and archiving threads, and viewing all private threads                                                         | T            |
 | USE_PUBLIC_THREADS    | `0x0800000000` `(1 << 35)` | Allows for creating and participating in threads                                                                                   | T            |
 | USE_PRIVATE_THREADS   | `0x1000000000` `(1 << 36)` | Allows for creating and participating in private threads                                                                           | T            |


### PR DESCRIPTION
This PR adds documentation for the `MANAGE_EVENTS` permission in the `Permission` topic.