### PR TITLE
Add SnowTransfer and CloudStorm to Community Libs

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -57,6 +57,8 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [discordeno](https://github.com/discordeno/discordeno)       | TypeScript |
 | [droff](https://github.com/tim-smart/droff)                  | TypeScript |
 | [Harmony](https://github.com/harmonyland/harmony)            | TypeScript |
+| [SnowTransfer](https://github.com/DasWolke/SnowTransfer)     | TypeScript |
+| [CloudStorm](https://github.com/DasWolke/CloudStorm)         | TypeScript |
 
 ## Interactions
 


### PR DESCRIPTION
These are libraries which cover different portions of the Discord API. SnowTransfer covers REST and CloudStorm covers gateway. These are older libs from V6 I now maintain with the consent of the owner. These libs now support support V9 and cover most or all of their respective field with respects to rate limits and allow for proxying requests to centralize rate limits.

I have not seen other modular libs on the community resources tab and was unsure if it was for a reason or just coincidental, but I believe more should be because making worker services to cover different tasks is cool and resource efficient!