### PR TITLE
docs(ErrorCodes): added 20035

### DIFF
--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -147,6 +147,7 @@ Along with the HTTP error code, our API can also return more detailed error code
 | 20022  | This message cannot be edited due to announcement rate limits                                                                 |
 | 20028  | The channel you are writing has hit the write rate limit                                                                      |
 | 20031  | Your Stage topic, server name, server description, or channel names contain words that are not allowed                        |
+| 20035  | Guild premium subscription level too low                                                                                      |
 | 30001  | Maximum number of guilds reached (100)                                                                                        |
 | 30002  | Maximum number of friends reached (1000)                                                                                      |
 | 30003  | Maximum number of pins reached for the channel (50)                                                                           |


### PR DESCRIPTION
Added code `20035`, which can obtained in the following ways:

- Creating a private thread in a server that has only public thread support.
- Using `auto_archive_duration: 4320`/`10080` for public threads (without `THREE_DAY_AUTO_ARCHIVE` nor `SEVEN_DAY_AUTO_ARCHIVE`).

\* Both cases happen when running them in a library testing server (which has `THREADS_ENABLED`) that doesn't meet the criteria for the `THREADS_ENABLED_TESTING` feature. I'm not aware of this being reproducible elsewhere until general release.

Credits to @ckohen for finding the error code and the routes in which they appear.

