### PR TITLE
Mark .md files as linguist-detectable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,7 @@
 .git* text
 *.json text
 *.js text
-*.md text
+*.md text linguist-detectable
 *.{yml,yaml} text
 
 *.png binary


### PR DESCRIPTION
Since this repository primarily consists of Markdown files, it would be nice to have them show up in the language bar displayed by GitHub. This PR implements this:

![image](https://user-images.githubusercontent.com/30873659/153226587-6277eb53-f73e-44a0-b062-d769b46855ce.png)
