### PR TITLE
Suppress member join sticker replies system channel flag.

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -117,11 +117,12 @@ Guilds in Discord represent an isolated collection of users and channels, and ar
 
 ###### System Channel Flags
 
-| Flag                                  | Value  | Description                         |
-| ------------------------------------- | ------ | ----------------------------------- |
-| SUPPRESS_JOIN_NOTIFICATIONS           | 1 << 0 | Suppress member join notifications  |
-| SUPPRESS_PREMIUM_SUBSCRIPTIONS        | 1 << 1 | Suppress server boost notifications |
-| SUPPRESS_GUILD_REMINDER_NOTIFICATIONS | 1 << 2 | Suppress server setup tips          |
+| Flag                                  | Value  | Description                          |
+| ------------------------------------- | ------ | ------------------------------------ |
+| SUPPRESS_JOIN_NOTIFICATIONS           | 1 << 0 | Suppress member join notifications   |
+| SUPPRESS_PREMIUM_SUBSCRIPTIONS        | 1 << 1 | Suppress server boost notifications  |
+| SUPPRESS_GUILD_REMINDER_NOTIFICATIONS | 1 << 2 | Suppress server setup tips           |
+| SUPPRESS_JOIN_NOTIFICATION_REPLIES    | 1 << 3 | Suppress member join sticker replies |
 
 ###### Guild Features
 

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -117,12 +117,12 @@ Guilds in Discord represent an isolated collection of users and channels, and ar
 
 ###### System Channel Flags
 
-| Flag                                  | Value  | Description                          |
-| ------------------------------------- | ------ | ------------------------------------ |
-| SUPPRESS_JOIN_NOTIFICATIONS           | 1 << 0 | Suppress member join notifications   |
-| SUPPRESS_PREMIUM_SUBSCRIPTIONS        | 1 << 1 | Suppress server boost notifications  |
-| SUPPRESS_GUILD_REMINDER_NOTIFICATIONS | 1 << 2 | Suppress server setup tips           |
-| SUPPRESS_JOIN_NOTIFICATION_REPLIES    | 1 << 3 | Suppress member join sticker replies |
+| Flag                                  | Value  | Description                            |
+| ------------------------------------- | ------ | -------------------------------------- |
+| SUPPRESS_JOIN_NOTIFICATIONS           | 1 << 0 | Suppress member join notifications     |
+| SUPPRESS_PREMIUM_SUBSCRIPTIONS        | 1 << 1 | Suppress server boost notifications    |
+| SUPPRESS_GUILD_REMINDER_NOTIFICATIONS | 1 << 2 | Suppress server setup tips             |
+| SUPPRESS_JOIN_NOTIFICATION_REPLIES    | 1 << 3 | Hide member join sticker reply buttons |
 
 ###### Guild Features
 


### PR DESCRIPTION
# Summary

This will, pending client rollouts that will happen soon™️, control whether or not users are able to see the "Wave to say hi" CTA. This will be editable in the server settings overview as well (pending the same client rollouts)

![image](https://user-images.githubusercontent.com/5456182/138171478-d174b3a4-af5e-478c-aa43-7d0b2e1a4cd1.png)

As a one-time migration, all (most :blobsweat:) servers with over 10000 members will have this suppress default true. This is to prevent disruption which we have encountered during the experiment phase of this feature.

During transition period of the client rollout, old clients may see the button, even if the toggle is off. Rest assured that they will still be _unable_ send the sticker.

I will keep this PR unmerged until the client changes have made it to beta on all mobile platforms _and_ canary on web/desktop. In the meantime this can also serve as a comment area for this field in case I messed up horribly and you folks find out.

Cheers!