### PR TITLE
Remove Application Command events from the docs

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -1450,8 +1450,6 @@ Sent when a guild channel's webhook is created, updated, or deleted.
 | guild_id   | snowflake | id of the guild   |
 | channel_id | snowflake | id of the channel |
 
-### Commands
-
 ### Interactions
 
 #### Interaction Create

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -479,9 +479,6 @@ Events are payloads sent over the socket to a client that correspond to events i
 | [Resumed](#DOCS_TOPICS_GATEWAY/resumed)                                             | response to [Resume](#DOCS_TOPICS_GATEWAY/resume)                                                                                |
 | [Reconnect](#DOCS_TOPICS_GATEWAY/reconnect)                                         | server is going away, client should reconnect to gateway and resume                                                              |
 | [Invalid Session](#DOCS_TOPICS_GATEWAY/invalid-session)                             | failure response to [Identify](#DOCS_TOPICS_GATEWAY/identify) or [Resume](#DOCS_TOPICS_GATEWAY/resume) or invalid active session |
-| [Application Command Create](#DOCS_TOPICS_GATEWAY/application-command-create)       | new [Application Command](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/) was created                                                  |
-| [Application Command Update](#DOCS_TOPICS_GATEWAY/application-command-update)       | [Application Command](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/) was updated                                                      |
-| [Application Command Delete](#DOCS_TOPICS_GATEWAY/application-command-delete)       | [Application Command](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/) was deleted                                                      |
 | [Channel Create](#DOCS_TOPICS_GATEWAY/channel-create)                               | new guild channel created                                                                                                        |
 | [Channel Update](#DOCS_TOPICS_GATEWAY/channel-update)                               | channel was updated                                                                                                              |
 | [Channel Delete](#DOCS_TOPICS_GATEWAY/channel-delete)                               | channel was deleted                                                                                                              |
@@ -1454,24 +1451,6 @@ Sent when a guild channel's webhook is created, updated, or deleted.
 | channel_id | snowflake | id of the channel |
 
 ### Commands
-
-#### Application Command Create
-
-Sent when a new [Application Command](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/) is created, relevant to the current user. The inner payload is an [ApplicationCommand](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-object-application-command-structure) object, with an optional extra `guild_id` key.
-
-#### Application Command Update
-
-Sent when an [Application Command](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/) relevant to the current user is updated. The inner payload is an [ApplicationCommand](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-object-application-command-structure) object, with an optional extra `guild_id` key.
-
-#### Application Command Delete
-
-Sent when an [Application Command](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/) relevant to the current user is deleted. The inner payload is an [ApplicationCommand](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-object-application-command-structure) object, with an optional extra `guild_id` key.
-
-###### Application Command Extra Fields
-
-| Field     | Type      | Description                       |
-|-----------|-----------|-----------------------------------|
-| guild_id? | snowflake | id of the guild the command is in |
 
 ### Interactions
 


### PR DESCRIPTION
Remove Application Command Create, Application Command Update, and Application Command Delete from the docs as [according to devsnake](https://github.com/discord/discord-api-docs/issues/3690#issuecomment-902915187), "They are not supposed to be sent to bots"