### PR TITLE
Add note for choice value type

### DIFF
--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -66,10 +66,12 @@ Application commands are commands that an application can register to Discord. T
 
 If you specify `choices` for an option, they are the **only** valid values for a user to pick
 
-| Field | Type                       | Description                                         |
-| ----- | -------------------------- |---------------------------------------------------- |
-| name  | string                     | 1-100 character choice name                         |
-| value | string, integer, or double | value of the choice, up to 100 characters if string |
+| Field | Type                          | Description                                         |
+| ----- | ----------------------------- |---------------------------------------------------- |
+| name  | string                        | 1-100 character choice name                         |
+| value | string, integer, or double \* | value of the choice, up to 100 characters if string |
+
+\* Type of `value` depends on the [option type](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-object-application-command-option-type) of option that the choice belongs to.
 
 ###### Application Command Interaction Data Option Structure
 

--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -67,7 +67,7 @@ Application commands are commands that an application can register to Discord. T
 If you specify `choices` for an option, they are the **only** valid values for a user to pick
 
 | Field | Type                          | Description                                         |
-| ----- | ----------------------------- |---------------------------------------------------- |
+| ----- | ----------------------------- | --------------------------------------------------- |
 | name  | string                        | 1-100 character choice name                         |
 | value | string, integer, or double \* | value of the choice, up to 100 characters if string |
 

--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -71,7 +71,7 @@ If you specify `choices` for an option, they are the **only** valid values for a
 | name  | string                        | 1-100 character choice name                         |
 | value | string, integer, or double \* | value of the choice, up to 100 characters if string |
 
-\* Type of `value` depends on the [option type](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-object-application-command-option-type) of option that the choice belongs to.
+\* Type of `value` depends on the [option type](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-object-application-command-option-type) that the choice belongs to.
 
 ###### Application Command Interaction Data Option Structure
 


### PR DESCRIPTION
The choice value's type caused some confusion as it depends on the type of option the choice belongs to. This pull requests adds a note that references that. 

https://canary.discord.com/channels/613425648685547541/788586647142793246/883791945426677790
#3900 