### PR TITLE
Patch Larko's intents calculator url

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -101,7 +101,7 @@ Using Discord's [Dispatch](#DOCS_DISPATCH_DISPATCH_AND_YOU) tool for game develo
 [Gateway Intents](#DOCS_TOPICS_GATEWAY/gateway-intents) are pretty confusing at first. If you're not sure what to send in your [identify payload](#DOCS_TOPICS_GATEWAY/identify), then these tools may be of help:
 
 - [ziad87's Intent Calculator](https://ziad87.net/intents/)
-- [Larko's Intent Calculator](https://intents.aymdj.me/)
+- [Larko's Intent Calculator](https://discord-intents-calculator.vercel.app/)
 
 ## Embed Visualizer
 


### PR DESCRIPTION
The provided url was https://intents.aymdj.me/ which is no longer accessible. So instead, it would be convenient to use [vercel's url](https://discord-intents-calculator.vercel.app). I've cross-verified this with multiple users.