### PR TITLE
Add another valid slash command nesting example

### DIFF
--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -419,6 +419,8 @@ command
 
 ----
 
+VALID
+
 command
 |
 |__ subcommand-group
@@ -429,11 +431,21 @@ command
     |
     |__ subcommand
 
+----
+
+VALID
+
+command
+|
+|__ subcommand-group
+    |
+    |__ subcommand
+|
+|__ subcommand
 
 -------
 
 INVALID
-
 
 command
 |


### PR DESCRIPTION
I've seen a lot of confusion as to whether a command can have subcommands as well as subcommand groups, so this change adds an example to clarify that you can.

It also improves consistency in that block.