### PR TITLE
Add a “Development Discontinued” indicator

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -41,7 +41,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [discordnim](https://github.com/Krognol/discordnim)          | Nim        |
 | [DiscordPHP](https://github.com/discord-php/DiscordPHP)      | PHP        |
 | [RestCord](https://www.restcord.com/)                        | PHP        |
-| [discord.py](https://github.com/Rapptz/discord.py)           | Python     |
+| [discord.py](https://github.com/Rapptz/discord.py)*          | Python     |
 | [disco](https://github.com/b1naryth1ef/disco)                | Python     |
 | [discordrb](https://github.com/shardlab/discordrb)           | Ruby       |
 | [discord-rs](https://github.com/SpaceManiac/discord-rs)      | Rust       |
@@ -53,6 +53,8 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [discordeno](https://github.com/discordeno/discordeno)       | TypeScript |
 | [droff](https://github.com/tim-smart/droff)                  | TypeScript |
 | [Harmony](https://github.com/harmonyland/harmony)            | TypeScript |
+
+* Development Discontinued
 
 ## Interactions
 


### PR DESCRIPTION
Now that **discord.py** has been discontinued I thinks it’s better to add a “`Development Discontinued`” indicator or maybe ~~remove~~ the lib from the table itself...