### PR TITLE
Adds lacord to Community Resources.

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -36,6 +36,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [Eris](https://github.com/abalabahaha/eris)                  | JavaScript |
 | [Discord.jl](https://github.com/Xh4H/Discord.jl)             | Julia      |
 | [Discordia](https://github.com/SinisterRectus/Discordia)     | Lua        |
+| [lacord](https://github.com/Mehgugs/lacord)                  | Lua        |
 | [Dimscord](https://github.com/krisppurg/dimscord)            | Nim        |
 | [discordnim](https://github.com/Krognol/discordnim)          | Nim        |
 | [DiscordPHP](https://github.com/discord-php/DiscordPHP)      | PHP        |


### PR DESCRIPTION
My project lacord is a discord api client for lua built on top of the `lua-http` framework. 

Relevant parts of the implementation in regards to ratelimiting:

Calculation of delay when we run out of requests:
<https://github.com/Mehgugs/lacord/blob/master/lua/lacord/api.lua#L424-L432>

Handling 429s:
<https://github.com/Mehgugs/lacord/blob/master/lua/lacord/api.lua#L473-L485>

The project offers almost full coverage of api methods, and transparently supports interactions and slash commands over the gateway. I also have a webserver built in as a low level way to receive slash commands over outgoing webhook. I also provide a sister project [`lacord-client`](https://github.com/Mehgugs/lacord-client) which has a higher level set of abstractions and richer support for components and event processing. 



