### PR TITLE
Add ring-discord-auth to community resources for interactions

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -57,6 +57,8 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 
 [Interactions and Slash Commands](#DOCS_INTERACTIONS_SLASH_COMMANDS/) are the great, new way of making a Discord bot. The following open-source libraries provide help for the security and authentication checks that are mandatory if you are receiving Interactions via outgoing webhook. They also include some types for the Interactions data models.
 
+- Clojure
+  - [ring-discord-auth](https://github.com/JohnnyJayJay/ring-discord-auth)
 - C#
   - [DSharpPlus.SlashCommands](https://github.com/IDoEverything/DSharpPlus.SlashCommands)
 - Go

--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -57,10 +57,10 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 
 [Interactions and Slash Commands](#DOCS_INTERACTIONS_SLASH_COMMANDS/) are the great, new way of making a Discord bot. The following open-source libraries provide help for the security and authentication checks that are mandatory if you are receiving Interactions via outgoing webhook. They also include some types for the Interactions data models.
 
-- Clojure
-  - [ring-discord-auth](https://github.com/JohnnyJayJay/ring-discord-auth)
 - C#
   - [DSharpPlus.SlashCommands](https://github.com/IDoEverything/DSharpPlus.SlashCommands)
+- Clojure
+  - [ring-discord-auth](https://github.com/JohnnyJayJay/ring-discord-auth)
 - Go
   - [discord-interactions-go](https://github.com/bsdlp/discord-interactions-go)
 - Javascript


### PR DESCRIPTION
This PR adds a [small Clojure library](https://github.com/JohnnyJayJay/ring-discord-auth) to the community resources that handles compliance with the interaction security requirements for ring-compliant web servers. [ring](https://github.com/ring-clojure/ring) is the de facto default for Clojure backend development.