### PR TITLE
Document exact number of max thread members

### DIFF
--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -171,7 +171,7 @@ Along with the HTTP error code, our API can also return more detailed error code
 | 30019  | Maximum number of server members reached                                                                                      |
 | 30030  | Maximum number of server categories has been reached (5)                                                                      |
 | 30031  | Guild already has a template                                                                                                  |
-| 30033  | Max number of thread participants has been reached                                                                            |
+| 30033  | Max number of thread participants has been reached (1000)                                                                     |
 | 30035  | Maximum number of bans for non-guild members have been exceeded                                                               |
 | 30037  | Maximum number of bans fetches has been reached                                                                               |
 | 30039  | Maximum number of stickers reached                                                                                            |


### PR DESCRIPTION
Currently the documented error message doesn't contain the number of max thread members, but the API returns the message `Max number of thread participants has been reached (1000)` which does contain the max number of thread members, hence I'm making this PR. 