### PR TITLE
Sticker fixes

### DIFF
--- a/docs/resources/Sticker.md
+++ b/docs/resources/Sticker.md
@@ -12,7 +12,7 @@ Represents a sticker that can be sent in messages.
 | pack_id?    | snowflake                                       | for standard stickers, id of the pack the sticker is from                                                                                                            |
 | name        | string                                          | name of the sticker                                                                                                                                                  |
 | description | ?string                                         | description of the sticker                                                                                                                                           |
-| tags        | string                                          | for guild stickers, the Discord name of a unicode emoji representing the sticker's expression. for standard stickers, a comma-separated list of related expressions. |
+| tags\*      | string                                          | autocomplete/suggestion tags for the sticker (max 500 characters) |
 | asset       | string                                          | **Deprecated** previously the sticker asset hash, now an empty string                                                                                                |
 | type        | integer                                         | [type of sticker](#DOCS_RESOURCES_STICKER/sticker-object-sticker-types)                                                                                              |
 | format_type | integer                                         | [type of sticker format](#DOCS_RESOURCES_STICKER/sticker-object-sticker-format-types)                                                                                |
@@ -21,6 +21,8 @@ Represents a sticker that can be sent in messages.
 | user?       | [user](#DOCS_RESOURCES_USER/user-object) object | the user that uploaded the guild sticker                                                                                                                             |
 | sort_value? | integer                                         | the standard sticker's sort order within its pack                                                                                                                    |
 
+\* A comma separated list of keywords is the format used in this field by standard stickers, but this is just a convention.
+Incidentally the client will always use a name generated from an emoji as the value of this field when creating or modifying a guild sticker.
 ###### Sticker Types
 
 | Type     | Value | Description                                                                   |

--- a/docs/resources/Sticker.md
+++ b/docs/resources/Sticker.md
@@ -12,7 +12,7 @@ Represents a sticker that can be sent in messages.
 | pack_id?    | snowflake                                       | for standard stickers, id of the pack the sticker is from                                                                                                            |
 | name        | string                                          | name of the sticker                                                                                                                                                  |
 | description | ?string                                         | description of the sticker                                                                                                                                           |
-| tags\*      | string                                          | autocomplete/suggestion tags for the sticker (max 500 characters) 
+| tags\*      | string                                          | autocomplete/suggestion tags for the sticker (max 200 characters) 
                     |
 | asset       | string                                          | **Deprecated** previously the sticker asset hash, now an empty string                                                                                                |
 | type        | integer                                         | [type of sticker](#DOCS_RESOURCES_STICKER/sticker-object-sticker-types)                                                                                              |

--- a/docs/resources/Sticker.md
+++ b/docs/resources/Sticker.md
@@ -133,7 +133,7 @@ Create a new sticker for the guild. Send a `multipart/form-data` body. Requires 
 | ----------- | ------------- | -------------------------------------------------------------------------------------------- |
 | name        | string        | name of the sticker (2-30 characters)                                                        |
 | description | string        | description of the sticker (empty or 2-100 characters)                                       |
-| tags        | string        | the Discord name of a unicode emoji representing the sticker's expression (2-200 characters) |
+| tags        | string        | autocomplete/suggestion tags for the sticker (max 200 characters)                            |
 | file        | file contents | the sticker file to upload, must be a PNG, APNG, or Lottie JSON file, max 500 KB             |
 
 ## Modify Guild Sticker % PATCH /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/stickers/{sticker.id#DOCS_RESOURCES_STICKER/sticker-object}
@@ -152,7 +152,7 @@ Modify the given sticker. Requires the `MANAGE_EMOJIS_AND_STICKERS` permission. 
 | ----------- | ------- | -------------------------------------------------------------------------------------------- |
 | name        | string  | name of the sticker (2-30 characters)                                                        |
 | description | ?string | description of the sticker (2-100 characters)                                                |
-| tags        | string  | the Discord name of a unicode emoji representing the sticker's expression (2-200 characters) |
+| tags        | string  | autocomplete/suggestion tags for the sticker (max 200 characters)                            |
 
 ## Delete Guild Sticker % DELETE /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/stickers/{sticker.id#DOCS_RESOURCES_STICKER/sticker-object}
 

--- a/docs/resources/Sticker.md
+++ b/docs/resources/Sticker.md
@@ -12,7 +12,8 @@ Represents a sticker that can be sent in messages.
 | pack_id?    | snowflake                                       | for standard stickers, id of the pack the sticker is from                                                                                                            |
 | name        | string                                          | name of the sticker                                                                                                                                                  |
 | description | ?string                                         | description of the sticker                                                                                                                                           |
-| tags\*      | string                                          | autocomplete/suggestion tags for the sticker (max 500 characters) |
+| tags\*      | string                                          | autocomplete/suggestion tags for the sticker (max 500 characters) 
+                    |
 | asset       | string                                          | **Deprecated** previously the sticker asset hash, now an empty string                                                                                                |
 | type        | integer                                         | [type of sticker](#DOCS_RESOURCES_STICKER/sticker-object-sticker-types)                                                                                              |
 | format_type | integer                                         | [type of sticker format](#DOCS_RESOURCES_STICKER/sticker-object-sticker-format-types)                                                                                |
@@ -23,6 +24,7 @@ Represents a sticker that can be sent in messages.
 
 \* A comma separated list of keywords is the format used in this field by standard stickers, but this is just a convention.
 Incidentally the client will always use a name generated from an emoji as the value of this field when creating or modifying a guild sticker.
+
 ###### Sticker Types
 
 | Type     | Value | Description                                                                   |


### PR DESCRIPTION
After a short discussion (#3562), it seems that the tags field can be any
string of text and is used in some way to power the autocomplete/suggestion popup.
The client using/displaying emoji names for the tag is just a good way of generating
a relevant keyword from a user, using the emojis as a pictorial aide, and is thus
not part of the API's concerns.