### PR TITLE
Document external asset URLs

### DIFF
--- a/docs/game_sdk/Activities.md
+++ b/docs/game_sdk/Activities.md
@@ -45,12 +45,12 @@ For more detailed information and documentation around the Rich Presence feature
 
 ###### ActivityAssets Struct
 
-| name       | type   | description                    |
-| ---------- | ------ | ------------------------------ |
-| LargeImage | string | keyname of an asset to display |
-| LargeText  | string | hover text for the large image |
-| SmallImage | string | keyname of an asset to display |
-| SmallText  | string | hover text for the small image |
+| name       | type   | description                                                                           |
+| ---------- | ------ | ------------------------------------------------------------------------------------- |
+| LargeImage | string | see [Activity Asset Image](#DOCS_TOPICS_GATEWAY/activity-object-activity-asset-image) |
+| LargeText  | string | hover text for the large image                                                        |
+| SmallImage | string | see [Activity Asset Image](#DOCS_TOPICS_GATEWAY/activity-object-activity-asset-image) |
+| SmallText  | string | hover text for the small image                                                        |
 
 ###### ActivityParty Struct
 
@@ -192,9 +192,9 @@ var activity = new Discord.Activity
   },
   Assets =
   {
-      LargeImage = "foo largeImageKey", // Larger Image Asset Key
+      LargeImage = "foo largeImageKey", // Larger Image Asset Value
       LargeText = "foo largeImageText", // Large Image Tooltip
-      SmallImage = "foo smallImageKey", // Small Image Asset Key
+      SmallImage = "foo smallImageKey", // Small Image Asset Value
       SmallText = "foo smallImageText", // Small Image Tooltip
   },
   Party =

--- a/docs/rich_presence/FAQ.md
+++ b/docs/rich_presence/FAQ.md
@@ -34,7 +34,7 @@ Currently, the SDK does not support this. Party slot information is determined b
 
 #### Q: Can I send images via the payload rather than uploading them to my Developer Dashboard?
 
-Unfortunately, the SDK does not support this feature right now. However, we hear your desires! We know that a lot of games, like customization-heavy RPGs, would benefit greatly from being able to programmatically upload assets. It may be something we tackle in the future.
+Yes! In addition to uploading an asset and specifying its name, you can also specify an external image URL for us to proxy. For more information, see [Activity Asset Image](#DOCS_TOPICS_GATEWAY/activity-object-activity-asset-image).
 
 #### Q: Can I change something in the SDK for my own purposes?
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -1376,6 +1376,8 @@ Active sessions are indicated with an "online", "idle", or "dnd" string per plat
 
 Activity asset images are arbitrary strings which usually contain snowflake IDs or prefixed image IDs. Treat data within this field carefully, as it is user-specifiable and not sanitized.
 
+To use an external image via media proxy, specify the URL as the field's value when sending. You will only receive the `mp:` prefix via the gateway.
+
 | Type              | Format                   | Image URL                                                                  |
 |-------------------|--------------------------|----------------------------------------------------------------------------|
 | Application Asset | `{application_asset_id}` | see [Application Asset Image Formatting](#DOCS_REFERENCE/image-formatting) |


### PR DESCRIPTION
From my understanding, external asset URLs (seemingly only for `large_image` and `small_image`) have been possible for the past month or so, yet have gone undocumented. This PR attempts to solve this!

Regarding the contents of this PR, should I keep the edit to the deprecated Rich Presence SDK? I did so as the RPC FAQ is still prominent on the sidebar listing, but I am not sure if this ideal.