### PR TITLE
Document that interactions endpoints are not bound the Global Rate Limit

### DIFF
--- a/docs/interactions/Receiving_and_Responding.md
+++ b/docs/interactions/Receiving_and_Responding.md
@@ -321,7 +321,7 @@ We highly recommend checking out our [Community Resources](#DOCS_TOPICS_COMMUNIT
 ### Endpoints
 
 > info
-> The endpoints below are not bound to the application's [Global Rate Limit](#DOCS_TOPICS_RATE-LIMITS/global-rate-limit).
+> The endpoints below are not bound to the application's [Global Rate Limit](#DOCS_TOPICS_RATE_LIMITS/global-rate-limit).
 
 ## Create Interaction Response % POST /interactions/{interaction.id#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction}/{interaction.token#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-object}/callback
 

--- a/docs/interactions/Receiving_and_Responding.md
+++ b/docs/interactions/Receiving_and_Responding.md
@@ -320,6 +320,9 @@ We highly recommend checking out our [Community Resources](#DOCS_TOPICS_COMMUNIT
 
 ### Endpoints
 
+> info
+> The endpoints below are not bound to the application's [Global Rate Limit](#DOCS_TOPICS_RATE-LIMITS/global-rate-limit).
+
 ## Create Interaction Response % POST /interactions/{interaction.id#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction}/{interaction.token#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-object}/callback
 
 Create a response to an Interaction from the gateway. Takes an [interaction response](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-response-object).

--- a/docs/topics/Rate_Limits.md
+++ b/docs/topics/Rate_Limits.md
@@ -109,7 +109,7 @@ Global rate limit issues generally show up as repeatedly getting banned from the
 
 If you are experiencing repeated CloudFlare bans from the Discord API within normal operations of your bot, you can reach out to support to see if you qualify for increased global rate limits. You can contact Discord support using [https://dis.gd/contact](https://dis.gd/contact).
 
-[Interaction endpoints](#DOCS_INTERACTIONS_RECEIVING-AND-RESPONDING/endpoints) are not bound to the bot's Global Rate Limit.
+[Interaction endpoints](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/endpoints) are not bound to the bot's Global Rate Limit.
 
 ## Invalid Request Limit aka CloudFlare bans
 

--- a/docs/topics/Rate_Limits.md
+++ b/docs/topics/Rate_Limits.md
@@ -109,6 +109,8 @@ Global rate limit issues generally show up as repeatedly getting banned from the
 
 If you are experiencing repeated CloudFlare bans from the Discord API within normal operations of your bot, you can reach out to support to see if you qualify for increased global rate limits. You can contact Discord support using [https://dis.gd/contact](https://dis.gd/contact).
 
+[Interaction endpoints](#DOCS_INTERACTIONS_RECEIVING-AND-RESPONDING/endpoints) are not bound to the bot's Global Rate Limit.
+
 ## Invalid Request Limit aka CloudFlare bans
 
 IP addresses that make too many invalid HTTP requests are automatically and temporarily restricted from accessing the Discord API. Currently, this limit is **10,000 per 10 minutes**. An invalid request is one that results in **401**, **403**, or **429** statuses.	


### PR DESCRIPTION
I've searched the documentation and didn't find any clear answer to whether requests to [interaction endpoints](https://discord.com/developers/docs/interactions/receiving-and-responding#endpoints) should use the Global Rate Limit bucket shared with other endpoints or not. This is especially important for large bots considering that Discord can theoretically send you dozens of interactions per second.

According to the information I've gathered, the Global Rate Limit doesn't apply to these endpoints, hence this PR to make it clear.

_PS: This is only a guess right now. I would not rely on this until a dev merges or otherwise confirms the information in this PR._