### PR TITLE
fix: Make member_id snowflake type string instead of number

### DIFF
--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -356,7 +356,7 @@ When someone uses a slash command, your application will receive an interaction:
     "token": "A_UNIQUE_TOKEN",
     "member": {
         "user": {
-            "id": 53908232506183680,
+            "id": "53908232506183680",
             "username": "Mason",
             "avatar": "a_d5efa99b3eeaa7dd43acca82f5692432",
             "discriminator": "1337",


### PR DESCRIPTION
The member id here is of type `number` 👍🏼 

However it is supposed to be type `string`