### PR TITLE
Fix fields incorrectly marked as optional in embed

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -566,7 +566,7 @@ Embed types are "loosely defined" and, for the most part, are not used by our cl
 
 | Field      | Type    | Description                                                     |
 |------------|---------|-----------------------------------------------------------------|
-| url?       | string  | source url of thumbnail (only supports http(s) and attachments) |
+| url        | string  | source url of thumbnail (only supports http(s) and attachments) |
 | proxy_url? | string  | a proxied url of the thumbnail                                  |
 | height?    | integer | height of thumbnail                                             |
 | width?     | integer | width of thumbnail                                              |
@@ -584,7 +584,7 @@ Embed types are "loosely defined" and, for the most part, are not used by our cl
 
 | Field      | Type    | Description                                                 |
 |------------|---------|-------------------------------------------------------------|
-| url?       | string  | source url of image (only supports http(s) and attachments) |
+| url        | string  | source url of image (only supports http(s) and attachments) |
 | proxy_url? | string  | a proxied url of the image                                  |
 | height?    | integer | height of image                                             |
 | width?     | integer | width of image                                              |
@@ -600,7 +600,7 @@ Embed types are "loosely defined" and, for the most part, are not used by our cl
 
 | Field           | Type   | Description                                                |
 |-----------------|--------|------------------------------------------------------------|
-| name?           | string | name of author                                             |
+| name            | string | name of author                                             |
 | url?            | string | url of author                                              |
 | icon_url?       | string | url of author icon (only supports http(s) and attachments) |
 | proxy_icon_url? | string | a proxied url of author icon                               |


### PR DESCRIPTION
These fields are required when creating an embed and always present when received (given the object itself exists) making the marking consistent with the footer and field structures.