### PR TITLE
Add Pincer to list of libraries

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -47,6 +47,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [discord.py](https://github.com/Rapptz/discord.py)           | Python     |
 | [disco](https://github.com/b1naryth1ef/disco)                | Python     |
 | [hikari](https://github.com/hikari-py/hikari)                | Python     |
+| [Pincer](https://github.com/Pincer-org/Pincer)               | Python     |
 | [discordrb](https://github.com/shardlab/discordrb)           | Ruby       |
 | [discord-rs](https://github.com/SpaceManiac/discord-rs)      | Rust       |
 | [Serenity](https://github.com/serenity-rs/serenity)          | Rust       |


### PR DESCRIPTION
We would like to add Pincer.
It is a young library written in Python and we want to have it under "Discord Libraries" in "Community Resources".

https://github.com/Pincer-org/Pincer