### PR TITLE
Clarify the focused option might not be sent alone

### DIFF
--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -854,7 +854,7 @@ When someone uses a message command, your application will receive an interactio
 
 Autocomplete interactions allow your application to dynamically return option suggestions to a user as they type.
 
-An autocomplete interaction **can return partial data** for option values. Your application will receive partial data for any existing user input, as long as that input passes client-side validation. For example, you may receive partial strings, but not invalid numbers. The option the user is currently typing will be sent with a `focused: true` boolean field.
+An autocomplete interaction **can return partial data** for option values. Your application will receive partial data for any existing user input, as long as that input passes client-side validation. For example, you may receive partial strings, but not invalid numbers. The option the user is currently typing will be sent with a `focused: true` boolean field and options the user has already filled will also be sent but without the `focused` field. This is a special case where options that are otherwise required might not be present, due to the user not having filled them yet.
 
 > warn
 > This validation is **client-side only**.


### PR DESCRIPTION
This PR clarifies the autocomplete documentation to mention already-filled options being sent in autocomplete interactions, and that required options might not be present in this type of interaction since the user will not always have filled them *yet*

It also implies the usefulness of the `focused` field, which might otherwise seem useless if the focused option is always the only one being sent

This behavior was originally mentioned in [devsnek's notion](https://devsnek.notion.site/devsnek/Application-Command-Option-Autocomplete-Interactions-dacc980320c948768cec5ae3a96a5886) but didn't end up in the official documentation for some reason  