### PR TITLE
Change wording for List Voice Regions

### DIFF
--- a/docs/resources/Voice.md
+++ b/docs/resources/Voice.md
@@ -53,4 +53,4 @@ Used to represent a user's voice connection status.
 
 ## List Voice Regions % GET /voice/regions
 
-Returns an array of [voice region](#DOCS_RESOURCES_VOICE/voice-region-object) objects that can be used when creating servers.
+Returns an array of [voice region](#DOCS_RESOURCES_VOICE/voice-region-object) objects that can be used when setting the `rtc_region` on voice and stage channels.

--- a/docs/resources/Voice.md
+++ b/docs/resources/Voice.md
@@ -53,4 +53,4 @@ Used to represent a user's voice connection status.
 
 ## List Voice Regions % GET /voice/regions
 
-Returns an array of [voice region](#DOCS_RESOURCES_VOICE/voice-region-object) objects that can be used when setting the `rtc_region` on voice and stage channels.
+Returns an array of [voice region](#DOCS_RESOURCES_VOICE/voice-region-object) objects that can be used when setting a voice or stage channel's [`rtc_region`](#DOCS_RESOURCES_CHANNEL/channel-object-channel-structure).


### PR DESCRIPTION
The current wording mentions it can be used when creating servers which can appear confusing for users who don't know that bots can actually create servers when they have <10 guilds (https://canary.discord.com/channels/613425648685547541/697489244649816084/875841463366348840 is a perfect example and what sparked this PR :joy:)

This PR changes it to reference the `rtc_region` field on voice and stage channels instead since server regions aren't used anymore.