### PR TITLE
docs: unmark non-nullable attachment properties

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -649,8 +649,8 @@ Embed types are "loosely defined" and, for the most part, are not used by our cl
 | size          | integer   | size of file in bytes                                                               |
 | url           | string    | source url of file                                                                  |
 | proxy_url     | string    | a proxied url of file                                                               |
-| height?       | integer  | height of file (if image)                                                           |
-| width?        | integer  | width of file (if image)                                                            |
+| height?       | integer   | height of file (if image)                                                           |
+| width?        | integer   | width of file (if image)                                                            |
 
 ### Channel Mention Object
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -649,8 +649,8 @@ Embed types are "loosely defined" and, for the most part, are not used by our cl
 | size          | integer   | size of file in bytes                                                               |
 | url           | string    | source url of file                                                                  |
 | proxy_url     | string    | a proxied url of file                                                               |
-| height?       | ?integer  | height of file (if image)                                                           |
-| width?        | ?integer  | width of file (if image)                                                            |
+| height?       | integer  | height of file (if image)                                                           |
+| width?        | integer  | width of file (if image)                                                            |
 
 ### Channel Mention Object
 


### PR DESCRIPTION
Both of the `height` and `width` properties of the attachment object's values are not nullable since they're only present if the attachment is an image but they're marked as nullable (`?integer`).