### PR TITLE
Add documentation for the `components` parameters to message-creating endpoints.

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -908,6 +908,7 @@ You may create a message as a reply to another message. To do so, include a [`me
 | payload_json      | string                                                                                            | JSON encoded body of non-file params                         | `multipart/form-data` only  |
 | allowed_mentions  | [allowed mention object](#DOCS_RESOURCES_CHANNEL/allowed-mentions-object)                         | allowed mentions for the message                             | false                       |
 | message_reference | [message reference](#DOCS_RESOURCES_CHANNEL/message-reference-object-message-reference-structure) | include to make your message a reply                         | false                       |
+| components        | array of [message component](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/component-object)              | the components to include with the message                   | false                       |
 
 ###### Example Request Body (application/json)
 
@@ -1049,15 +1050,16 @@ Returns a [message](#DOCS_RESOURCES_CHANNEL/message-object) object. Fires a [Mes
 
 ###### JSON/Form Params
 
-| Field            | Type                                                                      | Description                                                                                                                             |
-| ---------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| content          | string                                                                    | the message contents (up to 2000 characters)                                                                                            |
-| embed            | [embed](#DOCS_RESOURCES_CHANNEL/embed-object) object                      | embedded `rich` content                                                                                                                 |
-| flags            | integer                                                                   | edit the [flags](#DOCS_RESOURCES_CHANNEL/message-object-message-flags) of a message (only `SUPPRESS_EMBEDS` can currently be set/unset) |
-| file             | file contents                                                             | the contents of the file being sent/edited                                                                                              |
-| payload_json     | string                                                                    | JSON encoded body of non-file params (multipart/form-data only)                                                                         |
-| allowed_mentions | [allowed mention object](#DOCS_RESOURCES_CHANNEL/allowed-mentions-object) | allowed mentions for the message                                                                                                        |
-| attachments      | array of [attachment](#DOCS_RESOURCES_CHANNEL/attachment-object) objects  | attached files to keep                                                                                                                  |
+| Field            | Type                                                                                 | Description                                                                                                                             |
+| ---------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| content          | string                                                                               | the message contents (up to 2000 characters)                                                                                            |
+| embed            | [embed](#DOCS_RESOURCES_CHANNEL/embed-object) object                                 | embedded `rich` content                                                                                                                 |
+| flags            | integer                                                                              | edit the [flags](#DOCS_RESOURCES_CHANNEL/message-object-message-flags) of a message (only `SUPPRESS_EMBEDS` can currently be set/unset) |
+| file             | file contents                                                                        | the contents of the file being sent/edited                                                                                              |
+| payload_json     | string                                                                               | JSON encoded body of non-file params (multipart/form-data only)                                                                         |
+| allowed_mentions | [allowed mention object](#DOCS_RESOURCES_CHANNEL/allowed-mentions-object)            | allowed mentions for the message                                                                                                        |
+| attachments      | array of [attachment](#DOCS_RESOURCES_CHANNEL/attachment-object) objects             | attached files to keep                                                                                                                  |
+| components       | array of [message component](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/component-object) | the components to include with the message                                                                                              |
 
 ## Delete Message % DELETE /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/messages/{message.id#DOCS_RESOURCES_CHANNEL/message-object}
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -908,7 +908,7 @@ You may create a message as a reply to another message. To do so, include a [`me
 | payload_json      | string                                                                                            | JSON encoded body of non-file params                         | `multipart/form-data` only  |
 | allowed_mentions  | [allowed mention object](#DOCS_RESOURCES_CHANNEL/allowed-mentions-object)                         | allowed mentions for the message                             | false                       |
 | message_reference | [message reference](#DOCS_RESOURCES_CHANNEL/message-reference-object-message-reference-structure) | include to make your message a reply                         | false                       |
-| components        | array of [message component](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/component-object)              | the components to include with the message                   | false                       |
+| components        | array of [message component](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/component-object) objects      | the components to include with the message                   | false                       |
 
 ###### Example Request Body (application/json)
 

--- a/docs/resources/Webhook.md
+++ b/docs/resources/Webhook.md
@@ -175,16 +175,17 @@ Same as above, except this call does not require authentication.
 
 ###### JSON/Form Params
 
-| Field            | Type                                                                      | Description                                                  | Required                     |
-| ---------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------ | ---------------------------- |
-| content          | string                                                                    | the message contents (up to 2000 characters)                 | one of content, file, embeds |
-| username         | string                                                                    | override the default username of the webhook                 | false                        |
-| avatar_url       | string                                                                    | override the default avatar of the webhook                   | false                        |
-| tts              | boolean                                                                   | true if this is a TTS message                                | false                        |
-| file             | file contents                                                             | the contents of the file being sent                          | one of content, file, embeds |
-| embeds           | array of up to 10 [embed](#DOCS_RESOURCES_CHANNEL/embed-object) objects   | embedded `rich` content                                      | one of content, file, embeds |
-| payload_json     | string                                                                    | JSON encoded body of non-file params                         | `multipart/form-data` only   |
-| allowed_mentions | [allowed mention object](#DOCS_RESOURCES_CHANNEL/allowed-mentions-object) | allowed mentions for the message                             | false                        |
+| Field            | Type                                                                                 | Description                                                  | Required                     |
+| ---------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------ | ---------------------------- |
+| content          | string                                                                               | the message contents (up to 2000 characters)                 | one of content, file, embeds |
+| username         | string                                                                               | override the default username of the webhook                 | false                        |
+| avatar_url       | string                                                                               | override the default avatar of the webhook                   | false                        |
+| tts              | boolean                                                                              | true if this is a TTS message                                | false                        |
+| file             | file contents                                                                        | the contents of the file being sent                          | one of content, file, embeds |
+| embeds           | array of up to 10 [embed](#DOCS_RESOURCES_CHANNEL/embed-object) objects              | embedded `rich` content                                      | one of content, file, embeds |
+| payload_json     | string                                                                               | JSON encoded body of non-file params                         | `multipart/form-data` only   |
+| allowed_mentions | [allowed mention object](#DOCS_RESOURCES_CHANNEL/allowed-mentions-object)            | allowed mentions for the message                             | false                        |
+| components       | array of [message component](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/component-object) | the components to include with the message                   | false                        |
 
 > info
 > For the webhook embed objects, you can set every field except `type` (it will be `rich` regardless of if you try to set it), `provider`, `video`, and any `height`, `width`, or `proxy_url` values for images.
@@ -232,14 +233,15 @@ When the `content` field is edited, the `mentions` array in the message object w
 
 ###### JSON/Form Params
 
-| Field            | Type                                                                      | Description                                                     |
-| ---------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| content          | string                                                                    | the message contents (up to 2000 characters)                    |
-| embeds           | array of up to 10 [embed](#DOCS_RESOURCES_CHANNEL/embed-object) objects   | embedded `rich` content                                         |
-| file             | file contents                                                             | the contents of the file being sent/edited                      |
-| payload_json     | string                                                                    | JSON encoded body of non-file params (multipart/form-data only) |
-| allowed_mentions | [allowed mention object](#DOCS_RESOURCES_CHANNEL/allowed-mentions-object) | allowed mentions for the message                                |
-| attachments      | array of [attachment](#DOCS_RESOURCES_CHANNEL/attachment-object) objects  | attached files to keep                                          |
+| Field            | Type                                                                                 | Description                                                     |
+| ---------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
+| content          | string                                                                               | the message contents (up to 2000 characters)                    |
+| embeds           | array of up to 10 [embed](#DOCS_RESOURCES_CHANNEL/embed-object) objects              | embedded `rich` content                                         |
+| file             | file contents                                                                        | the contents of the file being sent/edited                      |
+| payload_json     | string                                                                               | JSON encoded body of non-file params (multipart/form-data only) |
+| allowed_mentions | [allowed mention object](#DOCS_RESOURCES_CHANNEL/allowed-mentions-object)            | allowed mentions for the message                                |
+| attachments      | array of [attachment](#DOCS_RESOURCES_CHANNEL/attachment-object) objects             | attached files to keep                                          |
+| components       | array of [message component](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/component-object) | the components to include with the message                      |
 
 # Delete Webhook Message % DELETE /webhooks/{webhook.id#DOCS_RESOURCES_WEBHOOK/webhook-object}/{webhook.token#DOCS_RESOURCES_WEBHOOK/webhook-object}/messages/{message.id#DOCS_RESOURCES_CHANNEL/message-object}
 


### PR DESCRIPTION
The various message-creating or message-editing endpoints can now, with the introduction of message components in #3007, take an array of components to add or modify the components of the message.

This PR adds documentation for these new parameters. Personally, I've only used and verified the Create Message and Edit Message endpoints, but as I understand it from others, the parameters function the same for webhooks.