### PR TITLE
Added `aoi.js` to the Discord Libraries

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -33,6 +33,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [Javacord](https://github.com/Javacord/Javacord)             | Java       |
 | [JDA](https://github.com/DV8FromTheWorld/JDA)                | Java       |
 | [discord.js](https://github.com/discordjs/discord.js)        | JavaScript |
+| [aoi.js](https://github.com/aoijs/aoi.js)                    | JavaScript |
 | [Eris](https://github.com/abalabahaha/eris)                  | JavaScript |
 | [Discord.jl](https://github.com/Xh4H/Discord.jl)             | Julia      |
 | [Discordia](https://github.com/SinisterRectus/Discordia)     | Lua        |


### PR DESCRIPTION
I wanted to submit a library I'm familiar with, which is `aoi.js`, to be in the list of community libraries.

These two files are what aoi.js request and handle system are.
They are also handled by [discord.js](https://github.com/discordjs/discord.js) hence preventing any future rate limit:

- https://github.com/aoijs/aoi.js/blob/master/package/handlers/rateLimitCommands.js
- https://github.com/aoijs/aoi.js/blob/master/package/handlers/request.js