### PR TITLE
Add Text Input to Component Types table

### DIFF
--- a/docs/interactions/Message_Components.md
+++ b/docs/interactions/Message_Components.md
@@ -41,6 +41,7 @@ The top-level `components` field is an array of [Action Row](#DOCS_INTERACTIONS_
 | 1    | Action Row  | A container for other components       |
 | 2    | Button      | A button object                        |
 | 3    | Select Menu | A select menu for picking from choices |
+| 4    | Text Input  | A text input prompt for modals         |
 
 ###### Example Component
 

--- a/docs/interactions/Message_Components.md
+++ b/docs/interactions/Message_Components.md
@@ -41,7 +41,7 @@ The top-level `components` field is an array of [Action Row](#DOCS_INTERACTIONS_
 | 1    | Action Row  | A container for other components       |
 | 2    | Button      | A button object                        |
 | 3    | Select Menu | A select menu for picking from choices |
-| 4    | Text Input  | A text input prompt for modals         |
+| 4    | Text Input  | A text input object                    |
 
 ###### Example Component
 


### PR DESCRIPTION
This was probably accidentally left out in https://github.com/discord/discord-api-docs/pull/4459.