### PR TITLE
Fix standardized HTTP endpoints formatting to be consistent

### DIFF
--- a/docs/game_sdk/Achievements.md
+++ b/docs/game_sdk/Achievements.md
@@ -4,7 +4,7 @@
 > Need help with the SDK? Talk to us in the [Discord Developers Server](https://discord.gg/discord-developers)!
 
 > warn
-> Game approval submissions are currently paused due to unforeseen circumstances. We apologize for the inconvenience. [Click here for more info.](https://support-dev.discord.com/hc/en-us/articles/360041437171)
+> Game approval submissions are currently paused due to unforeseen circumstances. We apologize for the inconvenience. Click [here]((https://support-dev.discord.com/hc/en-us/articles/360041437171)) for more info.
 
 There's no feeling quite like accomplishing a goal that you've set out to achieve. Is killing 1000 zombies in a game as great an achievement as climbing Mt. Everest? Of course it is, and I didn't even have to leave my house. So get off my back, society.
 
@@ -18,15 +18,15 @@ You can also mark achievements as `secret` and `secure`. "Secret" achievements w
 
 ###### Achievement Struct
 
-| name           | type    | description                                                                                                                      |
-| -------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| application_id | Int64   | the unique id of the application                                                                                                 |
-| name           | object  | the name of the achievement as an [achievement locale object](#DOCS_GAME_SDK_ACHIEVEMENTS/achievement-locale-object)             |
-| description    | object  | the user-facing achievement description as an [achievement locale object](#DOCS_GAME_SDK_ACHIEVEMENTS/achievement-locale-object) |
-| secret         | boolean | if the achievement is secret                                                                                                     |
-| secure         | boolean | if the achievement is secure                                                                                                     |
-| id             | Int64   | the unique id of the achievement                                                                                                 |
-| icon_hash      | string  | [the hash of the icon](#DOCS_REFERENCE/image-formatting)                                                                         |
+| Name           | Type      | Description                                                                                                                      |
+| -------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| application_id | snowflake | the unique id of the application                                                                                                 |
+| name           | object    | the name of the achievement as an [achievement locale object](#DOCS_GAME_SDK_ACHIEVEMENTS/achievement-locale-object)             |
+| description    | object    | the user-facing achievement description as an [achievement locale object](#DOCS_GAME_SDK_ACHIEVEMENTS/achievement-locale-object) |
+| secret         | boolean   | if the achievement is secret                                                                                                     |
+| secure         | boolean   | if the achievement is secure                                                                                                     |
+| id             | snowflake | the unique id of the achievement                                                                                                 |
+| icon_hash      | string    | [the hash of the icon](#DOCS_REFERENCE/image-formatting)                                                                         |
 
 ###### Achievement Locale Object
 
@@ -186,22 +186,13 @@ Fires when an achievement is updated for the currently connected user
 
 ## The API Way
 
-Below are the API endpoints and the parameters they accept. If you choose to interface directly with the Discord API, you will need a "Bot token". This is a special authorization token with which your application can access Discord's HTTP API. Head on over to [your app's dashboard](https://discord.com/developers/), and hit the big "Add a Bot User" button. From there, mutter _abra kadabra_ and reveal the token. This token is used as an authorization header against our API like so:
+Below are the API endpoints and the parameters they accept. If you choose to interface directly with the Discord API, you will need a "Bot token". This is a special authorization token with which your application can access Discord's HTTP API. Head on over to [your application's dashboard](https://discord.com/developers/), and hit the big "Add a Bot User" button. From there, mutter _abra kadabra_ and reveal the token. Click [here](#DOCS_REFERENCE/authentication) to see how you can authorize your requests.
 
-```
-curl -x POST -h "Authorization: Bot <your token>" https://discord.com/api/some-route/that-does-a-thing
-```
+## Get Achievements % GET /applications/{application.id#DOCS_RESOURCES_APPLICATION/application-object}/achievements
 
-> info
-> Make sure to prepend your token with "Bot"!
+Returns a list of [achievements](#DOCS_GAME_SDK_ACHIEVEMENTS/data-models-achievement-struct) for the given application.
 
-## Get Achievements
-
-`GET https://discord.com/api/v6/applications/<application_id>/achievements`
-
-Returns all achievements for the given application. This endpoint has a rate limit of 5 requests per 5 seconds per application.
-
-###### Return Object
+###### Example Response
 
 ```json
 [
@@ -221,13 +212,11 @@ Returns all achievements for the given application. This endpoint has a rate lim
 ]
 ```
 
-## Get Achievement
+## Get Achievement % GET /applications/{application.id#DOCS_RESOURCES_APPLICATION/application-object}/achievements/{achievement.id#DOCS_GAME_SDK_ACHIEVEMENTS/data-models-achievement-struct}
 
-`GET https://discord.com/api/v6/applications/<application_id>/achievements/<achievement_id>`
+Returns the given [achievement](#DOCS_GAME_SDK_ACHIEVEMENTS/data-models-achievement-struct) for the given application.
 
-Returns the given achievement for the given application. This endpoint has a rate limit of 5 requests per 5 seconds per application.
-
-###### Return Object
+###### Example Response
 
 ```json
 {
@@ -245,23 +234,24 @@ Returns the given achievement for the given application. This endpoint has a rat
 }
 ```
 
-## Create Achievement
+## Create Achievement % POST /applications/{application.id#DOCS_RESOURCES_APPLICATION/application-object}/achievements
 
-`POST https://discord.com/api/v6/applications/<application_id>/achievements`
+Creates a new [achievement](#DOCS_GAME_SDK_ACHIEVEMENTS/data-models-achievement-struct) for your application.
 
-Creates a new achievement for your application. Applications can have a maximum of 1000 achievements. This endpoint has a rate limit of 5 requests per 5 seconds per application.
+> info
+> Applications can have a maximum of 1000 achievements.
 
-###### Parameters
+###### JSON Params
 
 | name        | type      | description                             |
 | ----------- | --------- | --------------------------------------- |
 | name        | string    | the name of the achievement             |
 | description | string    | the user-facing achievement description |
-| secret      | bool      | if the achievement is secret            |
-| secure      | bool      | if the achievement is secure            |
+| secret      | boolean   | if the achievement is secret            |
+| secure      | boolean   | if the achievement is secure            |
 | icon        | ImageType | the icon for the achievement            |
 
-###### Example: Creating an Achievement
+###### Example Body
 
 ```json
 {
@@ -277,7 +267,7 @@ Creates a new achievement for your application. Applications can have a maximum 
 }
 ```
 
-###### Return Object
+###### Example Response
 
 ```json
 {
@@ -295,23 +285,21 @@ Creates a new achievement for your application. Applications can have a maximum 
 }
 ```
 
-## Update Achievement
+## Modify Achievement % PATCH /applications/{application.id#DOCS_RESOURCES_APPLICATION/application-object}/achievements/{achievement.id#DOCS_GAME_SDK_ACHIEVEMENTS/data-models-achievement-struct}
 
-`PATCH https://discord.com/api/v6/applications/<application_id>/achievements/<achievement_id>`
+Updates the [achievement](#DOCS_GAME_SDK_ACHIEVEMENTS/data-models-achievement-struct) for all users. This is **NOT** to update a single user's achievement progress; this is to edit the `UserAchievement` itself.
 
-Updates the achievement for **\_\_ALL USERS\_\_**. This is **NOT** to update a single user's achievement progress; this is to edit the UserAchievement itself. This endpoint has a rate limit of 5 requests per 5 seconds per application.
-
-###### Parameters
+###### JSON Params
 
 | name        | type      | description                             |
 | ----------- | --------- | --------------------------------------- |
 | name        | string    | the name of the achievement             |
 | description | string    | the user-facing achievement description |
-| secret      | bool      | if the achievement is secret            |
-| secure      | bool      | if the achievement is secure            |
+| secret      | boolean   | if the achievement is secret            |
+| secure      | boolean   | if the achievement is secure            |
 | icon        | ImageType | the icon for the achievement            |
 
-###### Example: Updating an Achievement
+###### Example Body
 
 ```json
 {
@@ -327,7 +315,7 @@ Updates the achievement for **\_\_ALL USERS\_\_**. This is **NOT** to update a s
 }
 ```
 
-###### Return Object
+###### Example Response
 
 ```json
 {
@@ -345,46 +333,34 @@ Updates the achievement for **\_\_ALL USERS\_\_**. This is **NOT** to update a s
 }
 ```
 
-## Delete Achievement
+## Delete Achievement % DELETE /applications/{application.id#DOCS_RESOURCES_APPLICATION/application-object}/achievements/{achievement.id#DOCS_GAME_SDK_ACHIEVEMENTS/data-models-achievement-struct}
 
-`DELETE https://discord.com/api/v6/applications/<application_id>/achievements/<achievement_id>`
+Deletes the given [achievement](#DOCS_GAME_SDK_ACHIEVEMENTS/data-models-achievement-struct) from your application. Returns a `204` on success.
 
-Deletes the given achievement from your application. This endpoint has a rate limit of 5 requests per 5 seconds per application.
+## Modify User Achievement % PUT /users/{user.id}/applications/{application.id}/achievements/{achievement.id}
 
-###### Return Object
+Updates the `UserAchievement` record for a given user. Use this endpoint to update `secure` achievement progress for users.
 
-```json
-// 204 No Content
-```
+###### JSON Params
 
-## Update User Achievement
+| Name             | Type     | Description                                            |
+| ---------------- | -------- | ------------------------------------------------------ |
+| percent_complete | integer  | the user's progress towards completing the achievement |
 
-`PUT https://discord.com/api/v6/users/<user_id>/applications/<application_id>/achievements/<achievement_id>`
-
-Updates the UserAchievement record for a given user. Use this endpoint to update `secure` achievement progress for users. This endpoint has a rate limit of 5 requests per 5 seconds per application.
-
-###### Parameters
-
-| name             | type | description                                            |
-| ---------------- | ---- | ------------------------------------------------------ |
-| percent_complete | int  | the user's progress towards completing the achievement |
-
-###### Return Object
+###### Example Response
 
 ```json
 {}
 ```
 
-## Get User Achievements
-
-`GET https://discord.com/api/v6/users/@me/applications/<application_id>/achievements`
+## Get User Achievements % GET /users/{user.id}/applications/{application.id}/achievements/{achievement.id}
 
 Returns a list of achievements for the user whose token you're making the request with. This endpoint will **NOT** accept the Bearer token for your application generated via the [Client Crendentials Grant](#DOCS_TOPICS_OAUTH2/client-credentials-grant). You will need the _user's_ bearer token, gotten via either the [Authorization Code OAuth2 Grant](#DOCS_TOPICS_OAUTH2/authorization-code-grant) or via the SDK with [GetOAuth2Token](#DOCS_GAME_SDK_APPLICATIONS/get-oauth2-token). This endpoint has a rate limit of 2 requests per 5 seconds per application per user.
 
 > info
 > This endpoint will _not_ return any achievements marked as `secret` that the user has not yet completed.
 
-###### Return Object
+###### Example Response
 
 ```json
 [

--- a/docs/game_sdk/Achievements.md
+++ b/docs/game_sdk/Achievements.md
@@ -353,7 +353,7 @@ Updates the `UserAchievement` record for a given user. Use this endpoint to upda
 {}
 ```
 
-## Get User Achievements % GET /users/{user.id}/applications/{application.id}/achievements/{achievement.id}
+## Get User Achievements % GET /users/{user.id#DOCS_RESOURCES_USER/user-object}/applications/{application.id#DOCS_RESOURCES_APPLICATION/application-object}//achievements/{achievement.id#DOCS_GAME_SDK_ACHIEVEMENTS/data-models-achievement-struct}
 
 Returns a list of achievements for the user whose token you're making the request with. This endpoint will **NOT** accept the Bearer token for your application generated via the [Client Crendentials Grant](#DOCS_TOPICS_OAUTH2/client-credentials-grant). You will need the _user's_ bearer token, gotten via either the [Authorization Code OAuth2 Grant](#DOCS_TOPICS_OAUTH2/authorization-code-grant) or via the SDK with [GetOAuth2Token](#DOCS_GAME_SDK_APPLICATIONS/get-oauth2-token). This endpoint has a rate limit of 2 requests per 5 seconds per application per user.
 

--- a/docs/game_sdk/Achievements.md
+++ b/docs/game_sdk/Achievements.md
@@ -18,15 +18,15 @@ You can also mark achievements as `secret` and `secure`. "Secret" achievements w
 
 ###### Achievement Struct
 
-| Name           | Type      | Description                                                                                                                      |
-| -------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| application_id | snowflake | the unique id of the application                                                                                                 |
-| name           | object    | the name of the achievement as an [achievement locale object](#DOCS_GAME_SDK_ACHIEVEMENTS/achievement-locale-object)             |
-| description    | object    | the user-facing achievement description as an [achievement locale object](#DOCS_GAME_SDK_ACHIEVEMENTS/achievement-locale-object) |
-| secret         | boolean   | if the achievement is secret                                                                                                     |
-| secure         | boolean   | if the achievement is secure                                                                                                     |
-| id             | snowflake | the unique id of the achievement                                                                                                 |
-| icon_hash      | string    | [the hash of the icon](#DOCS_REFERENCE/image-formatting)                                                                         |
+| Name           | Type    | Description                                                                                                                      |
+| -------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| application_id | Int64   | the unique id of the application                                                                                                 |
+| name           | object  | the name of the achievement as an [achievement locale object](#DOCS_GAME_SDK_ACHIEVEMENTS/achievement-locale-object)             |
+| description    | object  | the user-facing achievement description as an [achievement locale object](#DOCS_GAME_SDK_ACHIEVEMENTS/achievement-locale-object) |
+| secret         | boolean | if the achievement is secret                                                                                                     |
+| secure         | boolean | if the achievement is secure                                                                                                     |
+| id             | Int64   | the unique id of the achievement                                                                                                 |
+| icon_hash      | string  | [the hash of the icon](#DOCS_REFERENCE/image-formatting)                                                                         |
 
 ###### Achievement Locale Object
 

--- a/docs/game_sdk/Lobbies.md
+++ b/docs/game_sdk/Lobbies.md
@@ -1326,20 +1326,77 @@ Below are the API endpoints and the parameters they accept. If you choose to int
 
 Here are the routes; they all expect JSON bodies. Also, hey, while you're here. You've got a bot token. You're looking at our API. You should check out all the other [awesome stuff](#ODCS_INTRO/) you can do with it!
 
+### Lobby Object
+
+###### Lobby Structure
+
+| Name           | Type                                                          | Description                                                                                          |
+| -------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| id             | snowflake                                                     | lobby id                                                                                             |
+| type           | [lobby type](#DOCS_GAME_SDK_LOBBIES/lobby-object-lobby-types) | the type of lobby                                                                                    |
+| application_id | string                                                        | your application id                                                                                  |
+| capacity       | integer                                                       | max lobby capacity with a default of 16                                                              |
+| region         | string                                                        | the region in which to make the lobby - defaults to the region of the requesting server's IP address |
+| secret         | string                                                        | the password to the lobby                                                                            |
+| metadata       | dict                                                          | metadata for the lobby - key/value pairs with types `string`                                         |
+| owner_id       | snowflake                                                     | the owner of the lobby                                                                               |
+
+###### Lobby Type
+
+| Name    | Value |
+| ------- | ----- |
+| Private | 1     |
+| Public  | 2     |
+
+###### Search Filter Object
+
+| Name       | Type                                                                                  | Description                                       |
+| ---------- | ------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| key        | string                                                                                | the metadata key to search                        |
+| value      | string                                                                                | the value of the metadata key to validate against |
+| cast       | [search cast type](#DOCS_GAME_SDK_LOBBIES/lobby-object-search-cast-types)             | the type to cast `value` as                       |
+| comparison | [search comparison type](#DOCS_GAME_SDK_LOBBIES/lobby-object-search-comparison-types) | how to compare the metadata values                |
+
+###### Search Comparison Types
+
+| Name                     | Value |
+| ------------------------ | ----- |
+| EQUAL_TO_OR_LESS_THAN    | -2    |
+| LESS_THAN                | -1    |
+| EQUAL                    | 0     |
+| EQUAL_TO_OR_GREATER_THAN | 1     |
+| GREATER_THAN             | 2     |
+| NOT_EQUAL                | 3     |
+
+###### Search Sort Object
+
+| Name       | Type        | Description                                                             |
+| ---------- | ----------- | ----------------------------------------------------------------------- |
+| key        | string      | the metadata key on which to sort lobbies that meet the search criteria |
+| cast       | [search cast type](#DOCS_GAME_SDK_LOBBIES/lobby-object-search-cast-types) | the type to cast `value` as                                             |
+| near_value | string      | the value around which to sort the key                                  |
+
+###### Search Cast Types
+
+| name   | value |
+| ------ | ----- |
+| STRING | 1     |
+| NUMBER | 2     |
+
 ## Create Lobby % POST /lobbies
 
-Creates a new lobby. Returns an object similar to the SDK `Lobby` struct, documented below.
+Creates a new lobby. Returns a [lobby object](#DOCS_GAME_SDK_LOBBIES/lobby-object) on success.
 
 To get a list of valid regions, see the [List Voice Regions](#DOCS_RESOURCES_VOICE/list-voice-regions) endpoint.
 
 ###### JSON Params
 
-| name           | type      | description                                                                                          |
+| Name           | Type      | Description                                                                                          |
 | -------------- | --------- | ---------------------------------------------------------------------------------------------------- |
 | application_id | string    | your application id                                                                                  |
-| type           | LobbyType | the type of lobby                                                                                    |
+| type           | [lobby type](#DOCS_GAME_SDK_LOBBIES/lobby-object-lobby-types) | the type of lobby                                |
 | metadata       | dict      | metadata for the lobby - key/value pairs with types `string`                                         |
-| capacity       | int       | max lobby capacity with a default of 16                                                              |
+| capacity       | integer   | max lobby capacity with a default of 16                                                              |
 | region         | string    | the region in which to make the lobby - defaults to the region of the requesting server's IP address |
 
 ###### Example Response
@@ -1360,29 +1417,29 @@ To get a list of valid regions, see the [List Voice Regions](#DOCS_RESOURCES_VOI
 }
 ```
 
-## Modify Lobby % PATCH /lobbies/{lobby.id#DOCS_GAME_SDK_LOBBIES/data-models-lobby-struct}
+## Modify Lobby % PATCH /lobbies/{lobby.id#DOCS_GAME_SDK_LOBBIES/lobby-object}
 
-Modifies a lobby.
+Modifies a lobby. Returns the modified [lobby object](#DOCS_GAME_SDK_LOBBIES/lobby-object) on success.
 
 ###### JSON Params
 
-| name     | type      | description                                                  |
-| -------- | --------- | ------------------------------------------------------------ |
-| type     | LobbyType | the type of lobby                                            |
-| metadata | dict      | metadata for the lobby - key/value pairs with types `string` |
-| capacity | int       | max lobby capacity with a default of 16                      |
+| Name     | Type                                                          | Description                                                  |
+| -------- | ------------------------------------------------------------- | ------------------------------------------------------------ |
+| type     | [lobby type](#DOCS_GAME_SDK_LOBBIES/lobby-object-lobby-types) | the type of lobby                                            |
+| metadata | dict                                                          | metadata for the lobby - key/value pairs with types `string` |
+| capacity | integer                                                       | max lobby capacity with a default of 16                      |
 
-## Delete Lobby % DELETE /lobbies/{lobby.id#DOCS_GAME_SDK_LOBBIES/data-models-lobby-struct}
+## Delete Lobby % DELETE /lobbies/{lobby.id#DOCS_GAME_SDK_LOBBIES/lobby-object}
 
 Deletes a lobby. Returns a `204` on success.
 
-## Modify Lobby Member % PATCH /lobbies/{lobby.id#DOCS_GAME_SDK_LOBBIES/data-models-lobby-struct}/members/{user.id#DOCS_RESOURCES_USER/user-object}
+## Modify Lobby Member % PATCH /lobbies/{lobby.id#DOCS_GAME_SDK_LOBBIES/lobby-object}/members/{user.id#DOCS_RESOURCES_USER/user-object}
 
 Modifies the metadata for a lobby member.
 
 ###### JSON Params
 
-| name     | type | description                                                         |
+| Name     | Type | Description                                                         |
 | -------- | ---- | ------------------------------------------------------------------- |
 | metadata | dict | metadata for the lobby member - key/value pairs with types `string` |
 
@@ -1395,44 +1452,9 @@ Creates a lobby search for matchmaking around given criteria.
 | name           | type                | description                              |
 | -------------- | ------------------- | ---------------------------------------- |
 | application_id | string              | your application id                      |
-| filter         | SearchFilter object | the filter to check against              |
-| sort           | SearchSort object   | how to sort the results                  |
-| limit          | int                 | limit of lobbies returned, default of 25 |
-
-###### SearchFilter Object
-
-| name       | type             | description                                       |
-| ---------- | ---------------- | ------------------------------------------------- |
-| key        | string           | the metadata key to search                        |
-| value      | string           | the value of the metadata key to validate against |
-| cast       | SearchCast       | the type to cast `value` as                       |
-| comparison | SearchComparison | how to compare the metadata values                |
-
-###### SearchComparison Types
-
-| name                     | value |
-| ------------------------ | ----- |
-| EQUAL_TO_OR_LESS_THAN    | -2    |
-| LESS_THAN                | -1    |
-| EQUAL                    | 0     |
-| EQUAL_TO_OR_GREATER_THAN | 1     |
-| GREATER_THAN             | 2     |
-| NOT_EQUAL                | 3     |
-
-###### SearchSort Object
-
-| name       | type       | description                                                             |
-| ---------- | ---------- | ----------------------------------------------------------------------- |
-| key        | string     | the metadata key on which to sort lobbies that meet the search criteria |
-| cast       | SearchCast | the type to cast `value` as                                             |
-| near_value | string     | the value around which to sort the key                                  |
-
-###### SearchCast Types
-
-| name   | value |
-| ------ | ----- |
-| STRING | 1     |
-| NUMBER | 2     |
+| filter         | [search filter](#DOCS_GAME_SDK_LOBBIES/lobby-object-search-filter-object)       | the filter to check against              |
+| sort           | [search sort object](#DOCS_GAME_SDK_LOBBIES/lobby-object-search-sort-object)         | how to sort the results                  |
+| limit          | integer                 | limit of lobbies returned, default of 25 |
 
 ## Send Lobby Data % POST /lobbies/{lobby.id#DOCS_GAME_SDK_LOBBIES/data-models-lobby-struct}/send
 

--- a/docs/game_sdk/Lobbies.md
+++ b/docs/game_sdk/Lobbies.md
@@ -1322,18 +1322,11 @@ OK so this wasn't really a code example, but I think you get how this works.
 
 ## The API Way
 
-Below are the API endpoints and the parameters they accept. If you choose to interface directly with the Discord API, you will need a "Bot token". This is a special authorization token with which your application can access Discord's HTTP API. Head on over to [your app's dashboard](https://discord.com/developers/), and hit the big "Add a Bot User" button. From there, mutter _abra kadabra_ and reveal the token. This token is used as an authorization header against our API like so:
+Below are the API endpoints and the parameters they accept. If you choose to interface directly with the Discord API, you will need a "Bot token". This is a special authorization token with which your application can access Discord's HTTP API. Head on over to [your app's dashboard](https://discord.com/developers/), and hit the big "Add a Bot User" button. From there, mutter _abra kadabra_ and reveal the token. Click [here](#DOCS_REFERENCE/authentication) to see how you can authorize your requests.
 
-```
-curl -x POST -h "Authorization: Bot <your token>" https://discord.com/api/some-route/that-does-a-thing
-```
+Here are the routes; they all expect JSON bodies. Also, hey, while you're here. You've got a bot token. You're looking at our API. You should check out all the other [awesome stuff](#ODCS_INTRO/) you can do with it!
 
-> info
-> Make sure to prepend your token with "Bot"!
-
-Here are the routes; they all expect JSON bodies. Also, hey, while you're here. You've got a bot token. You're looking at our API. You should check out all the other [awesome stuff](https://discord.com/developers/docs/intro) you can do with it!
-
-### Create Lobby % POST /lobbies
+## Create Lobby % POST /lobbies
 
 Creates a new lobby. Returns an object similar to the SDK `Lobby` struct, documented below.
 
@@ -1367,7 +1360,7 @@ To get a list of valid regions, see the [List Voice Regions](#DOCS_RESOURCES_VOI
 }
 ```
 
-### Modify Lobby % PATCH /lobbies/{lobby.id#DOCS_GAME_SDK_LOBBIES/data-models-lobby-struct}
+## Modify Lobby % PATCH /lobbies/{lobby.id#DOCS_GAME_SDK_LOBBIES/data-models-lobby-struct}
 
 Modifies a lobby.
 
@@ -1379,11 +1372,11 @@ Modifies a lobby.
 | metadata | dict      | metadata for the lobby - key/value pairs with types `string` |
 | capacity | int       | max lobby capacity with a default of 16                      |
 
-### Delete Lobby % DELETE /lobbies/{lobby.id#DOCS_GAME_SDK_LOBBIES/data-models-lobby-struct}
+## Delete Lobby % DELETE /lobbies/{lobby.id#DOCS_GAME_SDK_LOBBIES/data-models-lobby-struct}
 
 Deletes a lobby. Returns a `204` on success.
 
-### Modify Lobby Member % PATCH /lobbies/{lobby.id#DOCS_GAME_SDK_LOBBIES/data-models-lobby-struct}/members/{user.id#DOCS_RESOURCES_USER/user-object}
+## Modify Lobby Member % PATCH /lobbies/{lobby.id#DOCS_GAME_SDK_LOBBIES/data-models-lobby-struct}/members/{user.id#DOCS_RESOURCES_USER/user-object}
 
 Modifies the metadata for a lobby member.
 
@@ -1393,7 +1386,7 @@ Modifies the metadata for a lobby member.
 | -------- | ---- | ------------------------------------------------------------------- |
 | metadata | dict | metadata for the lobby member - key/value pairs with types `string` |
 
-### Create Lobby Search % POST /lobbies/search
+## Create Lobby Search % POST /lobbies/search
 
 Creates a lobby search for matchmaking around given criteria.
 
@@ -1441,7 +1434,7 @@ Creates a lobby search for matchmaking around given criteria.
 | STRING | 1     |
 | NUMBER | 2     |
 
-### Send Lobby Data % POST /lobbies/{lobby.id#DOCS_GAME_SDK_LOBBIES/data-models-lobby-struct}/send
+## Send Lobby Data % POST /lobbies/{lobby.id#DOCS_GAME_SDK_LOBBIES/data-models-lobby-struct}/send
 
 Sends a message to the lobby, fanning it out to other lobby members.
 

--- a/docs/game_sdk/Lobbies.md
+++ b/docs/game_sdk/Lobbies.md
@@ -1333,15 +1333,13 @@ curl -x POST -h "Authorization: Bot <your token>" https://discord.com/api/some-r
 
 Here are the routes; they all expect JSON bodies. Also, hey, while you're here. You've got a bot token. You're looking at our API. You should check out all the other [awesome stuff](https://discord.com/developers/docs/intro) you can do with it!
 
-### Create Lobby
-
-`POST https://discord.com/api/v6/lobbies`
+### Create Lobby % POST /lobbies
 
 Creates a new lobby. Returns an object similar to the SDK `Lobby` struct, documented below.
 
-To get a list of valid regions, call the [List Voice Regions](https://discord.com/developers/docs/resources/voice#list-voice-regions) endpoint.
+To get a list of valid regions, see the [List Voice Regions](#DOCS_RESOURCES_VOICE/list-voice-regions) endpoint.
 
-###### Parameters
+###### JSON Params
 
 | name           | type      | description                                                                                          |
 | -------------- | --------- | ---------------------------------------------------------------------------------------------------- |
@@ -1351,7 +1349,7 @@ To get a list of valid regions, call the [List Voice Regions](https://discord.co
 | capacity       | int       | max lobby capacity with a default of 16                                                              |
 | region         | string    | the region in which to make the lobby - defaults to the region of the requesting server's IP address |
 
-###### Return Object
+###### Example Response
 
 ```json
 {
@@ -1369,13 +1367,11 @@ To get a list of valid regions, call the [List Voice Regions](https://discord.co
 }
 ```
 
-### Update Lobby
+### Modify Lobby % PATCH /lobbies/{lobby.id#DOCS_GAME_SDK_LOBBIES/data-models-lobby-struct}
 
-`PATCH https://discord.com/api/v6/lobbies/<lobby_id>`
+Modifies a lobby.
 
-Updates a lobby.
-
-###### Parameters
+###### JSON Params
 
 | name     | type      | description                                                  |
 | -------- | --------- | ------------------------------------------------------------ |
@@ -1383,31 +1379,25 @@ Updates a lobby.
 | metadata | dict      | metadata for the lobby - key/value pairs with types `string` |
 | capacity | int       | max lobby capacity with a default of 16                      |
 
-### Delete Lobby
+### Delete Lobby % DELETE /lobbies/{lobby.id#DOCS_GAME_SDK_LOBBIES/data-models-lobby-struct}
 
-`DELETE https://discord.com/api/v6/lobbies/<lobby_id>`
+Deletes a lobby. Returns a `204` on success.
 
-Deletes a lobby.
+### Modify Lobby Member % PATCH /lobbies/{lobby.id#DOCS_GAME_SDK_LOBBIES/data-models-lobby-struct}/members/{user.id#DOCS_RESOURCES_USER/user-object}
 
-### Update Lobby Member
+Modifies the metadata for a lobby member.
 
-`PATCH https://discord.com/api/v6/lobbies/<lobby_id>/members/<user_id>`
-
-Updates the metadata for a lobby member.
-
-###### Parameters
+###### JSON Params
 
 | name     | type | description                                                         |
 | -------- | ---- | ------------------------------------------------------------------- |
 | metadata | dict | metadata for the lobby member - key/value pairs with types `string` |
 
-### Create Lobby Search
-
-`POST https://discord.com/api/v6/lobbies/search`
+### Create Lobby Search % POST /lobbies/search
 
 Creates a lobby search for matchmaking around given criteria.
 
-###### Parameters
+###### JSON Params
 
 | name           | type                | description                              |
 | -------------- | ------------------- | ---------------------------------------- |
@@ -1451,15 +1441,13 @@ Creates a lobby search for matchmaking around given criteria.
 | STRING | 1     |
 | NUMBER | 2     |
 
-### Send Lobby Data
-
-`POST https://discord.com/api/v6/lobbies/<lobby_id>/send`
+### Send Lobby Data % POST /lobbies/{lobby.id#DOCS_GAME_SDK_LOBBIES/data-models-lobby-struct}/send
 
 Sends a message to the lobby, fanning it out to other lobby members.
 
 This endpoints accepts a UTF8 string. If your message is already a string, you're good to go! If you want to send binary, you can send it to this endpoint as a base64 encoded data uri.
 
-###### Parameters
+###### JSON Params
 
 | name | type   | description                                 |
 | ---- | ------ | ------------------------------------------- |


### PR DESCRIPTION
My documentation parser wasn't picking these up so I decided to fix them for anyone else who writes auto-generators.