### PR TITLE
Add Nextcord to community resources' libraries

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -47,6 +47,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [discord.py](https://github.com/Rapptz/discord.py)           | Python     |
 | [disco](https://github.com/b1naryth1ef/disco)                | Python     |
 | [hikari](https://github.com/hikari-py/hikari)                | Python     |
+| [nextcord](https://github.com/nextcord/nextcord)             | Python     |
 | [discordrb](https://github.com/shardlab/discordrb)           | Ruby       |
 | [discord-rs](https://github.com/SpaceManiac/discord-rs)      | Rust       |
 | [Serenity](https://github.com/serenity-rs/serenity)          | Rust       |


### PR DESCRIPTION
Nextcord is a Python wrapper for the API, based on discord.py. As you all know, discord.py was archived, so features stopped being implemented there, so the things that distinct Nextcord from dpy are essentially the API changes since that point:

- Added slash command support
- Added user/message command support
- Support for timeouts and scheduled events

**Ratelimiting**
As this is based on discord.py the ratelimiting is still implemented well and correctly to avoid 429s where possible.

I'd like to clarify why I'm making this PR now: It's been quite a long time since dpy was archived now, and the API has gained quite a few features, as detailed above. Discord.py is a great library, and was - is - well-liked by users, but I believe it's also time to add more libs that implement newer API features so that users are recommended to use up-to-date libs. I've waited for the ecosystem to become more stable too, and I believe the current predominant libraries are likely to stick around now for the foreseeable future.