### PR TITLE
Document filename restrictions for attachment URLs

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -347,8 +347,7 @@ All `files[n]` parameters must include a valid `Content-Disposition` subpart hea
 
 The file upload limit applies to the entire request, not individual files in a request. This limit depends on the **Boost Tier** of a Guild and is 8 MiB by default.
 
-Images can also be referenced in embeds using the `attachment://filename` URL.
-The `filename` for these URLs must be ASCII alphanumeric with underscores and dots. An example payload is provided below.
+Images can also be referenced in embeds using the `attachment://filename` URL. The `filename` for these URLs must be ASCII alphanumeric with underscores, dashes, or dots. An example payload is provided below.
 
 ### Editing Message Attachments
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -347,7 +347,8 @@ All `files[n]` parameters must include a valid `Content-Disposition` subpart hea
 
 The file upload limit applies to the entire request, not individual files in a request. This limit depends on the **Boost Tier** of a Guild and is 8 MiB by default.
 
-Images can also be referenced in embeds using the `attachment://filename` URL. An example payload is provided below.
+Images can also be referenced in embeds using the `attachment://filename` URL.
+The `filename` for these URLs must be ASCII alphanumeric with underscores and dots. An example payload is provided below.
 
 ### Editing Message Attachments
 


### PR DESCRIPTION
It actually seems to be caused by the way discord sanitizes file names. When you upload a file named `hello (world).png`, it will be renamed to `hello_world.png`, which breaks the attachment link. Maybe this same rename strategy could also be performed on the link to make this compatible?

I don't think there is any good reason the attachment links would need to be restricted to a limited range of characters like this. The client actually sends the filenames unsanitized in the HTTP request.

Closes #2102