### PR TITLE
Remove unmaintained libraries

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -45,7 +45,6 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [Serenity](https://github.com/serenity-rs/serenity)          | Rust       |
 | [Twilight](https://github.com/twilight-rs/twilight)          | Rust       |
 | [AckCord](https://github.com/Katrix/AckCord)                 | Scala      |
-| [Sword](https://github.com/Azoy/Sword)                       | Swift      |
 | [Detritus](https://github.com/detritusjs/client)             | TypeScript |
 | [discordeno](https://github.com/discordeno/discordeno)       | TypeScript |
 | [droff](https://github.com/tim-smart/droff)                  | TypeScript |

--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -41,7 +41,6 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [DiscordPHP](https://github.com/discord-php/DiscordPHP)      | PHP        |
 | [RestCord](https://www.restcord.com/)                        | PHP        |
 | [discord.py](https://github.com/Rapptz/discord.py)           | Python     |
-| [disco](https://github.com/b1naryth1ef/disco)                | Python     |
 | [discordrb](https://github.com/shardlab/discordrb)           | Ruby       |
 | [discord-rs](https://github.com/SpaceManiac/discord-rs)      | Rust       |
 | [Serenity](https://github.com/serenity-rs/serenity)          | Rust       |

--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -40,7 +40,6 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [discordnim](https://github.com/Krognol/discordnim)          | Nim        |
 | [DiscordPHP](https://github.com/discord-php/DiscordPHP)      | PHP        |
 | [RestCord](https://www.restcord.com/)                        | PHP        |
-| [discord.py](https://github.com/Rapptz/discord.py)           | Python     |
 | [discordrb](https://github.com/shardlab/discordrb)           | Ruby       |
 | [discord-rs](https://github.com/SpaceManiac/discord-rs)      | Rust       |
 | [Serenity](https://github.com/serenity-rs/serenity)          | Rust       |


### PR DESCRIPTION
This PR removes discord.py, disco and Sword from the community resources libraries list as the libraries are unmaintained (GitHub repos have been archived) and they do not provide an interface for Slash Commands, which appears to be the recommended approach to implement a bot on Discord now.