### PR TITLE
Clarify embed character limit

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -779,7 +779,7 @@ All of the following limits are measured inclusively. Leading and trailing white
 | [footer.text](#DOCS_RESOURCES_CHANNEL/embed-object-embed-footer-structure) | 2048 characters                                                                      |
 | [author.name](#DOCS_RESOURCES_CHANNEL/embed-object-embed-author-structure) | 256 characters                                                                       |
 
-Additionally, the characters in all `title`, `description`, `field.name`, `field.value`, `footer.text`, and `author.name` fields must not exceed 6000 characters in total. Violating any of these constraints will result in a `Bad Request` response.
+Additionally, the combined sum of characters in all `title`, `description`, `field.name`, `field.value`, `footer.text`, and `author.name` fields across all embeds attached to a message must not exceed 6000 characters. Violating any of these constraints will result in a `Bad Request` response.
 
 ## Get Channel % GET /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}
 


### PR DESCRIPTION
There has been quite a bit of confusion about the 6,000 character limit applying to *all* embeds instead of each individual one so this PR aims at rewording the documentation to make it more clear 