### PR TITLE
Change integration account id description 

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -333,10 +333,10 @@ A partial [guild](#DOCS_RESOURCES_GUILD/guild-object) object. Represents an Offl
 
 ###### Integration Account Structure
 
-| Field | Type      | Description         |
-| ----- | --------- | ------------------- |
-| id    | snowflake | id of the account   |
-| name  | string    | name of the account |
+| Field | Type   | Description                                                                                        |
+| ----- | ------ | -------------------------------------------------------------------------------------------------- |
+| id    | string | regular string when referring to a non-discord application integration, otherwise a snowflake ID   |
+| name  | string | name of the account                                                                                |
 
 ### Integration Application Object
 

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -333,10 +333,10 @@ A partial [guild](#DOCS_RESOURCES_GUILD/guild-object) object. Represents an Offl
 
 ###### Integration Account Structure
 
-| Field | Type   | Description         |
-| ----- | ------ | ------------------- |
-| id    | string | id of the account   |
-| name  | string | name of the account |
+| Field | Type      | Description         |
+| ----- | --------- | ------------------- |
+| id    | snowflake | id of the account   |
+| name  | string    | name of the account |
 
 ### Integration Application Object
 


### PR DESCRIPTION
The integration account ID can sometimes be a snowflake. This PR hopefully explains when it's a string and when it's a snowflake better