### PR TITLE
Add hikari to community resources

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -42,6 +42,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [RestCord](https://www.restcord.com/)                        | PHP        |
 | [discord.py](https://github.com/Rapptz/discord.py)           | Python     |
 | [disco](https://github.com/b1naryth1ef/disco)                | Python     |
+| [hikari](https://github.com/hikari-py/hikari)                | Python     |
 | [discordrb](https://github.com/shardlab/discordrb)           | Ruby       |
 | [discord-rs](https://github.com/SpaceManiac/discord-rs)      | Rust       |
 | [Serenity](https://github.com/serenity-rs/serenity)          | Rust       |


### PR DESCRIPTION
This pull request aims to add [hikari](https://github.com/hikari-py/hikari) to the community resources.

Hikari is a new, powerful, static-typed Python API for writing Discord bots. We provide a flexible way of making bots with different options like a rest based bot (interactions server), gateway based bot or only a rest application if you are working on a dashboard or similar.

#

Rate limiting implementation: https://github.com/hikari-py/hikari/blob/master/hikari/impl/buckets.py