### PR TITLE
Fix Thread Member Object fields.

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -524,6 +524,8 @@ A thread member is used to indicate whether a user has joined a thread or not.
 |----------------|-------------------|-----------------------------------------------------------------|
 | id? \*         | snowflake         | the id of the thread                                            |
 | user_id? \*    | snowflake         | the id of the user                                              |
+| presence?      | partial [presence update](https://discord.com/developers/docs/topics/gateway#presence-update) object | the partial presence of the user
+| member?        | [guild member](https://discord.com/developers/docs/resources/guild#guild-member-object) object | the guild member object of the user | 
 | join_timestamp | ISO8601 timestamp | the time the current user last joined the thread                |
 | flags          | integer           | any user-thread settings, currently only used for notifications |
 


### PR DESCRIPTION
# Summary
The [Thread member](https://discord.com/developers/docs/resources/channel#thread-member-object) object doesn't contain the `member` and `presence` field. Looking at the raw json coming from the `THREAD_MEMBERS_UPDATED` I can see its included there.
```json
"added_members": [
    {
      "user_id": "726114833392730124",
      "presence": {
        "user": {
          "username": "Luminous Beta",
          "id": "726114833392730124",
          "discriminator": "8327",
          "bot": true,
          "avatar": "fca78cb94ce17e6a4ca997b7ef63ee33"
        },
        "status": "online",
        "game": null,
        "client_status": {},
        "activities": []
      },
      "member": {
        "user": {
          "username": "Luminous Beta",
          "id": "726114833392730124",
          "discriminator": "8327",
          "bot": true,
          "avatar": "fca78cb94ce17e6a4ca997b7ef63ee33"
        },
        "roles": [
          "870022237632213013"
        ],
        "premium_since": null,
        "pending": false,
        "nick": null,
        "mute": false,
        "joined_at": "2021-07-28T16:17:45.719405-03:00",
        "is_pending": false,
        "hoisted_role": null,
        "deaf": false,
        "avatar": null
      },
      "join_timestamp": "2021-07-28T16:23:10.742465-03:00",
      "id": "869943099361742908",
      "flags": 1
    }
  ],
```

This pr adds those two fields to the docs.