### PR TITLE
Add breaking change to guild scheduled events and more details for guild scheduled events feature

### DIFF
--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -8,6 +8,7 @@
 - Add `with_user_count` query param for `GET /guilds/{guild.id}/scheduled-events/{guild_scheduled_event.id}`
 - Return additional `creator` field by default in response for `GET /guilds/{guild.id}/scheduled-events/{guild_scheduled_event.id}`
 - More details and clarification for the guild scheduled events feature.
+- Document support for `before` and `after` query params for `GET /guilds/{guild.id}/scheduled-events/{guild_scheduled_event.id}/users`
 
 #### Nov 15, 2021
 

--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## Guild Scheduled Events
+
+#### Nov 18, 2021
+
+- Breaking change for return type for `GET /guilds/{guild.id}/scheduled-events/{guild_scheduled_event.id}/users`
+- Add `with_user_count` query param for `GET /guilds/{guild.id}/scheduled-events/{guild_scheduled_event.id}`
+- Return additional `creator` field by default in response for `GET /guilds/{guild.id}/scheduled-events/{guild_scheduled_event.id}`
+- More details and clarification for the guild scheduled events feature.
+
+#### Nov 15, 2021
+
+Add new documentation for recently released Guild Scheduled Events feature.
+
 ## Application Command Autocomplete Interactions
 
 #### October 27, 2021

--- a/docs/resources/Guild_Scheduled_Event.md
+++ b/docs/resources/Guild_Scheduled_Event.md
@@ -11,7 +11,7 @@ A representation of a scheduled event in a [guild](#DOCS_RESOURCES_GUILD/).
 | id                    | snowflake                                                                                                                      | the id of the scheduled event                                                                       |
 | guild_id              | snowflake                                                                                                                      | the guild id which the scheduled event belongs to                                                   |
 | channel_id **         | ?snowflake                                                                                                                     | the channel id in which the scheduled event will be hosted, or `null` if [scheduled entity type](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-types) is `EXTERNAL` |
-| creator_id            | ?snowflake                                                                                                                     | the id of the user that created the scheduled event *                                               |
+| creator_id *           | ?snowflake                                                                                                                     | the id of the user that created the scheduled event *                                               |
 | name                  | string                                                                                                                         | the name of the scheduled event (1-100 characters)                                                  |
 | description?          | string                                                                                                                         | the description of the scheduled event (1-1000 characters)                                          |
 | scheduled_start_time  | ISO8601 timestamp                                                                                                              | the time the scheduled event will start                                                             |
@@ -24,8 +24,8 @@ A representation of a scheduled event in a [guild](#DOCS_RESOURCES_GUILD/).
 | creator?              | [user](#DOCS_RESOURCES_USER/user-object) object                                                                                | the user that created the scheduled event                                                           |
 | user_count?           | integer                                                                                                                        | the number of users subscribed to the scheduled event                                               |
 
-> note
-> `creator_id` will be null and `creator` will not be included for events created before October 25th, 2021, when the concept of `creator_id` was introduced and tracked.
+
+\* `creator_id` will be null and `creator` will not be included for events created before October 25th, 2021, when the concept of `creator_id` was introduced and tracked.
 
 \** See [field requirements by entity type](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-field-requirements-by-entity-type) to understand the relationship between `entity_type` and the following fields: `channel_id`, `entity_metadata`, and `scheduled_end_time` 
 
@@ -122,7 +122,7 @@ Create a guild scheduled event in the guild. Returns a [guild scheduled event](#
 
 | Field                | Type                                                                                                                        | Description                                                                                |
 | -------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| channel_id           | ?snowflake *                                                                                                                | the channel id of the scheduled event.                                                     |
+| channel_id? *        | snowflake *                                                                                                                 | the channel id of the scheduled event.                                                     |
 | entity_metadata?     | [entity metadata](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-metadata) | the entity metadata of the scheduled event                                                 |
 | name                 | string                                                                                                                      | the name of the scheduled event                                                            |
 | privacy_level        | [privacy level](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-privacy-level)     | the privacy level of the scheduled event                                                   |
@@ -131,7 +131,7 @@ Create a guild scheduled event in the guild. Returns a [guild scheduled event](#
 | description?         | string                                                                                                                      | the description of the scheduled event                                                     |
 | entity_type          | [entity type](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-types)        | the entity type of the scheduled event                                                     |
 
-\* [null](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-metadata) for events with `'entity_type': EXTERNAL` 
+\* Optional for events with `'entity_type': EXTERNAL`
 
 ## Get Guild Scheduled Event % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/scheduled-events/{guild_scheduled_event.id#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object}
 
@@ -151,26 +151,27 @@ Get a guild scheduled event. Returns a [guild scheduled event](#DOCS_RESOURCES_G
 Modify a guild scheduled event. Returns the modified [guild scheduled event](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object) object on success.
 
 > info
-> All parameters to this endpoint are optional
-
-> info
 > To start or end an event, use this endpoint to modify the event's [status](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-status) field.
 
 ###### JSON Params
 
 | Field                 | Type                                                                                                                        | Description                                                                                |
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| channel_id *          | snowflake                                                                                                                   | the channel id of the scheduled event, set to `null` if changing entity type to `EXTERNAL` |
-| entity_metadata       | [entity metadata](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-metadata) | the entity metadata of the scheduled event                                                 |
-| name                  | string                                                                                                                      | the name of the scheduled event                                                            |
-| privacy_level         | [privacy level](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-privacy-level)     | the privacy level of the scheduled event                                                   |
-| scheduled_start_time  | ISO8601 timestamp                                                                                                           | the time to schedule the scheduled event                                                   |
-| scheduled_end_time    | ISO8601 timestamp                                                                                                           | the time when the scheduled event is scheduled to end                                      |
-| description           | string                                                                                                                      | the description of the scheduled event                                                     |
-| entity_type *         | [event entity type](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-types)  | the entity type of the scheduled event                                                     |
-| status                | [event status](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-status)             | the status of the scheduled event                                                          |
+| channel_id? *         | ?snowflake                                                                                                                  | the channel id of the scheduled event, set to `null` if changing entity type to `EXTERNAL` |
+| entity_metadata?      | [entity metadata](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-metadata) | the entity metadata of the scheduled event                                                 |
+| name?                 | string                                                                                                                      | the name of the scheduled event                                                            |
+| privacy_level?        | [privacy level](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-privacy-level)     | the privacy level of the scheduled event                                                   |
+| scheduled_start_time? | ISO8601 timestamp                                                                                                           | the time to schedule the scheduled event                                                   |
+| scheduled_end_time? * | ISO8601 timestamp                                                                                                           | the time when the scheduled event is scheduled to end                                      |
+| description?          | string                                                                                                                      | the description of the scheduled event                                                     |
+| entity_type? *        | [event entity type](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-types)  | the entity type of the scheduled event                                                     |
+| status?               | [event status](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-status)             | the status of the scheduled event                                                          |
 
-\* If updating `entity_type` to `EXTERNAL`, `channel_id` [must be set to null](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-field-requirements-by-entity-type)
+\* If updating `entity_type` to `EXTERNAL`:
+
+- `channel_id` is required and [must be set to null](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-field-requirements-by-entity-type)
+- `entity_metadata` with a `location` field must be provided
+- `scheduled_end_time` must be provided
 
 ## Delete Guild Scheduled Event % DELETE /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/scheduled-events/{guild_scheduled_event.id#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object}
 
@@ -185,10 +186,14 @@ Get a list of guild scheduled event users subscribed to a guild scheduled event.
 
 ###### Query String Params
 
-| Field        | Type    | Description                                                                    | Default |
-| ------------ | ------- | ------------------------------------------------------------------------------ | ------- |
-| limit?       | number  | how many users to receive from the event                                       | 100     |
-| with_member? | boolean | include guild member data if it exists                                         | false   |
+| Field        | Type      | Description                                                                    | Default |
+| ------------ | -------   | ------------------------------------------------------------------------------ | ------- |
+| limit?       | number    | how many users to receive from the event                                       | 100     |
+| with_member? | boolean   | include guild member data if it exists                                         | false   |
+| before? *    | snowflake | consider only users before given user id                                       | null    |
+| after? *     | snowflake | consider only users after given user id                                        | null    |
+
+\* Provide a user id to `before` and `after` for pagination. Users will always be returned in ascending order by `user_id`. If both `before` and `after` are provided, only `before` is respected. Fetching users in-between `before` and `after` is not supported.
 
 
 ## Guild Scheduled Event Status Update Automation

--- a/docs/resources/Guild_Scheduled_Event.md
+++ b/docs/resources/Guild_Scheduled_Event.md
@@ -55,9 +55,9 @@ The following table shows field requirements based on current entity type.
 
 | Entity Type    | channel_id | entity_metadata | scheduled_end_time |
 | -------------- | ---------- | --------------- | ------------------ |
-| STAGE_INSTANCE |  non-null  |      null       |         -          |
-| VOICE          |  non-null  |      null       |         -          |
-| EXTERNAL       |    null    |    non-null *   |      non-null      |
+| STAGE_INSTANCE |    value   |      null       |         -          |
+| VOICE          |    value   |      null       |         -          |
+| EXTERNAL       |    null    |     value *     |       value        |
 
 \* `entity_metadata` with a non-null `location` must be provided
 

--- a/docs/resources/Guild_Scheduled_Event.md
+++ b/docs/resources/Guild_Scheduled_Event.md
@@ -24,7 +24,8 @@ A representation of a scheduled event in a [guild](#DOCS_RESOURCES_GUILD/).
 | creator?              | [user](#DOCS_RESOURCES_USER/user-object) object                                                                                | the user that created the scheduled event                                                           |
 | user_count?           | integer                                                                                                                        | the number of users subscribed to the scheduled event                                               |
 
-\* `creator_id` will be null and `creator` will not be included for events created before October 25th, 2021, when the concept of `creator_id` was introduced and tracked.
+> note
+> `creator_id` will be null and `creator` will not be included for events created before October 25th, 2021, when the concept of `creator_id` was introduced and tracked.
 
 \** See [field requirements by entity type](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-field-requirements-by-entity-type) to understand the relationship between `entity_type` and the following fields: `channel_id`, `entity_metadata`, and `scheduled_end_time` 
 
@@ -44,9 +45,9 @@ A representation of a scheduled event in a [guild](#DOCS_RESOURCES_GUILD/).
 
 ###### Field Requirements By Entity Type
 
-The following matrix describes field requirements based on current entity type.
+The following table shows field requirements based on current entity type.
 
-`non-null` : This field is required to be a non-null value
+`value` : This field is required to be a non-null value
 
 `null`     : This field is required to be null
 
@@ -139,7 +140,7 @@ Get a guild scheduled event. Returns a [guild scheduled event](#DOCS_RESOURCES_G
 ###### Query String Params
 
 > warn
-> The with_user_count query param was introduced on Thursday Nov 18, 2021 after the initial publication of this documentation to remain consitent with other guild scheduled events endpoints
+> The `with_user_count` query param was introduced on Thursday Nov 18, 2021 after the initial publication of this documentation to remain consitent with other guild scheduled events endpoints
 
 | Field            | Type    | Description                                      |
 | ---------------- | ------- | ------------------------------------------------ |

--- a/docs/resources/Guild_Scheduled_Event.md
+++ b/docs/resources/Guild_Scheduled_Event.md
@@ -6,54 +6,99 @@ A representation of a scheduled event in a [guild](#DOCS_RESOURCES_GUILD/).
 
 ###### Guild Scheduled Event Structure
 
-| Field                | Type                                                                                                                           | Description                                                                                         |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
-| id                   | snowflake                                                                                                                      | the id of the scheduled event                                                                       |
-| guild_id             | snowflake                                                                                                                      | the guild id which the scheduled event belongs to                                                   |
-| channel_id           | ?snowflake                                                                                                                     | the channel id in which the scheduled event will be hosted, or `null` if [scheduled entity type](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-types) is `EXTERNAL` |
-| creator_id?          | snowflake                                                                                                                      | the id of the user that created the scheduled event                                                 |
-| name                 | string                                                                                                                         | the name of the scheduled event (1-100 characters)                                                  |
-| description?         | string                                                                                                                         | the description of the scheduled event (1-1000 characters)                                          |
-| scheduled_start_time | ISO8601 timestamp                                                                                                              | the time the scheduled event will start                                                             |
-| scheduled_end_time   | ?ISO8601 timestamp                                                                                                             | the time the scheduled event will end, or `null` if the event does not have a scheduled time to end |
-| privacy_level        | [privacy level](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-privacy-level)        | the privacy level of the scheduled event                                                            |
-| status               | [event status](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-status)                | the status of the scheduled event                                                                   |
-| entity_type          | [scheduled entity type](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-types) | the type of hosting entity associated with a scheduled event, e.g. voice channel or stage channel   |
-| entity_id            | ?snowflake                                                                                                                     | any additional id of the hosting entity associated with event, e.g. [stage instance id](#DOCS_RESOURCES_STAGE_INSTANCE/stage-instance-object)) |
-| entity_metadata      | ?[entity metadata](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-metadata)   | the entity metadata for the scheduled event                                                         |
-| creator?             | [user](#DOCS_RESOURCES_USER/user-object) object                                                                                | the user that created the scheduled event                                                           |
-| user_count?          | integer                                                                                                                        | the number of users subscribed to the scheduled event                                               |
+| Field                 | Type                                                                                                                           | Description                                                                                         |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| id                    | snowflake                                                                                                                      | the id of the scheduled event                                                                       |
+| guild_id              | snowflake                                                                                                                      | the guild id which the scheduled event belongs to                                                   |
+| channel_id **         | ?snowflake                                                                                                                     | the channel id in which the scheduled event will be hosted, or `null` if [scheduled entity type](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-types) is `EXTERNAL` |
+| creator_id            | ?snowflake                                                                                                                     | the id of the user that created the scheduled event *                                               |
+| name                  | string                                                                                                                         | the name of the scheduled event (1-100 characters)                                                  |
+| description?          | string                                                                                                                         | the description of the scheduled event (1-1000 characters)                                          |
+| scheduled_start_time  | ISO8601 timestamp                                                                                                              | the time the scheduled event will start                                                             |
+| scheduled_end_time ** | ?ISO8601 timestamp                                                                                                             | the time the scheduled event will end, required if entity_type is `EXTERNAL`                        |
+| privacy_level         | [privacy level](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-privacy-level)        | the privacy level of the scheduled event                                                            |
+| status                | [event status](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-status)                | the status of the scheduled event                                                                   |
+| entity_type           | [scheduled entity type](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-types) | the type of the scheduled event                                                                     |
+| entity_id             | ?snowflake                                                                                                                     | the id of an entity associated with a guild scheduled event                                         |
+| entity_metadata **    | ?[entity metadata](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-metadata)   | additional metadata for the guild scheduled event                                                   |
+| creator?              | [user](#DOCS_RESOURCES_USER/user-object) object                                                                                | the user that created the scheduled event                                                           |
+| user_count?           | integer                                                                                                                        | the number of users subscribed to the scheduled event                                               |
+
+\* `creator_id` will be null and `creator` will not be included for events created before October 25th, 2021, when the concept of `creator_id` was introduced and tracked.
+
+\** See [field requirements by entity type](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-field-requirements-by-entity-type) to understand the relationship between `entity_type` and the following fields: `channel_id`, `entity_metadata`, and `scheduled_end_time` 
 
 ###### Guild Scheduled Event Privacy Level
 
 | Level      | Value | Description                                              |
 | ---------- | ----- | -------------------------------------------------------- |
-| PUBLIC     | 1     | the scheduled event is public and available in discovery |
 | GUILD_ONLY | 2     | the scheduled event is only accessible to guild members  |
 
 ###### Guild Scheduled Event Entity Types
 
 | Type           | Value |
 | -------------- | ----- |
-| NONE           | 0     |
 | STAGE_INSTANCE | 1     |
 | VOICE          | 2     |
 | EXTERNAL       | 3     |
 
+###### Field Requirements By Entity Type
+
+The following matrix describes field requirements based on current entity type.
+
+`non-null` : This field is required to be a non-null value
+
+`null`     : This field is required to be null
+
+`-`        : No strict requirements
+
+| Entity Type    | channel_id | entity_metadata | scheduled_end_time |
+| -------------- | ---------- | --------------- | ------------------ |
+| STAGE_INSTANCE |  non-null  |      null       |         -          |
+| VOICE          |  non-null  |      null       |         -          |
+| EXTERNAL       |    null    |    non-null *   |      non-null      |
+
+\* `entity_metadata` with a non-null `location` must be provided
+
+
 ###### Guild Scheduled Event Status
 
-| Type      | Value |
-| --------- | ----- |
-| SCHEDULED | 1     |
-| ACTIVE    | 2     |
-| COMPLETED | 3     |
-| CANCELED  | 4     |
+| Type        | Value |
+| ----------- | ----- |
+| SCHEDULED   | 1     |
+| ACTIVE      | 2     |
+| COMPLETED * | 3     |
+| CANCELED  * | 4     |
+
+\* Once `status` is set to `COMPLETED` or `CANCELED`, the `status` can no longer be updated
+
+###### Valid Guild Scheduled Event Status Transitions
+
+SCHEDULED --> ACTIVE
+
+ACTIVE --------> COMPLETED
+
+SCHEDULED --> CANCELED
+
 
 ###### Guild Scheduled Event Entity Metadata
 
-| Field        | Type                | Description                               |
-| ------------ | ------------------- | ----------------------------------------- |
-| location?    | string              | location of the event (1-100 characters)  |
+| Field        | Type                | Description                              |
+| ------------ | ------------------- | ---------------------------------------- |
+| location? *  | string              | location of the event (1-100 characters) |
+
+\* [required](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-metadata) for events with `'entity_type': EXTERNAL` 
+
+### Guild Scheduled Event User Object
+
+###### Guild Scheduled Event User Structure
+
+| Field                     | Type                                                         | Description                                                                                         |
+| --------------------      | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| guild_scheduled_event_id  | snowflake                                                    | the scheduled event id which the user subscribed to                                                 |
+| user                      | [user](#DOCS_RESOURCES_USER/user-object)                     | user which subscribed to an event                                                                   |
+| member?                   | [guild member](#DOCS_RESOURCES_GUILD/guild-member-object)    | guild member data for this user for the guild which this event belongs to, if any                   |
+
 
 ## List Scheduled Events for Guild % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/scheduled-events
 
@@ -74,20 +119,31 @@ Create a guild scheduled event in the guild. Returns a [guild scheduled event](#
 
 ###### JSON Params
 
-| Field                | Type                                                                                                                        | Description                                                                     |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| channel_id?          | snowflake                                                                                                                   | the channel id of the scheduled event, if for a stage instance of voice channel |
-| entity_metadata?     | [entity metadata](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-metadata) | the entity metadata of the scheduled event                                      |
-| name                 | string                                                                                                                      | the name of the scheduled event                                                 |
-| privacy_level        | [privacy level](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-privacy-level)     | the privacy level of the scheduled event                                        |
-| scheduled_start_time | ISO8601 timestamp                                                                                                           | the time to schedule the scheduled event                                        |
-| scheduled_end_time?  | ISO8601 timestamp                                                                                                           | the time when the scheduled event is scheduled to end                           |
-| description?         | string                                                                                                                      | the description of the scheduled event                                          |
-| entity_type          | [entity type](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-types)        | the entity type of the scheduled event                                          |
+| Field                | Type                                                                                                                        | Description                                                                                |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| channel_id           | ?snowflake *                                                                                                                | the channel id of the scheduled event.                                                     |
+| entity_metadata?     | [entity metadata](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-metadata) | the entity metadata of the scheduled event                                                 |
+| name                 | string                                                                                                                      | the name of the scheduled event                                                            |
+| privacy_level        | [privacy level](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-privacy-level)     | the privacy level of the scheduled event                                                   |
+| scheduled_start_time | ISO8601 timestamp                                                                                                           | the time to schedule the scheduled event                                                   |
+| scheduled_end_time?  | ISO8601 timestamp                                                                                                           | the time when the scheduled event is scheduled to end                                      |
+| description?         | string                                                                                                                      | the description of the scheduled event                                                     |
+| entity_type          | [entity type](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-types)        | the entity type of the scheduled event                                                     |
+
+\* [null](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-metadata) for events with `'entity_type': EXTERNAL` 
 
 ## Get Guild Scheduled Event % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/scheduled-events/{guild_scheduled_event.id#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object}
 
 Get a guild scheduled event. Returns a [guild scheduled event](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object) object on success.
+
+###### Query String Params
+
+> warn
+> The with_user_count query param was introduced on Thursday Nov 18, 2021 after the initial publication of this documentation to remain consitent with other guild scheduled events endpoints
+
+| Field            | Type    | Description                                      |
+| ---------------- | ------- | ------------------------------------------------ |
+| with_user_count? | boolean | include number of users subscribed to this event |
 
 ## Modify Guild Scheduled Event % PATCH /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/scheduled-events/{guild_scheduled_event.id#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object}
 
@@ -101,17 +157,19 @@ Modify a guild scheduled event. Returns the modified [guild scheduled event](#DO
 
 ###### JSON Params
 
-| Field                | Type                                                                                                                        | Description                                                                     |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| channel_id           | snowflake                                                                                                                   | the channel id of the scheduled event, required if [entity_type](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-types) is `STAGE_INSTANCE` or `VOICE`
-| entity_metadata      | [entity metadata](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-metadata) | the entity metadata of the scheduled event                                      |
-| name                 | string                                                                                                                      | the name of the scheduled event                                                 |
-| privacy_level        | [privacy level](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-privacy-level)     | the privacy level of the scheduled event                                        |
-| scheduled_start_time | ISO8601 timestamp                                                                                                           | the time to schedule the scheduled event                                        |
-| scheduled_end_time   | ISO8601 timestamp                                                                                                           | the time when the scheduled event is scheduled to end                           |
-| description          | string                                                                                                                      | the description of the scheduled event                                          |
-| entity_type          | [event entity type](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-types)  | the entity type of the scheduled event                                          |
-| status               | [event status](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-status)             | the status of the scheduled event                                               |
+| Field                 | Type                                                                                                                        | Description                                                                                |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| channel_id *          | snowflake                                                                                                                   | the channel id of the scheduled event, set to `null` if changing entity type to `EXTERNAL` |
+| entity_metadata       | [entity metadata](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-metadata) | the entity metadata of the scheduled event                                                 |
+| name                  | string                                                                                                                      | the name of the scheduled event                                                            |
+| privacy_level         | [privacy level](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-privacy-level)     | the privacy level of the scheduled event                                                   |
+| scheduled_start_time  | ISO8601 timestamp                                                                                                           | the time to schedule the scheduled event                                                   |
+| scheduled_end_time    | ISO8601 timestamp                                                                                                           | the time when the scheduled event is scheduled to end                                      |
+| description           | string                                                                                                                      | the description of the scheduled event                                                     |
+| entity_type *         | [event entity type](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-entity-types)  | the entity type of the scheduled event                                                     |
+| status                | [event status](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-guild-scheduled-event-status)             | the status of the scheduled event                                                          |
+
+\* If updating `entity_type` to `EXTERNAL`, `channel_id` [must be set to null](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object-field-requirements-by-entity-type)
 
 ## Delete Guild Scheduled Event % DELETE /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/scheduled-events/{guild_scheduled_event.id#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object}
 
@@ -119,17 +177,82 @@ Delete a guild scheduled event. Returns a `204` on success.
 
 ## Get Guild Scheduled Event Users % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/scheduled-events/{guild_scheduled_event.id#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object}/users
 
-Get a list of users RSVP'd to the guild scheduled event. Returns a list of [user](#DOCS_RESOURCES_USER/user-object) objects on success with an optional `guild_member` property for each user if `with_member` query parameter is passed in.
+> warn
+> A breaking change was introduced for this endpoint on Thursday Nov 18, 2021 after the initial publication of this documentation in which the return type was changed in response to developer feedback. We apologize for the inconvenience and additional work this creates for developers.
+
+Get a list of guild scheduled event users subscribed to a guild scheduled event. Returns a list of [guild scheduled event user](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-user-object) objects on success. Guild member data, if it exists, is included if the `with_member` query parameter is set.
 
 ###### Query String Params
 
 | Field        | Type    | Description                                                                    | Default |
 | ------------ | ------- | ------------------------------------------------------------------------------ | ------- |
 | limit?       | number  | how many users to receive from the event                                       | 100     |
-| with_member? | boolean | include guild member data. attaches `guild_member` property to the user object | false   |
+| with_member? | boolean | include guild member data if it exists                                         | false   |
 
-###### Response Structure
 
-| Field         | Type                                                                                                             |
-| ------------- | ---------------------------------------------------------------------------------------------------------------- |
-| users         | array of [user](#DOCS_RESOURCES_USER/user-object) objects with an optional `guild_member` property for each user |
+## Guild Scheduled Event Status Update Automation
+
+NOTE: `status` and `entity_type` here are expressed by name rather than their value for readability
+
+### An active scheduled event for a stage channel where all users have left the stage channel will automatically end a few minutes after the last user leaves the channel
+
+When an event with `'status': ACTIVE` and `'entity_type': STAGE_INSTANCE` has no users connected to the stage channel for a certain period of time (on the order of minutes), the event `status` will be automatically set to `COMPLETED`.
+
+### An active scheduled event for a voice channel where all users have left the voice channel will automatically end a few minutes after the last user leaves the channel
+
+When an event with `'status': ACTIVE` and `'entity_type': VOICE` has no users connected to the voice channel for a certain period of time (on the order of minutes), the event `status` will be automatically set to `COMPLETED`.
+
+### An external event will automatically begin at its scheduled start time
+
+An event with `'entity_type': EXTERNAL` at its `scheduled_start_time` will automatically have `status` set to `ACTIVE`.
+
+### An external event will automatically end at its scheduled end time
+
+An event with `'entity_type': EXTERNAL` at its `scheduled_end_time`  will automatically have `status` set to `COMPLETED`.
+
+### Any scheduled event which has not begun after its scheduled start time will be automatically cancelled after a few hours
+
+Any event with `'status': SCHEDULED` after a certain time interval (on the order of hours) beyond its `scheduled_start_time` will have its `status` automatically set to `CANCELLED`.
+
+## Guild Scheduled Event Permissions Requirements
+
+NOTE: `entity_type` is expressed by name rather than value for readability
+
+> info
+> A user must be a member of the guild and not banned from the guild. These two requirements must be met before other permissions are considered.
+
+### Permissions to create an event with entity_type: STAGE_INSTANCE
+
+#### Write Permissions (CREATE / UPDATE)
+
+- `MANAGE_EVENTS` at the guild level or at least `MANAGE_EVENTS` for the `channel_id` associated with the event
+- `MANAGE_CHANNELS`
+- `MUTE_MEMBERS`
+- `MOVE_MEMBERS`
+
+#### Read Permissions (GET)
+
+- `READ_MESSAGES` for `channel_id` associated with the event
+
+### Permissions to create an event with entity_type: VOICE
+
+#### Write Permissions (CREATE / UPDATE)
+
+- `MANAGE_EVENTS` at the guild level or `MANAGE_EVENTS` for the `channel_id` associated with the event
+- `READ_MESSAGES` for `channel_id` associated with event
+- `CONNECT` for `channel_id` associated with event
+
+#### Read Permissions (GET)
+
+- `READ_MESSAGES` for `channel_id` associated with the event
+
+
+### Permissions to create an event with entity_type: EXTERNAL
+
+#### Write Permissions (CREATE / UPDATE)
+
+- `MANAGE_EVENTS` at the guild level
+
+#### Read Permissions (GET)
+
+* *No other permissions required*


### PR DESCRIPTION
NOTE: Not final, open to comments for additional changes / clarifications

# Breaking change

The `GET /guilds/{guild.id}/scheduled-events/{guild_scheduled_event.id}/users` endpoint return type will be changed to use consistent models which already exist in the rest of our api.

The new return type will be an array of `GuildScheduledEventUser`:
```
[
    {
        "user":  User,
        "member": GuildMember,
        "guild_scheduled_event_id": snowflake
    },
    {
        "user":  User,
        "member": GuildMember,
        "guild_scheduled_event_id": snowflake
    },
]
```

Note: The `member` parameter will only be included if `with_member` query param is set.

# More detailed explanations
- Permissions scheme
- Field requirements for `entity_type`
- valid `status` update transitions
- status update automation