### PR TITLE
Adding a "unarchivable" field; fixing some typos

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -182,7 +182,7 @@ Bots can post or publish messages in this type of channel if they have the prope
 
 ###### Example Store Channel
 
-Bots can neither send or read messages from this channel type (as it is a store page).
+Bots can neither send nor read messages from this channel type (as it is a store page).
 
 ```json
 {
@@ -517,6 +517,7 @@ The thread metadata object contains a number of thread-specific channel fields t
 | archive_timestamp     | ISO8601 timestamp | timestamp when the thread's archive status was last changed, used for calculating recent activity                   |
 | locked                | boolean           | whether the thread is locked; when a thread is locked, only users with MANAGE_THREADS can unarchive it              |
 | invitable?            | boolean           | whether non-moderators can add other non-moderators to a thread; only available on private threads                  |
+| unarchivable          | boolean           | whether non-moderators can unarchive a thread that is not locked                                                    |
 
 ### Thread Member Object
 
@@ -825,9 +826,11 @@ Otherwise, requires the `MANAGE_THREADS` permission. Fires a [Thread Update](#DO
 | auto_archive_duration\* | integer  | duration in minutes to automatically archive the thread after recent activity, can be set to: 60, 1440, 4320, 10080                                                                               |
 | locked                  | boolean  | whether the thread is locked; when a thread is locked, only users with MANAGE_THREADS can unarchive it                                                                                            |
 | invitable               | boolean  | whether non-moderators can add other non-moderators to a thread; only available on private threads                                                                                                |
+| unarchivable            | boolean  | whether non-moderators can unarchive a thread that is not locked                                                    
+                                                       |
 | rate_limit_per_user     | ?integer | amount of seconds a user has to wait before sending another message (0-21600); bots, as well as users with the permission `manage_messages`, `manage_thread`, or `manage_channel`, are unaffected |
 
-\* The 3 day and 7 day archive durations require the server to be boosted. The [guild features](#DOCS_RESOURCES_GUILD/guild-object-guild-features) will indicate if a server is able to use those settings.
+\* The 3-day and 7-day archive durations require the server to be boosted. The [guild features](#DOCS_RESOURCES_GUILD/guild-object-guild-features) will indicate if a server is able to use those settings.
 
 ## Delete/Close Channel % DELETE /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}
 
@@ -1195,7 +1198,7 @@ When called on a `GUILD_TEXT` channel, creates a `GUILD_PUBLIC_THREAD`. When cal
 | name                    | string  | 1-100 character channel name                                                                                        |
 | auto_archive_duration\* | integer | duration in minutes to automatically archive the thread after recent activity, can be set to: 60, 1440, 4320, 10080 |
 
-\* The 3 day and 7 day archive durations require the server to be boosted. The [guild features](#DOCS_RESOURCES_GUILD/guild-object-guild-features) will indicate if a server is able to use those settings.
+\* The 3-day and 7-day archive durations require the server to be boosted. The [guild features](#DOCS_RESOURCES_GUILD/guild-object-guild-features) will indicate if a server is able to use those settings.
 
 ## Start Thread without Message % POST /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/threads
 
@@ -1212,12 +1215,13 @@ Creates a new thread that is not connected to an existing message. The created t
 | auto_archive_duration\*\* | integer | duration in minutes to automatically archive the thread after recent activity, can be set to: 60, 1440, 4320, 10080 |
 | type?\*\*\*               | integer | the [type of thread](#DOCS_RESOURCES_CHANNEL/channel-object-channel-types) to create                                |
 | invitable?                | boolean | whether non-moderators can add other non-moderators to a thread; only available when creating a private thread      |
+| unarchivable              | boolean | whether non-moderators can unarchive a thread that is not locked                                                    |
 
 \* Creating a private thread requires the server to be boosted. The [guild features](#DOCS_RESOURCES_GUILD/guild-object-guild-features) will indicate if that is possible for the guild.
 
-\*\* The 3 day and 7 day archive durations require the server to be boosted. The [guild features](#DOCS_RESOURCES_GUILD/guild-object-guild-features) will indicate if that is possible for the guild.
+\*\* The 3-day and 7-day archive durations require the server to be boosted. The [guild features](#DOCS_RESOURCES_GUILD/guild-object-guild-features) will indicate if that is possible for the guild.
 
-\*\*\* In API v9, `type` defaults to `PRIVATE_THREAD` in order to match the behavior when thread documentation was first published. In API v10 this will be changed to be a required field, with no default.
+\*\*\* In API v9, `type` defaults to `PRIVATE_THREAD` in order to match the behavior when thread documentation was first published. In API v10, this will be changed to be a required field, with no default.
 
 ## Join Thread % PUT /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/thread-members/@me
 


### PR DESCRIPTION
I suggest adding a new field called "unarchivable", which is equivalent to the "Anyone can unarchive" option of the thread settings on the Discord app, and fixing some typos on the documentation.