### PR TITLE
docs(resources): changed `Update` to `Modify`

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -998,7 +998,7 @@ Modify the guild's [Welcome Screen](#DOCS_RESOURCES_GUILD/welcome-screen-object)
 | welcome_channels | array of [welcome screen channel](#DOCS_RESOURCES_GUILD/welcome-screen-object-welcome-screen-channel-structure) objects | channels linked in the welcome screen and their display options |
 | description      | string                                                                                                                  | the server description to show in the welcome screen            |
 
-## Update Current User Voice State % PATCH /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/voice-states/@me
+## Modify Current User Voice State % PATCH /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/voice-states/@me
 
 Updates the current user's voice state.
 
@@ -1020,7 +1020,7 @@ There are currently several caveats for this endpoint:
 - You must have the `REQUEST_TO_SPEAK` permission to request to speak. You can always clear your own request to speak.
 - You are able to set `request_to_speak_timestamp` to any present or future time.
 
-## Update User Voice State % PATCH /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/voice-states/{user.id#DOCS_RESOURCES_USER/user-object}
+## Modify User Voice State % PATCH /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/voice-states/{user.id#DOCS_RESOURCES_USER/user-object}
 
 Updates another user's voice state.
 

--- a/docs/resources/Stage_Instance.md
+++ b/docs/resources/Stage_Instance.md
@@ -75,7 +75,7 @@ Requires the user to be a moderator of the Stage channel.
 
 Gets the stage instance associated with the Stage channel, if it exists.
 
-## Update Stage Instance % PATCH /stage-instances/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}
+## Modify Stage Instance % PATCH /stage-instances/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}
 
 Updates fields of an existing Stage instance.
 


### PR DESCRIPTION
I noticed `Update` was being used in a few instances within the resources, while `Modify` was used everywhere else (and `Edit` for messages). This PR changes the term for consistency with the rest of the docs.

> **Note**: Should I also change `Edit` to `Modify`, as the behavior is similar?
