### PR TITLE
Document `permissions` field on channels when part of resolved

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -33,6 +33,7 @@ Represents a guild or DM channel within Discord.
 | thread_metadata?               | a [thread metadata](#DOCS_RESOURCES_CHANNEL/thread-metadata-object) object | thread-specific fields not needed by other channels                                                                                                                             |
 | member?                        | a [thread member](#DOCS_RESOURCES_CHANNEL/thread-member-object) object     | thread member object for the current user, if they have joined the thread, only included on certain API endpoints                                                               |
 | default_auto_archive_duration? | integer                                                                    | default duration for newly created threads, in minutes, to automatically archive the thread after recent activity, can be set to: 60, 1440, 4320, 10080                         |
+| permissions?                   | string                                                                     | computed permissions for the invoking user in the channel, including overwrites, only included when part of the `resolved` data received on a slash command interaction         |
 
 \* `rate_limit_per_user` also applies to thread creation. Users can send one message and create one thread during each `rate_limit_per_user` interval.
 


### PR DESCRIPTION
Used https://gist.github.com/msciotti/b1dabde51ebe2f3e875faf73a7a3509b as a reference 

Wasn't sure if the channel object was the right place to include it but saw that `permissions` had been documented on the member object.

resolves #3379