### PR TITLE
Fix documentation of role icons

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -870,15 +870,17 @@ Create a new [role](#DOCS_TOPICS_PERMISSIONS/role-object) for the guild. Require
 
 ###### JSON Params
 
-| Field         | Type                                     | Description                                                          | Default                        |
-| ------------- | ---------------------------------------- | -------------------------------------------------------------------- | ------------------------------ |
-| name          | string                                   | name of the role                                                     | "new role"                     |
-| permissions   | string                                   | bitwise value of the enabled/disabled permissions                    | @everyone permissions in guild |
-| color         | integer                                  | RGB color value                                                      | 0                              |
-| hoist         | boolean                                  | whether the role should be displayed separately in the sidebar       | false                          |
-| icon          | [image data](#DOCS_REFERENCE/image-data) | the role's icon image (if the guild has the `ROLE_ICONS` feature)    | null                           |
-| unicode_emoji | string                                   | the role's unicode emoji (if the guild has the `ROLE_ICONS` feature) | null                           |
-| mentionable   | boolean                                  | whether the role should be mentionable                               | false                          |
+| Field         | Type                                     | Description                                                            | Default                        |
+| ------------- | ---------------------------------------- | ---------------------------------------------------------------------- | ------------------------------ |
+| name          | string                                   | name of the role                                                       | "new role"                     |
+| permissions   | string                                   | bitwise value of the enabled/disabled permissions                      | @everyone permissions in guild |
+| color         | integer                                  | RGB color value                                                        | 0                              |
+| hoist         | boolean                                  | whether the role should be displayed separately in the sidebar         | false                          |
+| icon          | [image data](#DOCS_REFERENCE/image-data) | the role's icon image (if the guild has the `ROLE_ICONS` feature)      | null                           |
+| unicode_emoji | string                                   | the role's unicode emoji\* (if the guild has the `ROLE_ICONS` feature) | null                           |
+| mentionable   | boolean                                  | whether the role should be mentionable                                 | false                          |
+
+\* You need to send the unicode emoji name without colons.
 
 ## Modify Guild Role Positions % PATCH /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/roles
 
@@ -908,15 +910,17 @@ Modify a guild role. Requires the `MANAGE_ROLES` permission. Returns the updated
 
 ###### JSON Params
 
-| Field         | Type                                     | Description                                                          |
-| ------------- | ---------------------------------------- | -------------------------------------------------------------------- |
-| name          | string                                   | name of the role                                                     |
-| permissions   | string                                   | bitwise value of the enabled/disabled permissions                    |
-| color         | integer                                  | RGB color value                                                      |
-| hoist         | boolean                                  | whether the role should be displayed separately in the sidebar       |
-| icon          | [image data](#DOCS_REFERENCE/image-data) | the role's icon image (if the guild has the `ROLE_ICONS` feature)    |
-| unicode_emoji | string                                   | the role's unicode emoji (if the guild has the `ROLE_ICONS` feature) |
-| mentionable   | boolean                                  | whether the role should be mentionable                               |
+| Field         | Type                                     | Description                                                            |
+| ------------- | ---------------------------------------- | ---------------------------------------------------------------------- |
+| name          | string                                   | name of the role                                                       |
+| permissions   | string                                   | bitwise value of the enabled/disabled permissions                      |
+| color         | integer                                  | RGB color value                                                        |
+| hoist         | boolean                                  | whether the role should be displayed separately in the sidebar         |
+| icon          | [image data](#DOCS_REFERENCE/image-data) | the role's icon image (if the guild has the `ROLE_ICONS` feature)      |
+| unicode_emoji | string                                   | the role's unicode emoji\* (if the guild has the `ROLE_ICONS` feature) |
+| mentionable   | boolean                                  | whether the role should be mentionable                                 |
+
+\* You need to send the unicode emoji name without colons.
 
 ## Delete Guild Role % DELETE /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/roles/{role.id#DOCS_TOPICS_PERMISSIONS/role-object}
 

--- a/docs/topics/Permissions.md
+++ b/docs/topics/Permissions.md
@@ -177,19 +177,19 @@ Roles represent a set of permissions attached to a group of users. Roles have un
 
 ###### Role Structure
 
-| Field         | Type                                                                         | Description                                       |
-| ------------- | ---------------------------------------------------------------------------- | ------------------------------------------------- |
-| id            | snowflake                                                                    | role id                                           |
-| name          | string                                                                       | role name                                         |
-| color         | integer                                                                      | integer representation of hexadecimal color code  |
-| hoist         | boolean                                                                      | if this role is pinned in the user listing        |
-| icon          | ?string                                                                      | role [icon hash](#DOCS_REFERENCE/image-formatting)|
-| unicode_emoji | ?string                                                                      | role unicode emoji name without colons            |
-| position      | integer                                                                      | position of this role                             |
-| permissions   | string                                                                       | permission bit set                                |
-| managed       | boolean                                                                      | whether this role is managed by an integration    |
-| mentionable   | boolean                                                                      | whether this role is mentionable                  |
-| tags?         | [role tags](#DOCS_TOPICS_PERMISSIONS/role-object-role-tags-structure) object | the tags this role has                            |
+| Field         | Type                                                                         | Description                                        |
+| ------------- | ---------------------------------------------------------------------------- | -------------------------------------------------- |
+| id            | snowflake                                                                    | role id                                            |
+| name          | string                                                                       | role name                                          |
+| color         | integer                                                                      | integer representation of hexadecimal color code   |
+| hoist         | boolean                                                                      | if this role is pinned in the user listing         |
+| icon          | ?string                                                                      | role [icon hash](#DOCS_REFERENCE/image-formatting) |
+| unicode_emoji | ?string                                                                      | role unicode emoji name                            |
+| position      | integer                                                                      | position of this role                              |
+| permissions   | string                                                                       | permission bit set                                 |
+| managed       | boolean                                                                      | whether this role is managed by an integration     |
+| mentionable   | boolean                                                                      | whether this role is mentionable                   |
+| tags?         | [role tags](#DOCS_TOPICS_PERMISSIONS/role-object-role-tags-structure) object | the tags this role has                             |
 
 Roles without colors (`color == 0`) do not count towards the final computed color in the user list.
 

--- a/docs/topics/Permissions.md
+++ b/docs/topics/Permissions.md
@@ -184,7 +184,7 @@ Roles represent a set of permissions attached to a group of users. Roles have un
 | color         | integer                                                                      | integer representation of hexadecimal color code  |
 | hoist         | boolean                                                                      | if this role is pinned in the user listing        |
 | icon          | ?string                                                                      | role [icon hash](#DOCS_REFERENCE/image-formatting)|
-| unicode_emoji | ?string                                                                      | role unicode emoji                                |
+| unicode_emoji | ?string                                                                      | role unicode emoji name without colons            |
 | position      | integer                                                                      | position of this role                             |
 | permissions   | string                                                                       | permission bit set                                |
 | managed       | boolean                                                                      | whether this role is managed by an integration    |

--- a/docs/topics/Permissions.md
+++ b/docs/topics/Permissions.md
@@ -217,3 +217,19 @@ Roles without colors (`color == 0`) do not count towards the final computed colo
   "mentionable": false
 }
 ```
+###### Example Role with Unicode Emoji as icon
+
+```json
+{
+  "id": "41771983423143936",
+  "name": "WE DEM BOYZZ!!!!!!",
+  "color": 3447003,
+  "hoist": true,
+  "icon": null,
+  "unicode_emoji": "thinking",
+  "position": 1,
+  "permissions": "66321471",
+  "managed": false,
+  "mentionable": false
+}
+```


### PR DESCRIPTION
So, this is a followup to #3847 

Thing is, it seems like the API does not accept the unicode entity for role icons in the emoji name.

We have to send the discord assigned name of the unicode emoji.
I.e. `thinking` without colons.

Otherwise the API just resets the role icon.

Which brings me to the issue: #3879


API result:
![2021-09-28_02h55_36](https://user-images.githubusercontent.com/14029133/135007455-84fe634e-a51c-4397-892b-e12770744f4a.png)

API call with unicode entity (Note, that the roll previously had a unicode emoji, which I set with the Discord Canary Client:
![2021-09-28_03h10_47](https://user-images.githubusercontent.com/14029133/135007507-7c169a1e-1a75-440a-88e1-d49306bcab53.png)
![2021-09-28_03h10_54](https://user-images.githubusercontent.com/14029133/135007511-498789c8-ed81-4ec7-9fea-c2dd70adf89b.png)

API call with unicode name:
![2021-09-28_03h19_51](https://user-images.githubusercontent.com/14029133/135007536-e269aa2b-41ac-4b91-96f8-4840f039941f.png)
![2021-09-28_03h19_59](https://user-images.githubusercontent.com/14029133/135007538-1ead1e39-ddb1-429e-9f39-8a249026810d.png)


