### PR TITLE
Fix position of Remora.Discord in library list

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -17,9 +17,9 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | Name                                                         | Language   |
 | ------------------------------------------------------------ | ---------- |
 | [orca](https://github.com/cee-studio/orca)                   | C          |
-| [Remora.Discord](https://github.com/Nihlus/Remora.Discord)   | C#         |
 | [Discord.Net](https://github.com/RogueException/Discord.Net) | C#         |
 | [DSharpPlus](https://github.com/DSharpPlus/DSharpPlus)       | C#         |
+| [Remora.Discord](https://github.com/Nihlus/Remora.Discord)   | C#         |
 | [aegis.cpp](https://github.com/zeroxs/aegis.cpp)             | C++        |
 | [D++](https://github.com/brainboxdotcc/DPP)                  | C++        |
 | [Discord++](https://github.com/DiscordPP/discordpp)          | C++        |


### PR DESCRIPTION
the rest of the list is alphabetized within the language