### PR TITLE
Add community library Diskord

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -35,6 +35,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [discord.js](https://github.com/discordjs/discord.js)        | JavaScript |
 | [Eris](https://github.com/abalabahaha/eris)                  | JavaScript |
 | [Discord.jl](https://github.com/Xh4H/Discord.jl)             | Julia      |
+| [Diskord](https://gitlab.com/jesselcorbett/diskord)          | Kotlin     |
 | [Discordia](https://github.com/SinisterRectus/Discordia)     | Lua        |
 | [Dimscord](https://github.com/krisppurg/dimscord)            | Nim        |
 | [discordnim](https://github.com/Krognol/discordnim)          | Nim        |


### PR DESCRIPTION
I would like to submit my library, Diskord, to be listed as a community library.
It is a Kotlin-based library which fully implements the ratelimit system and has been in active development and use for a few years now.

The core of the ratelimit system is implemented here in [RestClient.kt](https://gitlab.com/jesselcorbett/diskord/-/blob/master/diskord-core/src/commonMain/kotlin/com/jessecorbett/diskord/internal/client/RestClient.kt) with the wait logic on [line 28](https://gitlab.com/jesselcorbett/diskord/-/blob/master/diskord-core/src/commonMain/kotlin/com/jessecorbett/diskord/internal/client/RestClient.kt#L28), the global and bucket-based limits checked for each requests on [line 134](https://gitlab.com/jesselcorbett/diskord/-/blob/master/diskord-core/src/commonMain/kotlin/com/jessecorbett/diskord/internal/client/RestClient.kt#L134), the buckets are subsequently updated on [line 158](https://gitlab.com/jesselcorbett/diskord/-/blob/master/diskord-core/src/commonMain/kotlin/com/jessecorbett/diskord/internal/client/RestClient.kt#L158) using logic on [line 174](https://gitlab.com/jesselcorbett/diskord/-/blob/master/diskord-core/src/commonMain/kotlin/com/jessecorbett/diskord/internal/client/RestClient.kt#L174).

If there are any questions I'll be happy to assist