### PR TITLE
Document guild_scheduled_events field on audit log object

### DIFF
--- a/docs/resources/Audit_Log.md
+++ b/docs/resources/Audit_Log.md
@@ -8,13 +8,14 @@ Whenever an admin action is performed on the API, an entry is added to the respe
 
 ###### Audit Log Structure
 
-| Field             | Type                                                                                 | Description                              |
-| ----------------- | ------------------------------------------------------------------------------------ | ---------------------------------------- |
-| audit_log_entries | array of [audit log entry](#DOCS_RESOURCES_AUDIT_LOG/audit-log-entry-object) objects | list of audit log entries                |
-| integrations      | array of partial [integration](#DOCS_RESOURCES_GUILD/integration-object) objects     | list of partial integration objects      |
-| threads           | array of [channel](#DOCS_RESOURCES_CHANNEL/channel-object) objects                   | list of threads found in the audit log\* |
-| users             | array of [user](#DOCS_RESOURCES_USER/user-object) objects                            | list of users found in the audit log     |
-| webhooks          | array of [webhook](#DOCS_RESOURCES_WEBHOOK/webhook-object) objects                   | list of webhooks found in the audit log  |
+| Field                  | Type                                                                                                         | Description                                           |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
+| audit_log_entries      | array of [audit log entry](#DOCS_RESOURCES_AUDIT_LOG/audit-log-entry-object) objects                         | list of audit log entries                             |
+| guild_scheduled_events | array of [guild scheduled event](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object) objects | list of guild scheduled events found in the audit log |
+| integrations           | array of partial [integration](#DOCS_RESOURCES_GUILD/integration-object) objects                             | list of partial integration objects                   |
+| threads                | array of [channel](#DOCS_RESOURCES_CHANNEL/channel-object) objects                                           | list of threads found in the audit log\*              |
+| users                  | array of [user](#DOCS_RESOURCES_USER/user-object) objects                                                    | list of users found in the audit log                  |
+| webhooks               | array of [webhook](#DOCS_RESOURCES_WEBHOOK/webhook-object) objects                                           | list of webhooks found in the audit log               |
 
 \* Threads referenced in THREAD_CREATE and THREAD_UPDATE events are included in the threads map, since archived threads might not be kept in memory by clients.
 


### PR DESCRIPTION
Adds the missing `guild_scheduled_events` field to the audit log object.