### PR TITLE
TweetNaCl to native crypto module

### DIFF
--- a/docs/interactions/Receiving_and_Responding.md
+++ b/docs/interactions/Receiving_and_Responding.md
@@ -281,7 +281,7 @@ const PUBLIC_KEY = 'APPLICATION_PUBLIC_KEY';
 
 const IMPORTED_PUBLIC_KEY=await crypto.webcrypto.subtle.importKey(
   "raw",
-  Buffer.from(process.env.PUBLIC_KEY, "hex"),
+  Buffer.from(PUBLIC_KEY, "hex"),
   { name: "NODE-ED25519", namedCurve: "NODE-ED25519", public: true },
   false,
   ["verify"]) 

--- a/docs/interactions/Receiving_and_Responding.md
+++ b/docs/interactions/Receiving_and_Responding.md
@@ -292,11 +292,11 @@ const body = req.rawBody; // rawBody is expected to be a string, not raw bytes
 
 
 const isVerified = await crypto.webcrypto.subtle.verify(
-            "NODE-ED25519",
-            IMPORTED_PUBLIC_KEY,
-            Buffer.from(signature, "hex"),
-            Buffer.from(timestamp + body)
-        );
+  "NODE-ED25519",
+  IMPORTED_PUBLIC_KEY,
+  Buffer.from(signature, "hex"),
+  Buffer.from(timestamp + body)
+);
 
 if (!isVerified) {
   return res.status(401).end('invalid request signature');


### PR DESCRIPTION
Rewrite example from third-party `tweetnacl` library to [native node.js crypto module](https://nodejs.org/api/crypto.html)