### PR TITLE
Fix header merging with table

### DIFF
--- a/docs/resources/Audit_Log.md
+++ b/docs/resources/Audit_Log.md
@@ -111,6 +111,7 @@ Whenever an admin action is performed on the API, an entry is added to the respe
 | message_id         | snowflake | id of the message that was targeted                             | MESSAGE_PIN & MESSAGE_UNPIN                                                                                                        |
 | role_name          | string    | name of the role if type is "0" (not present if type is "1")    | CHANNEL_OVERWRITE_CREATE & CHANNEL_OVERWRITE_UPDATE & CHANNEL_OVERWRITE_DELETE                                                     |
 | type               | string    | type of overwritten entity - "0" for "role" or "1" for "member" | CHANNEL_OVERWRITE_CREATE & CHANNEL_OVERWRITE_UPDATE & CHANNEL_OVERWRITE_DELETE                                                     |
+
 ### Audit Log Change Object
 
 ###### Audit Log Change Structure


### PR DESCRIPTION
This is what it looks like on the website currently

![image](https://user-images.githubusercontent.com/68407783/154150224-f8b62ee0-3985-4fdb-8f3b-a782e570165a.png)

Link: https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-change-structure

This PR just adds another space so the markdown renderer sees them as 2 elements