### PR TITLE
Add Swiftcord to community resources

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -53,7 +53,8 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [Serenity](https://github.com/serenity-rs/serenity)          | Rust       |
 | [Twilight](https://github.com/twilight-rs/twilight)          | Rust       |
 | [AckCord](https://github.com/Katrix/AckCord)                 | Scala      |
-| [Sword](https://github.com/SketchMaster2001/Sword)           | Swift      |
+| [Swiftcord](https://github.com/SketchMaster2001/Swiftcord)   | Swift      |
+| [Sword](https://github.com/Azoy/Sword)                       | Swift      |
 | [Detritus](https://github.com/detritusjs/client)             | TypeScript |
 | [discordeno](https://github.com/discordeno/discordeno)       | TypeScript |
 | [droff](https://github.com/tim-smart/droff)                  | TypeScript |

--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -53,7 +53,7 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 | [Serenity](https://github.com/serenity-rs/serenity)          | Rust       |
 | [Twilight](https://github.com/twilight-rs/twilight)          | Rust       |
 | [AckCord](https://github.com/Katrix/AckCord)                 | Scala      |
-| [Sword](https://github.com/Azoy/Sword)                       | Swift      |
+| [Sword](https://github.com/SketchMaster2001/Sword)           | Swift      |
 | [Detritus](https://github.com/detritusjs/client)             | TypeScript |
 | [discordeno](https://github.com/discordeno/discordeno)       | TypeScript |
 | [droff](https://github.com/tim-smart/droff)                  | TypeScript |


### PR DESCRIPTION
The current version of Sword is using gateway version 6 and is archived. 

I have forked the repository and made it compatible with the v9 API. This includes Application Commands, Message Components, Stickers, Guild Scheduled Events and Timeouts.

The rate limit handler and bucket system were left untouched, which means it conforms to the standards you are looking for.