### PR TITLE
Add another schema error example

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -81,6 +81,23 @@ In API v8, we've improved error formatting in form error responses. The response
 }
 ```
 
+###### Request Error
+
+```json
+{
+    "code": 50035,
+    "message": "Invalid Form Body",
+    "errors": {
+        "_errors": [
+            {
+                "code": "APPLICATION_COMMAND_TOO_LARGE",
+                "message": "Command exceeds maximum size (4000)"
+            }
+        ]
+    }
+}
+```
+
 ## Authentication
 
 Authenticating with the Discord API can be done in one of two ways:

--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -99,7 +99,7 @@ Our API will return semantically valid HTTP response codes based on the success 
 
 ## JSON
 
-Along with the HTTP error code, our API can also return more detailed error codes through a `code` key in the JSON error response. The response will also contain a `message` key containing a more friendly error string.
+Along with the HTTP error code, our API can also return more detailed error codes through a `code` key in the JSON error response. The response will also contain a `message` key containing a more friendly error string. Some of these errors may also send [Schema Errors](#DOCS_REFERENCE/error-messages) in addition to `code` and `message` in an `errors` object.
 
 ###### JSON Error Codes
 

--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -99,7 +99,7 @@ Our API will return semantically valid HTTP response codes based on the success 
 
 ## JSON
 
-Along with the HTTP error code, our API can also return more detailed error codes through a `code` key in the JSON error response. The response will also contain a `message` key containing a more friendly error string. Some of these errors may also send [Schema Errors](#DOCS_REFERENCE/error-messages) in addition to `code` and `message` in an `errors` object.
+Along with the HTTP error code, our API can also return more detailed error codes through a `code` key in the JSON error response. The response will also contain a `message` key containing a more friendly error string. Some of these errors may include additional details in the form of [Error Messages](#DOCS_REFERENCE/error-messages) provided by an `errors` object.
 
 ###### JSON Error Codes
 


### PR DESCRIPTION
Since schema errors may not necessarily appear only for specific json properties, I think a specific example for this makes sense. I used the request error for max characters in a command. Additionally, I added a link to the schema errors in the error codes docs to make it more discoverable.