### PR TITLE
Add max scheduled events error

### DIFF
--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -174,6 +174,7 @@ Along with the HTTP error code, our API can also return more detailed error code
 | 30033  | Max number of thread participants has been reached                                                                            |
 | 30035  | Maximum number of bans for non-guild members have been exceeded                                                               |
 | 30037  | Maximum number of bans fetches has been reached                                                                               |
+| 30038  | Maximum number of uncompleted guild scheduled events reached (100)                                                            |
 | 30039  | Maximum number of stickers reached                                                                                            |
 | 30040  | Maximum number of prune requests has been reached. Try again later                                                            |
 | 30042  | Maximum number of guild widget settings updates has been reached. Try again later                                             |


### PR DESCRIPTION
It seems the error occurs when trying to make the 100th event rather than event 101, seems like a bug or an oversight in the errors wording.