### PR TITLE
Rename guild active threads endpoint

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -687,7 +687,7 @@ This endpoint takes a JSON array of parameters in the following format:
 | lock_permissions | ?boolean   | syncs the permission overwrites with the new parent, if moving to a new category |
 | parent_id        | ?snowflake | the new parent ID for the channel that is moved                                  |
 
-## List Guild Active Threads % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/threads/active
+## List Active Guild Threads % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/threads/active
 
 Returns all active threads in the guild, including public and private threads. Threads are ordered by their `id`, in descending order.
 

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -687,7 +687,7 @@ This endpoint takes a JSON array of parameters in the following format:
 | lock_permissions | ?boolean   | syncs the permission overwrites with the new parent, if moving to a new category |
 | parent_id        | ?snowflake | the new parent ID for the channel that is moved                                  |
 
-## List Active Threads % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/threads/active
+## List Guild Active Threads % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/threads/active
 
 Returns all active threads in the guild, including public and private threads. Threads are ordered by their `id`, in descending order.
 


### PR DESCRIPTION
This ensures it has a unique name compared to the active threads
endpoint for channels.