### PR TITLE
Improve autocomplete description

### DIFF
--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -854,10 +854,7 @@ When someone uses a message command, your application will receive an interactio
 
 Autocomplete interactions allow your application to dynamically return option suggestions to a user as they type.
 
-An autocomplete interaction **can return partial data** for option values. Your application will receive partial data for any existing user input, as long as that input passes client-side validation. For example, you may receive partial strings, but not invalid numbers. The option the user is currently typing will be sent with a `focused: true` boolean field.
-
-> warn
-> This validation is **client-side only**.
+An autocomplete interaction **can return partial data** for option values. Your application will receive partial data for any existing user input. For options with `focused: true`, the value will not be validated as the user is actively writing the inputs, which may also include empty strings and invalid numbers. All other options which fail server-side validation are omitted (empty strings may fall back to `0` for NUMBER and INTEGER options).
 
 ```json
 {

--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -854,7 +854,7 @@ When someone uses a message command, your application will receive an interactio
 
 Autocomplete interactions allow your application to dynamically return option suggestions to a user as they type.
 
-An autocomplete interaction **can return partial data** for option values. Your application will receive partial data for any existing user input. For options with `focused: true`, the value will not be validated as the user is actively writing the inputs, which may also include empty strings and invalid numbers. All other options which fail server-side validation are omitted (empty strings may fall back to `0` for NUMBER and INTEGER options).
+An autocomplete interaction **can return partial data** for option values. Your application will receive partial data for any existing user input. For options with `focused: true`, the value will not be validated as the user is actively writing the inputs, which may also include empty strings and invalid numbers. All other options are omitted if they fail server-side validation, even if they are set as `required: true`.
 
 ```json
 {

--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -856,7 +856,7 @@ Autocomplete interactions allow your application to dynamically return option su
 
 An autocomplete interaction **can return partial data** for option values. Your application will receive partial data for any existing user input. For options with `focused: true`, the value will not be validated as the user is actively writing the inputs, which may also include empty strings and invalid numbers. All other options are omitted if they fail server-side validation, even if they are set as `required: true`.
 
-To enable autocomplete for a command option, you must configure it with `autcomplete: true`. The only option types which currently support `autocomplete` are `STRING`, `INTEGER`, and `NUMBER`. Autocomplete options cannot configure `choices`, since they are provided by the interaction response instead.
+To enable autocomplete for a command option, you must configure it with `autocomplete: true`. The only option types which currently support `autocomplete` are `STRING`, `INTEGER`, and `NUMBER`. Autocomplete options cannot configure `choices`, since they are provided by the interaction response instead.
 
 While typing a command with autocomplete, the client will cache the responses for option values to avoid sending the same request twice.
 

--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -856,6 +856,12 @@ Autocomplete interactions allow your application to dynamically return option su
 
 An autocomplete interaction **can return partial data** for option values. Your application will receive partial data for any existing user input. For options with `focused: true`, the value will not be validated as the user is actively writing the inputs, which may also include empty strings and invalid numbers. All other options are omitted if they fail server-side validation, even if they are set as `required: true`.
 
+To enable autocomplete for a command option, you must configure it with `autcomplete: true`. The only option types which currently support `autocomplete` are `STRING`, `INTEGER`, and `NUMBER`. Autocomplete options cannot configure `choices`, since they are provided by the interaction response instead.
+
+While typing a command with autocomplete, the client will cache the responses for option values to avoid sending the same request twice.
+
+###### Example Autocomplete Interaction
+
 ```json
 {
   "type": 4,

--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -856,7 +856,7 @@ Autocomplete interactions allow your application to dynamically return option su
 
 An autocomplete interaction **can return partial data** for option values. Your application will receive partial data for any existing user input. For options with `focused: true`, the value will not be validated as the user is actively writing the inputs, which may also include empty strings and invalid numbers. All other options are omitted if they fail server-side validation, even if they are set as `required: true`.
 
-To enable autocomplete for a command option, you must configure it with `autocomplete: true`. The only option types which currently support `autocomplete` are `STRING`, `INTEGER`, and `NUMBER`. Autocomplete options cannot configure `choices`, since they are provided by the interaction response instead.
+To enable autocomplete for a command option, you must configure it with `autocomplete: true`. Option types which support `choices` also support `autocomplete`. Autocomplete options cannot configure `choices` at the same time, since they are provided by the interaction response instead.
 
 While typing a command with autocomplete, the client will cache the responses for option values to avoid sending the same request twice.
 


### PR DESCRIPTION
Addresses #4338

The falling back to 0 on required options seems to be a bug in the desktop client.