### PR TITLE
Document error code 30001 (Nitro extends guild count with +100)

### DIFF
--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -156,7 +156,7 @@ Along with the HTTP error code, our API can also return more detailed error code
 | 20028  | The channel you are writing has hit the write rate limit                                                                      |
 | 20031  | Your Stage topic, server name, server description, or channel names contain words that are not allowed                        |
 | 20035  | Guild premium subscription level too low                                                                                      |
-| 30001  | Maximum number of guilds reached (100)                                                                                        |
+| 30001  | Maximum number of guilds reached (100/200)                                                                                        |
 | 30002  | Maximum number of friends reached (1000)                                                                                      |
 | 30003  | Maximum number of pins reached for the channel (50)                                                                           |
 | 30004  | Maximum number of recipients reached (10)                                                                                     |


### PR DESCRIPTION
With Discord Nitro your max guild count will be set to 200 (+100)