### PR TITLE
Getting own oauth application now returns flags

### DIFF
--- a/docs/topics/OAuth2.md
+++ b/docs/topics/OAuth2.md
@@ -375,7 +375,7 @@ Any user that wishes to add your webhook to their channel will need to go throug
 
 ## Get Current Bot Application Information % GET /oauth2/applications/@me
 
-Returns the bot's [application](#DOCS_RESOURCES_APPLICATION/application-object) object with `flags`.
+Returns the bot's [application](#DOCS_RESOURCES_APPLICATION/application-object) object.
 
 ## Get Current Authorization Information % GET /oauth2/@me
 

--- a/docs/topics/OAuth2.md
+++ b/docs/topics/OAuth2.md
@@ -375,7 +375,7 @@ Any user that wishes to add your webhook to their channel will need to go throug
 
 ## Get Current Bot Application Information % GET /oauth2/applications/@me
 
-Returns the bot's [application](#DOCS_RESOURCES_APPLICATION/application-object) object without `flags`.
+Returns the bot's [application](#DOCS_RESOURCES_APPLICATION/application-object) object with `flags`.
 
 ## Get Current Authorization Information % GET /oauth2/@me
 


### PR DESCRIPTION
Getting your own OAuth Application via the `GET /oauth2/applications/@me` route now returns the `flags` field for the application.