### PR TITLE
Document extra guild_id field on thread member update.

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -862,7 +862,14 @@ Sent when the current user _gains_ access to a channel.
 
 #### Thread Member Update
 
-Sent when the [thread member](#DOCS_RESOURCES_CHANNEL/thread-member-object) object for the current user is updated. The inner payload is a [thread member](#DOCS_RESOURCES_CHANNEL/thread-member-object) object. This event is documented for completeness, but unlikely to be used by most bots. For bots, this event largely is just a signal that you are a member of the thread. See the [threads docs](#DOCS_TOPICS_THREADS) for more details.
+Sent when the [thread member](#DOCS_RESOURCES_CHANNEL/thread-member-object) object for the current user is updated. The inner payload is a [thread member](#DOCS_RESOURCES_CHANNEL/thread-member-object) object with an extra `guild_id` field. This event is documented for completeness, but unlikely to be used by most bots. For bots, this event largely is just a signal that you are a member of the thread. See the [threads docs](#DOCS_TOPICS_THREADS) for more details.
+
+###### Thread Member Update Event Extra Fields
+
+| Field     | Type         | Description              |
+|-----------|--------------|--------------------------|
+| guild_id  | snowflake    | the id of the guild      |
+
 
 #### Thread Members Update
 


### PR DESCRIPTION
The `guild_id` "extra" field is sent in `THREAD_MEMBER_UPDATE` which wasn't documented. This PR documents it. 