### PR TITLE
Add hata to Community Resources

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -46,6 +46,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [RestCord](https://www.restcord.com/)                        | PHP        |
 | [discord.py](https://github.com/Rapptz/discord.py)           | Python     |
 | [disco](https://github.com/b1naryth1ef/disco)                | Python     |
+| [hata](https://github.com/HuyaneMatsu/hata)                  | Python     |
 | [hikari](https://github.com/hikari-py/hikari)                | Python     |
 | [discordrb](https://github.com/shardlab/discordrb)           | Ruby       |
 | [discord-rs](https://github.com/SpaceManiac/discord-rs)      | Rust       |


### PR DESCRIPTION
This PR adds [Hata](https://github.com/HuyaneMatsu/hata) to community resources.

> I'm opening a new PR since @davfsa told me my [PR](https://github.com/discord/discord-api-docs/pull/3732) has conflicts and since it was closed.

Hata is an async Discord API wrapper written in Python.

The library tries to do things differently than other Python wrappers - its main feature is supporting multiple clients with shared cache between them.

It also aims to be fully PyPy compatible for the best performance, and it supports the newest features natively like slash commands, components and context commands.

It properly handles ratelimits, for which the code can be found here:
https://github.com/HuyaneMatsu/hata/blob/master/hata/discord/http/rate_limit.py#L477-L668
https://github.com/HuyaneMatsu/hata/blob/master/hata/discord/http/http_client.py#L243-L301

We also have a long-running Discord support server and technical documentation hosted on https://www.astil.dev/project/hata/docs/hata
