### PR TITLE
Add Autocode embed builder link to community resources doc

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -106,6 +106,7 @@ Using Discord's [Dispatch](#DOCS_DISPATCH_DISPATCH_AND_YOU) tool for game develo
 
 Webhooks and embeds might seem like black magic. That's because they are, but let us help you demystify them a bit. This sweet embed visualizer lets you play around with JSON data and see exactly how it will look embedded in Discord. It even includes a webhook mode!
 
+- [Autocode Embed Builder](https://autocode.com/tools/discord/embed-builder/)
 - [LeoV's Embed Visualizer](https://leovoel.github.io/embed-visualizer/)
 
 ## API Types


### PR DESCRIPTION
We've built a pretty robust, up to date embed visualizer for Discord and would love to have it included in the community resources section. 

 - Up-to-date feature parity with the embed API, including buttons and select menus!
 - Auto-generates code required to send the embed message and updates previews in realtime!