### PR TITLE
Remove (outdated) reference to the Create Message gateway requirement from the Reference page

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -226,10 +226,6 @@ Certain endpoints in the API are documented to accept booleans for their query s
 
 Discord's Gateway API is used for maintaining persistent, stateful websocket connections between your client and our servers. These connections are used for sending and receiving real-time events your client can use to track and update local state. The Gateway API uses secure websocket connections as specified in [RFC 6455](https://tools.ietf.org/html/rfc6455). For information on opening Gateway connections, please see the [Gateway API](#DOCS_TOPICS_GATEWAY/gateways) section.
 
-> warn
-> A bot must connect to and identify with a gateway at least once before it can use the [Create Message](#DOCS_RESOURCES_CHANNEL/create-message) endpoint.
-> If your only requirement is to send messages to a channel, consider using a [Webhook](#DOCS_RESOURCES_WEBHOOK) instead.
-
 ## Message Formatting
 
 Discord utilizes a subset of markdown for rendering message content on its clients, while also adding some custom functionality to enable things like mentioning users and channels. This functionality uses the following formats:


### PR DESCRIPTION
was missed in https://github.com/discord/discord-api-docs/commit/5f4decb7c488064d469188bc631e23fef7adf6ae