### PR TITLE
Document `with_counts` for user guilds endpoint

### DIFF
--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -157,6 +157,9 @@ Returns a list of partial [guild](#DOCS_RESOURCES_GUILD/guild-object) objects th
 > info
 > This endpoint returns 200 guilds by default, which is the maximum number of guilds a non-bot user can join. Therefore, pagination is **not needed** for integrations that need to get a list of the users' guilds.
 
+> info
+> This endpoint supports the [with_counts](#DOCS_RESOURCES_GUILD/get-guild-query-string-params) query parameter.
+
 ###### Query String Params
 
 | Field  | Type      | Description                            | Required | Default |


### PR DESCRIPTION
`/users/@me/guilds` can not only be used by bots (I think the current notice about the OAuth2 scope is a bit misleading, but I don't want to touch that) but it interestingly also supports the `with_counts` query parameter just like `/guilds/:guild_id`.

That wasn't documented previously, but this PR adds a notice its support. 