### PR TITLE
add discord-buttons Community Resources

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -67,6 +67,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
   - [discord-interactions-js](https://github.com/discord/discord-interactions-js)
   - [discord-slash-commands](https://github.com/MeguminSama/discord-slash-commands) and its [Deno fork](https://deno.land/x/discord_slash_commands)
   - [slash-create](https://github.com/Snazzah/slash-create)
+  - [discord-buttons](https://github.com/AngeloCore/discord-buttons)
 - Python
   - [discord-py-slash-command](https://github.com/eunwoo1104/discord-py-slash-command)
   - [discord-interactions-python](https://github.com/discord/discord-interactions-python)


### PR DESCRIPTION
Add [discord-buttons](https://github.com/AngeloCore/discord-buttons) on Community Resources interactions.
discord-buttons is a package for the button interactions, addon for [discord.js](https://github.com/discordjs/discord.js)