### PR TITLE
correct 8MB to 8MiB in Message Limitations

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -887,7 +887,7 @@ Files must be attached using a `multipart/form-data` body as described in [Uploa
 - When sending a message with `tts` (text-to-speech) set to `true`, the current user must have the `SEND_TTS_MESSAGES` permission.
 - When creating a message as a reply to another message, the current user must have the `READ_MESSAGE_HISTORY` permission.
     - The referenced message must exist and cannot be a system message.
-- The maximum request size when sending a message is **8MB**
+- The maximum request size when sending a message is **8MiB**
 - For the embed object, you can set every field except `type` (it will be `rich` regardless of if you try to set it), `provider`, `video`, and any `height`, `width`, or `proxy_url` values for images.
 
 > info


### PR DESCRIPTION
The https://discord.com/developers/docs/reference#uploading-files section says the maximum request size is 8MiB as in Mebibytes, 8 * 1024 * 1024.