### PR TITLE
Document X-Audit-Log-Reason on webhook endpoints.

### DIFF
--- a/docs/resources/Webhook.md
+++ b/docs/resources/Webhook.md
@@ -103,6 +103,9 @@ Create a new webhook. Requires the `MANAGE_WEBHOOKS` permission. Returns a [webh
 
 - Webhook names cannot be: 'clyde'
 
+> info
+> This endpoint supports `X-Audit-Log-Reason` header.
+
 ###### JSON Params
 
 | Field   | Type                                      | Description                           |
@@ -133,6 +136,9 @@ Modify a webhook. Requires the `MANAGE_WEBHOOKS` permission. Returns the updated
 > info
 > All parameters to this endpoint are optional
 
+> info
+> This endpoint supports `X-Audit-Log-Reason` header.
+
 ###### JSON Params
 
 | Field      | Type                                      | Description                                        |
@@ -148,6 +154,9 @@ Same as above, except this call does not require authentication, does not accept
 ## Delete Webhook % DELETE /webhooks/{webhook.id#DOCS_RESOURCES_WEBHOOK/webhook-object}
 
 Delete a webhook permanently. Requires the `MANAGE_WEBHOOKS` permission. Returns a `204 No Content` response on success.
+
+> info
+> This endpoint supports `X-Audit-Log-Reason` header.
 
 ## Delete Webhook with Token % DELETE /webhooks/{webhook.id#DOCS_RESOURCES_WEBHOOK/webhook-object}/{webhook.token#DOCS_RESOURCES_WEBHOOK/webhook-object}
 

--- a/docs/resources/Webhook.md
+++ b/docs/resources/Webhook.md
@@ -104,7 +104,7 @@ Create a new webhook. Requires the `MANAGE_WEBHOOKS` permission. Returns a [webh
 - Webhook names cannot be: 'clyde'
 
 > info
-> This endpoint supports `X-Audit-Log-Reason` header.
+> This endpoint supports the `X-Audit-Log-Reason` header.
 
 ###### JSON Params
 
@@ -137,7 +137,7 @@ Modify a webhook. Requires the `MANAGE_WEBHOOKS` permission. Returns the updated
 > All parameters to this endpoint are optional
 
 > info
-> This endpoint supports `X-Audit-Log-Reason` header.
+> This endpoint supports the `X-Audit-Log-Reason` header.
 
 ###### JSON Params
 
@@ -156,7 +156,7 @@ Same as above, except this call does not require authentication, does not accept
 Delete a webhook permanently. Requires the `MANAGE_WEBHOOKS` permission. Returns a `204 No Content` response on success.
 
 > info
-> This endpoint supports `X-Audit-Log-Reason` header.
+> This endpoint supports the `X-Audit-Log-Reason` header.
 
 ## Delete Webhook with Token % DELETE /webhooks/{webhook.id#DOCS_RESOURCES_WEBHOOK/webhook-object}/{webhook.token#DOCS_RESOURCES_WEBHOOK/webhook-object}
 


### PR DESCRIPTION
These webhook endpoints support `X-Audit-Log-Reason` header but wasn't documented.  This pull request documents them.