### PR TITLE
Clarify that updating the message is optional when ACKing a component interaction

### DIFF
--- a/docs/interactions/Receiving_and_Responding.md
+++ b/docs/interactions/Receiving_and_Responding.md
@@ -159,14 +159,14 @@ There are a number of ways you can respond to an interaction:
 
 ###### Interaction Callback Type
 
-| Name                                    | Value | Description                                                                                                   |
-| --------------------------------------- | ----- | ------------------------------------------------------------------------------------------------------------- |
-| PONG                                    | 1     | ACK a `Ping`                                                                                                  |
-| CHANNEL_MESSAGE_WITH_SOURCE             | 4     | respond to an interaction with a message                                                                      |
-| DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE    | 5     | ACK an interaction and edit a response later, the user sees a loading state                                   |
-| DEFERRED_UPDATE_MESSAGE\*               | 6     | for components, ACK an interaction and edit the original message later; the user does not see a loading state |
-| UPDATE_MESSAGE\*                        | 7     | for components, edit the message the component was attached to                                                |
-| APPLICATION_COMMAND_AUTOCOMPLETE_RESULT | 8     | respond to an autocomplete interaction with suggested choices                                                 |
+| Name                                    | Value | Description                                                                                                              |
+| --------------------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------ |
+| PONG                                    | 1     | ACK a `Ping`                                                                                                             |
+| CHANNEL_MESSAGE_WITH_SOURCE             | 4     | respond to an interaction with a message                                                                                 |
+| DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE    | 5     | ACK an interaction and edit a response later, the user sees a loading state                                              |
+| DEFERRED_UPDATE_MESSAGE\*               | 6     | for components, ACK an interaction and optionally edit the original message later; the user does not see a loading state |
+| UPDATE_MESSAGE\*                        | 7     | for components, edit the message the component was attached to                                                           |
+| APPLICATION_COMMAND_AUTOCOMPLETE_RESULT | 8     | respond to an autocomplete interaction with suggested choices                                                            |
 
 \* Only valid for [component-based](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/) interactions
 


### PR DESCRIPTION
Unlike acknowledging a slash/context command with DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE which requires a message to be sent later, acknowledging an interaction (button presses etc.) with DEFERRED_UPDATE_MESSAGE does not require that the message is actually updated later.

The current wording is a bit ambiguous and resulted in some questions in the Discord Developer server; adding an "optionally" hopefully makes it clearer that a follow up is not required.