### PR TITLE
Fix wording for header format.

### DIFF
--- a/docs/topics/Rate_Limits.md
+++ b/docs/topics/Rate_Limits.md
@@ -13,7 +13,7 @@ Because we may change rate limits at any time and rate limits can be different p
 
 ## Header Format
 
-For every API request made, we return optional HTTP response headers containing the rate limit encountered during your request.
+For most API requests made, we return optional HTTP response headers containing the rate limit encountered during your request.
 
 ###### Rate Limit Header Examples
 


### PR DESCRIPTION
Some routes don't return rate limit headers (Such as when creating webhooks), and some people (including myself) have been confused with the Header Format section stating "For every API request".

In additional context, creating a webhook for a channel does not return with rate limit headers, and some bots (such as NQN) may need to create webhooks for every channel, and since they that end point doesn't return with rate limit headers, they can't respect the rate limits put in place, so they don't spam the API.

In conclusion, not all endpoints/routes return rate limit headers, and this PR should clear up some confusion