### PR TITLE
Add droff typescript client to community resources

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -50,6 +50,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [Sword](https://github.com/Azoy/Sword)                       | Swift      |
 | [Detritus](https://github.com/detritusjs/client)             | TypeScript |
 | [discordeno](https://github.com/discordeno/discordeno)       | TypeScript |
+| [droff](https://github.com/tim-smart/droff)                  | TypeScript |
 | [Harmony](https://github.com/harmonyland/harmony)            | TypeScript |
 
 ## Interactions


### PR DESCRIPTION
This adds a new discord client option to the community resources.

It aims to please the reactive / functional programming crowd.
It also implements all the latest API features, such as slash commands and message components.

It uses https://github.com/tim-smart/discord-api-docs-parser to generate the REST endpoints and type information from the docs in this project. Which should help with project maintenance and API conformity.

REST API rate limiting is implemented here, in case that needed review: https://github.com/tim-smart/droff/blob/main/src/rest/rate-limits.ts#L93

It is quite new, so I totally understand if you don't want to include this project :)