### PR TITLE
Add Discord++ to Community Resources > Libraries

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -19,6 +19,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [discljord](https://github.com/igjoshua/discljord)           | Clojure    |
 | [aegis.cpp](https://github.com/zeroxs/aegis.cpp)             | C++        |
 | [D++](https://github.com/brainboxdotcc/DPP)                  | C++        |
+| [Discord++](https://github.com/DiscordPP/discordpp)          | C++        |
 | [Sleepy Discord](https://github.com/yourWaifu/sleepy-discord)| C++        |
 | [discordcr](https://github.com/shardlab/discordcr)           | Crystal    |
 | [Remora.Discord](https://github.com/Nihlus/Remora.Discord)   | C#         |


### PR DESCRIPTION
Added my C++ library, Discord++, to the list of community libraries.

One of the core tenants of my library is modularity. Core functionality like the HTTP and WebSocket gateway modules can be swapped out to make use of different dependencies (though currently there aren't extra options) and plugins can be added seamlessly.

To this effect, my ratelimiting implementation is in a plugin: https://github.com/DiscordPP/plugin-ratelimit/blob/master/discordpp/plugin-ratelimit.hh
*I plan to add a check to make sure *some* ratelimiting plugin is installed for safety. Edit: done*

An example of a plugin, this one allows for easy use of `!keyword`-style commands: https://github.com/DiscordPP/plugin-responder

An example bot: https://github.com/DiscordPP/echo-bot

Edit 8/29: [**Plugin: Endpoints**](https://github.com/DiscordPP/plugin-endpoints) now has all of the endpoints for handling interactions. They're under `discordpp/categories/application-commands.hh` and `discordpp/categories/receiving-and-responding.hh`
Edit 8/29: An example of these in use: https://github.com/DiscordPP/echo-bot/blob/master/main.cc#L111-L139
Edit 8/30: Added thread endpoints [under /channel/](https://github.com/DiscordPP/plugin-endpoints/commit/c9a3a957294f1063804ebbf599a19617c7b0bf17) and [under /guild/](https://github.com/DiscordPP/plugin-endpoints/commit/ae850db41ed9b8dbd29abd33d5d05e90a018454d)
Edit 9/1: **Plugin: Endpoints** now has all endpoints minus GitHub and Slack-compatible webhooks