### PR TITLE
Deprecate Invite Stage Instance

### DIFF
--- a/docs/resources/Invite.md
+++ b/docs/resources/Invite.md
@@ -6,20 +6,20 @@ Represents a code that when used, adds a user to a guild or group DM channel.
 
 ###### Invite Structure
 
-| Field                       | Type                                                                                               | Description                                                                                                                       |
-| --------------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------|
-| code                        | string                                                                                             | the invite code (unique ID)                                                                                                         |
-| guild?                      | partial [guild](#DOCS_RESOURCES_GUILD/guild-object) object                                         | the guild this invite is for                                                                                                         |
-| channel                     | ?partial [channel](#DOCS_RESOURCES_CHANNEL/channel-object) object                                  | the channel this invite is for                                                                                                       |
-| inviter?                    | [user](#DOCS_RESOURCES_USER/user-object) object                                                    | the user who created the invite                                                                                                     |
-| target_type?                | integer                                                                                            | the [type of target](#DOCS_RESOURCES_INVITE/invite-object-invite-target-types) for this voice channel invite|
-| target_user?                | [user](#DOCS_RESOURCES_USER/user-object) object                                                    | the user whose stream to display for this voice channel stream invite                                                             |
-| target_application?         | partial [application](#DOCS_RESOURCES_APPLICATION/application-object) object                       | the embedded application to open for this voice channel embedded application invite                                               |
-| approximate_presence_count? | integer                                                                                            | approximate count of online members, returned from the `GET /invites/<code>` endpoint when `with_counts` is `true`           |
-| approximate_member_count?   | integer                                                                                            | approximate count of total members, returned from the `GET /invites/<code>` endpoint when `with_counts` is `true`                    |
-| expires_at?                 | ?ISO8601 timestamp                                                                                 | the expiration date of this invite, returned from the `GET /invites/<code>` endpoint when `with_expiration` is `true`                |
-| stage_instance?             | [invite stage instance](#DOCS_RESOURCES_INVITE/invite-stage-instance-object) object                | stage instance data if there is a [public Stage instance](#DOCS_RESOURCES_STAGE_INSTANCE) in the Stage channel this invite is for |
-| guild_scheduled_event?      | [guild scheduled event](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object) object | guild scheduled event data, only included if `guild_scheduled_event_id` contains a valid guild scheduled event id                    |
+| Field                       | Type                                                                                               | Description                                                                                                                                    |
+| --------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| code                        | string                                                                                             | the invite code (unique ID)                                                                                                                    |
+| guild?                      | partial [guild](#DOCS_RESOURCES_GUILD/guild-object) object                                         | the guild this invite is for                                                                                                                   |
+| channel                     | ?partial [channel](#DOCS_RESOURCES_CHANNEL/channel-object) object                                  | the channel this invite is for                                                                                                                 |
+| inviter?                    | [user](#DOCS_RESOURCES_USER/user-object) object                                                    | the user who created the invite                                                                                                                |
+| target_type?                | integer                                                                                            | the [type of target](#DOCS_RESOURCES_INVITE/invite-object-invite-target-types) for this voice channel invite                                   |
+| target_user?                | [user](#DOCS_RESOURCES_USER/user-object) object                                                    | the user whose stream to display for this voice channel stream invite                                                                          |
+| target_application?         | partial [application](#DOCS_RESOURCES_APPLICATION/application-object) object                       | the embedded application to open for this voice channel embedded application invite                                                            |
+| approximate_presence_count? | integer                                                                                            | approximate count of online members, returned from the `GET /invites/<code>` endpoint when `with_counts` is `true`                             |
+| approximate_member_count?   | integer                                                                                            | approximate count of total members, returned from the `GET /invites/<code>` endpoint when `with_counts` is `true`                              |
+| expires_at?                 | ?ISO8601 timestamp                                                                                 | the expiration date of this invite, returned from the `GET /invites/<code>` endpoint when `with_expiration` is `true`                          |
+| stage_instance?             | [invite stage instance](#DOCS_RESOURCES_INVITE/invite-stage-instance-object) object                | stage instance data if there is a [public Stage instance](#DOCS_RESOURCES_STAGE_INSTANCE) in the Stage channel this invite is for (deprecated) |
+| guild_scheduled_event?      | [guild scheduled event](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object) object | guild scheduled event data, only included if `guild_scheduled_event_id` contains a valid guild scheduled event id                              |
 
 ###### Invite Target Types
 
@@ -94,7 +94,7 @@ Extra information about an invite, will extend the [invite](#DOCS_RESOURCES_INVI
 }
 ```
 
-### Invite Stage Instance Object
+### Invite Stage Instance Object (deprecated)
 
 ###### Invite Stage Instance Structure
 

--- a/docs/resources/Invite.md
+++ b/docs/resources/Invite.md
@@ -94,7 +94,10 @@ Extra information about an invite, will extend the [invite](#DOCS_RESOURCES_INVI
 }
 ```
 
-### Invite Stage Instance Object (deprecated)
+### Invite Stage Instance Object
+
+> warn
+> This is deprecated.
 
 ###### Invite Stage Instance Structure
 


### PR DESCRIPTION
Public Stage Instances are deprecated (see [here](https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-privacy-level)) so it makes sense that the `stage_instance` field in invites (and its type) should also be deprecated.