### PR TITLE
Fix broken link in Gateways

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -701,7 +701,7 @@ Sent by the client to indicate a presence or status update.
 |------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
 | since      | ?integer                                                          | unix time (in milliseconds) of when the client went idle, or null if the client is not idle |
 | activities | array of [activity](#DOCS_TOPICS_GATEWAY/activity-object) objects | the user's activities                                                                       |
-| status     | string                                                            | the user's new [status](#DOCS_TOPICS_GATEWAY/update-status-status-types)                    |
+| status     | string                                                            | the user's new [status](#DOCS_TOPICS_GATEWAY/update-presence-status-types)                  |
 | afk        | boolean                                                           | whether or not the client is afk                                                            |
 
 ###### Status Types


### PR DESCRIPTION
Fixed link in "Gateway Presence Update Structure" to "Status Types" table below. Previously referenced `update-status-status-types` when correct link is `update-presence-status-types`.