### PR TITLE
Add Autocode Slash command builder to Interactions list

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -75,6 +75,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 - Other
   - [caddy-discord-interactions-verifier](https://github.com/CarsonHoffman/caddy-discord-interactions-verifier)
   - [Rauf's Slash Command Generator](https://rauf.wtf/slash)
+  - [Autocode Slash Command Builder](https://autocode.com/tools/discord/command-builder/)
 
 ## Game SDK Tools
 


### PR DESCRIPTION
I've built a visualization and code-generation tool for Discord slash commands! 

To my knowledge it's the most robust slash command builder out there. This tool helps to generate *and* visualize how slash commands will show up in your Discord server. Allows for full UI based Slash command creation, with access to the underlying code for further development and modification.

**Current features:**
 - Can register guild-specific and global commands 
 - Handles complex option configurations like subcommands and subcommand groups with ease
 - Provides a handy preview of how those commands will appear in the Slash command list.
 - Auto-generates required code for registering these commands.
 - For registered Autocode users, will register the commands upon save and generate event handler files for commands as needed as well!