### PR TITLE
Add Remora.Discord to Community Resources

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -21,6 +21,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [D++](https://github.com/brainboxdotcc/DPP)                  | C++        |
 | [Sleepy Discord](https://github.com/yourWaifu/sleepy-discord)| C++        |
 | [discordcr](https://github.com/shardlab/discordcr)           | Crystal    |
+| [Remora.Discord](https://github.com/Nihlus/Remora.Discord)   | C#         |
 | [Discord.Net](https://github.com/RogueException/Discord.Net) | C#         |
 | [DSharpPlus](https://github.com/DSharpPlus/DSharpPlus)       | C#         |
 | [dscord](https://github.com/b1naryth1ef/dscord)              | D          |


### PR DESCRIPTION
This PR adds a link to Remora.Discord, a low-to-medium level C# library. The library comes with full API coverage (excluding voice), support for the latest features (v9 API, slash commands, buttons, etc), and an extensively tested codebase. Generally, the library aims to (as far as is reasonable and feasible) map 1:1 with the Discord API, and to only perform minimal abstractions or coercions.

Rate limits are transparently handled via a [Polly policy](https://github.com/Nihlus/Remora.Discord/blob/master/Backend/Remora.Discord.Rest/Polly/DiscordRateLimitPolicy.cs).