### PR TITLE
Document creation limitation for Lottie stickers

### DIFF
--- a/docs/resources/Sticker.md
+++ b/docs/resources/Sticker.md
@@ -123,6 +123,9 @@ Create a new sticker for the guild. Send a `multipart/form-data` body. Requires 
 > info
 > This endpoint supports the `X-Audit-Log-Reason` header.
 
+> warn
+> Lottie stickers can only be uploaded on guilds that have either the `VERIFIED` and/or the `PARTNERED` [guild feature](#DOCS_RESOURCES_GUILD/guild-object-guild-features). 
+
 ###### Form Params
 
 | Field       | Type          | Description                                                                                  |


### PR DESCRIPTION
When creating stickers using my bot I noticed that it's no longer possible to create Lottie stickers in servers that aren't verified or partnered. I've also cross checked this in my Discord client via the server settings of a verified server, where I'm staff in, and asked a friend who is staff in a partnered server, with both servers having access to Lottie stickers, whilst normal servers not having access to them.
This PR adds a small note to document this behavior since this could cause confusion.