### PR TITLE
Remove incorrect statement about slash command permissions

### DIFF
--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -277,7 +277,7 @@ Need to keep some of your commands safe from prying eyes, or only available to t
 > info
 > For now, if you don't have permission to use a command, they'll show up in the command picker as disabled and unusable. They will **not** be hidden.
 
-You can also set a `default_permission` on your commands if you want them to be disabled by default when your app is added to a new guild. Setting `default_permission` to `false` will disallow _anyone_ in a guild from using the command—except Administrators and guild owners—unless a specific overwrite is configured. It will also disable the command from being usable in DMs.
+You can also set a `default_permission` on your commands if you want them to be disabled by default when your app is added to a new guild. Setting `default_permission` to `false` will disallow _anyone_ in a guild from using the command, unless a specific overwrite is configured. It will also disable the command from being usable in DMs.
 
 For example, this command will not be usable by anyone in any guilds by default:
 


### PR DESCRIPTION
The changelog about `default_permissions` no longer affecting  guild owners/admins was reverted in [this commit](https://github.com/discord/discord-api-docs/commit/5e60ddae608b9ecefba4ea5126c175116c9282c9) because it'll be part of the upcoming permission rework. This PR removes a statement about the behavior that was reverted