### PR TITLE
change the max and min ranges of the integer type

### DIFF
--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -53,7 +53,7 @@ Application commands are commands that an application can register to Discord. T
 | SUB_COMMAND       | 1     |                                                   |
 | SUB_COMMAND_GROUP | 2     |                                                   |
 | STRING            | 3     |                                                   |
-| INTEGER           | 4     | Any integer between -2147483647 and 2147483647    |
+| INTEGER           | 4     | Any integer between -2147483648 and 2147483647    |
 | BOOLEAN           | 5     |                                                   |
 | USER              | 6     |                                                   |
 | CHANNEL           | 7     | Includes all channel types + categories           |

--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -48,18 +48,18 @@ Application commands are commands that an application can register to Discord. T
 
 ###### Application Command Option Type
 
-| Name              | Value | Note                                    |
-| ----------------- | ----- | --------------------------------------- |
-| SUB_COMMAND       | 1     |                                         |
-| SUB_COMMAND_GROUP | 2     |                                         |
-| STRING            | 3     |                                         |
-| INTEGER           | 4     | Any integer between -2^53 and 2^53      |
-| BOOLEAN           | 5     |                                         |
-| USER              | 6     |                                         |
-| CHANNEL           | 7     | Includes all channel types + categories |
-| ROLE              | 8     |                                         |
-| MENTIONABLE       | 9     | Includes users and roles                |
-| NUMBER            | 10    | Any double between -2^53 and 2^53       |
+| Name              | Value | Note                                              |
+| ----------------- | ----- | ------------------------------------------------- |
+| SUB_COMMAND       | 1     |                                                   |
+| SUB_COMMAND_GROUP | 2     |                                                   |
+| STRING            | 3     |                                                   |
+| INTEGER           | 4     | Any integer between -2147483647 and 2147483647    |
+| BOOLEAN           | 5     |                                                   |
+| USER              | 6     |                                                   |
+| CHANNEL           | 7     | Includes all channel types + categories           |
+| ROLE              | 8     |                                                   |
+| MENTIONABLE       | 9     | Includes users and roles                          |
+| NUMBER            | 10    | Any double between -2^53 and 2^53                 |
 
 ###### Application Command Option Choice Structure
 


### PR DESCRIPTION
Application Command Option Type has an integer type, which the docs said was between -2^53 and 2^53. This is actually the correct range for `NUMBER`, a `double` type.
Testing and investigation reveals the correct range is between -2147483647 and 2147483647 making this type a signed 32 bit value.

I have corrected the docs to match the implementation in use.