### PR TITLE
Add Skycord to Community Resources

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -52,6 +52,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [discordeno](https://github.com/discordeno/discordeno)       | TypeScript |
 | [droff](https://github.com/tim-smart/droff)                  | TypeScript |
 | [Harmony](https://github.com/harmonyland/harmony)            | TypeScript |
+| [Skycord](https://github.com/skycord/skycord)                | TypeScript |
 
 ## Interactions
 


### PR DESCRIPTION
In this PR, it adds Skycord to the Discord Libraries list on the Community Resources page.

Skycord is a low-level Discord API wrapper written in TypeScript. The reason for it being made low-level is to allow developers using it do not need to wait for the library to update in order to take advantage of Discords' latest features. This also lets developers get more control over how things on it are implementing (such as implementing their own cache if needed).

The library supports ratelimiting, does not support user bots, and can support the latest Discord features such as interactions.

Ratelimiting: (It is split across multiple files)
- https://github.com/skycord/skycord/blob/main/src/rest/modes/LocalRestClient.ts#L100
- https://github.com/skycord/skycord/blob/main/src/utils/QueuedRatelimitBucket.ts
- https://github.com/skycord/skycord/blob/main/src/utils/RatelimitBucket.ts

Please let me know if I messed up this PR so I can make the necessary adjustments.