### PR TITLE
Removed deaf? and mute? fields from Guild Member Update

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -999,8 +999,6 @@ Sent when a guild member is updated. This will also fire when the user object of
 | nick?          | ?string                                           | nickname of the user in the guild                                                                                                      |
 | joined_at      | ?ISO8601 timestamp                                 | when the user joined the guild                                                                                                         |
 | premium_since? | ?ISO8601 timestamp                                | when the user starting [boosting](https://support.discord.com/hc/en-us/articles/360028038352-Server-Boosting-) the guild               |
-| deaf?          | boolean                                           | whether the user is deafened in voice channels                                                                                         |
-| mute?          | boolean                                           | whether the user is muted in voice channels                                                                                            |
 | pending?       | boolean                                           | whether the user has not yet passed the guild's [Membership Screening](#DOCS_RESOURCES_GUILD/membership-screening-object) requirements |
 
 #### Guild Members Chunk


### PR DESCRIPTION
Myself and a few others noticed when implementing both the `deaf` and `mute` properties that these are not sent in `GUILD_MEMBER_UPDATE`. I have not been able to get these fields to be included in the json Discord sends with the members intent. It does not fire when someone either deafens/mutes themselves or gets server muted/deafened. It also doesn't seem to be included when someone is muted/deafened and something else causes the event to fire. 

I have noticed that these fields are included on the member objects in `GUILD_CREATE`, so this addition was either an oversight or it was changed.