### PR TITLE
Add Discord.Net.Rest to the Interactions section in Community Resources

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -65,6 +65,8 @@ Many of these libraries are represented in the [unofficial, community-driven Dis
 
 [Interactions](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/) are the great, new way of making a Discord bot. The following open-source libraries provide help for the security and authentication checks that are mandatory if you are receiving Interactions via outgoing webhook. They also include some types for the Interactions data models.
 
+- C#
+  - [Discord.Net.Rest](https://github.com/discord-net/Discord.Net)
 - Clojure
   - [ring-discord-auth](https://github.com/JohnnyJayJay/ring-discord-auth)
 - Dart


### PR DESCRIPTION
## Summary
This PR adds the package Discord.Net.Rest to the Interactions section in the community resources

The rest package provides methods to both verify and deserialize webhook interactions.
Below is an example on using the webhook based interactions.
```cs
string publicKey = "YOUR_APPS_PUBLIC_KEY";
var signature = request.Headers["X-Signature-Ed25519"];
var timestamp = request.Headers["X-Signature-Timestamp"];
var body = await new StreamReader(request.InputStream).ReadToEndAsync();

try
{
   RestInteraction interaction = await client.Rest.ParseHttpInteractionAsync(publicKey, signature, timestamp, body);
   // your code here
}
catch(BadSignatureException)
{
    // return a 401
}
```

You can extend this with the [Discord.Net.Interactions framework](https://discordnet.dev/guides/int_framework/intro.html) allowing you to write module based handlers for interactions.

A full sample project using ASP.NET can be found [here](https://github.com/Cenngo/DiscordWebhookInteractions)