### PR TITLE
Document client credentials grant scope limitation for team applications

### DIFF
--- a/docs/topics/OAuth2.md
+++ b/docs/topics/OAuth2.md
@@ -184,6 +184,9 @@ The client credential flow is a quick and easy way for bot developers to get the
 
 You can specify scopes with the `scope` parameter, which is a list of [OAuth2 scopes](#DOCS_TOPICS_OAUTH2/shared-resources-oauth2-scopes) separated by spaces:
 
+> info
+> Team applications are limited to the `identify` and `applications.commands.update` scope, because teams are not bound to a specific user.
+
 ###### Client Credentials Token Request Example
 
 ```python


### PR DESCRIPTION
As discussed in #2644, applications managed by a team omit most scopes since they are not bound to a specific user; currently, this is not documented.

**Proposed preview:**
![image](https://user-images.githubusercontent.com/34300238/124499130-7f3f9c80-dd8b-11eb-9ea9-8ac99397ca83.png)

A Bearer token is also returned by the scopes `applications.builds.read`, `applications.builds.upload`, `applications.entitlements`, `applications.store.update`, however I opted to omit these, as they are internal scopes for Dispatch, outlined in #1094.