### PR TITLE
Add application command option 11

### DIFF
--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -69,6 +69,7 @@ Application commands are commands that an application can register to Discord. T
 | ROLE              | 8     |                                         |
 | MENTIONABLE       | 9     | Includes users and roles                |
 | NUMBER            | 10    | Any double between -2^53 and 2^53       |
+| ATTACHMENT        | 11    |                                         |
 
 ###### Application Command Option Choice Structure
 

--- a/docs/interactions/Receiving_and_Responding.md
+++ b/docs/interactions/Receiving_and_Responding.md
@@ -66,6 +66,7 @@ For [Message Components](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/) it includes ide
 | roles?        | Map of Snowflakes to [role](#DOCS_TOPICS_PERMISSIONS/role-object) objects                | the ids and Role objects            |
 | channels?\*\* | Map of Snowflakes to [partial channel](#DOCS_RESOURCES_CHANNEL/channel-object) objects   | the ids and partial Channel objects |
 | messages?     | Map of Snowflakes to [partial messages](#DOCS_RESOURCES_CHANNEL/message-object) objects  | the ids and partial Message objects |
+| attachments?  | Map of Snowflakes to [attachment](#DOCS_RESOURCES_CHANNEL/attachment-object)             | the ids and Attachment objects      |
 
 \* Partial `Member` objects are missing `user`, `deaf` and `mute` fields
 


### PR DESCRIPTION
This pr properly adds the slash option 11 `attachment` 

**WIP, not released**

- [x] Add Application Command Option Type
- [x] Add Resolved Data Structure
- [ ] Add additional route for cdn (If existing)