### PR TITLE
Document Guild#ModifyCurrentMember supports X-Audit-Log-Reason Header

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -785,6 +785,9 @@ Modify attributes of a [guild member](#DOCS_RESOURCES_GUILD/guild-member-object)
 
 Modifies the current member in a guild. Returns a 200 with the updated member object on success. Fires a [Guild Member Update](#DOCS_TOPICS_GATEWAY/guild-member-update) Gateway event.
 
+> info
+> This endpoint supports the `X-Audit-Log-Reason` header.
+
 ###### JSON Params
 
 | Field | Type    | Description                    | Permission      |


### PR DESCRIPTION
Sending a `PATCH` request to this endpoint with the `X-Audit-Log-Reason` header generates an audit log entry.