### PR TITLE
Add bio field to user documentation

### DIFF
--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -35,7 +35,7 @@ There are other rules and restrictions not shared here for the sake of spam and 
 | mfa_enabled?  | boolean   | whether the user has two factor enabled on their account                                             | identify              |
 | banner?       | ?string   | the user's [banner hash](#DOCS_REFERENCE/image-formatting)                                           | identify              |
 | accent_color? | ?integer  | the user's banner color encoded as an integer representation of hexadecimal color code               | identify              |
-| bio?          | string.   | the user's bio                                                                                       | identify              |
+| bio?          | string    | the user's bio                                                                                       | identify              |
 | locale?       | string    | the user's chosen language option                                                                    | identify              |
 | verified?     | boolean   | whether the email on this account has been verified                                                  | email                 |
 | email?        | ?string   | the user's email                                                                                     | email                 |

--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -35,6 +35,7 @@ There are other rules and restrictions not shared here for the sake of spam and 
 | mfa_enabled?  | boolean   | whether the user has two factor enabled on their account                                             | identify              |
 | banner?       | ?string   | the user's [banner hash](#DOCS_REFERENCE/image-formatting)                                           | identify              |
 | accent_color? | ?integer  | the user's banner color encoded as an integer representation of hexadecimal color code               | identify              |
+| bio?          | string.   | the user's bio
 | locale?       | string    | the user's chosen language option                                                                    | identify              |
 | verified?     | boolean   | whether the email on this account has been verified                                                  | email                 |
 | email?        | ?string   | the user's email                                                                                     | email                 |

--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -35,7 +35,7 @@ There are other rules and restrictions not shared here for the sake of spam and 
 | mfa_enabled?  | boolean   | whether the user has two factor enabled on their account                                             | identify              |
 | banner?       | ?string   | the user's [banner hash](#DOCS_REFERENCE/image-formatting)                                           | identify              |
 | accent_color? | ?integer  | the user's banner color encoded as an integer representation of hexadecimal color code               | identify              |
-| bio?          | string.   | the user's bio
+| bio?          | string.   | the user's bio                                                                                       | identify              |
 | locale?       | string    | the user's chosen language option                                                                    | identify              |
 | verified?     | boolean   | whether the email on this account has been verified                                                  | email                 |
 | email?        | ?string   | the user's email                                                                                     | email                 |


### PR DESCRIPTION
This PR adds documentation for the `bio` field, which is sent to bots on the `/users/@me` endpoint.