### PR TITLE
Mark flags on Application as optional

### DIFF
--- a/docs/resources/Application.md
+++ b/docs/resources/Application.md
@@ -23,7 +23,7 @@
 | primary_sku_id?        | snowflake                                                  | if this application is a game sold on Discord, this field will be the id of the "Game SKU" that is created, if exists      |
 | slug?                  | string                                                     | if this application is a game sold on Discord, this field will be the URL slug that links to the store page                |
 | cover_image?           | string                                                     | the application's default rich presence invite [cover image hash](#DOCS_REFERENCE/image-formatting)                        |
-| flags                  | integer                                                    | the application's public [flags](#DOCS_RESOURCES_APPLICATION/application-application-flags)                                        |
+| flags?                 | integer                                                    | the application's public [flags](#DOCS_RESOURCES_APPLICATION/application-application-flags)                                        |
 
 ###### Example Application Object
 


### PR DESCRIPTION
This is due to ` /oauth2/applications/@me` returning the object without `flags`. See https://github.com/discord/discord-api-docs/blob/master/docs/topics/OAuth2.md#get-current-bot-application-information--get-oauth2applicationsme