### PR TITLE
Removed the disclaimer for threads

### DIFF
--- a/docs/topics/Threads.md
+++ b/docs/topics/Threads.md
@@ -4,10 +4,6 @@
 
 Threads have been designed to be very similar to [channel](#DOCS_RESOURCES_CHANNEL/channel-object) objects, and this topic aggregates all of the information about threads, which should all help to make migrating very straightforward.
 
-## Disclaimer
-
-Threads have not shipped yet, and so everything in this documentation is still subject to change. At a minimum additional status codes will be added for reaching certain limits, and we may implement additional features, especially around moderation tooling, but we don't expect any of those to be breaking changes for what is currently documented.
-
 ## Backwards Compatibility
 
 Threads are only available in API v9. Bots that do not update to API v9 will not receive most gateway events for threads, or things that happen in threads (such as [Message Create](#DOCS_TOPICS_GATEWAY/message-create)). Bots on APIv8 will still receive gateway events for Interactions though.


### PR DESCRIPTION
Since threads have shipped, this disclaimer is incorrect.