### PR TITLE
Fix Guild NSFW level table

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -95,6 +95,7 @@ Guilds in Discord represent an isolated collection of users and channels, and ar
 | VERY_HIGH | 4       | must have a verified phone number                         |
 
 ###### Guild NSFW Level
+
 | Level          | Value   |
 | -------------- | ------- |
 | DEFAULT        | 0       |


### PR DESCRIPTION
The lack of an extra line (markdown new line) here seems to be leading to this being rendered as literal text in the heading rather than as a table in docs site.
![image](https://user-images.githubusercontent.com/11181703/119972733-7993b180-bfaa-11eb-8465-b49eb9eaa784.png)
