### PR TITLE
Typo in name of guild application commands permissions endpoint

### DIFF
--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -989,7 +989,7 @@ Takes a list of application commands, overwriting the existing command list for 
 > danger
 > This will overwrite **all** types of application commands: slash commands, user commands, and message commands.
 
-## Get Guild Application Command Permissions % GET /applications/{application.id#DOCS_RESOURCES_APPLICATION/application-object}/guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/commands/permissions
+## Get Guild Application Commands Permissions % GET /applications/{application.id#DOCS_RESOURCES_APPLICATION/application-object}/guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/commands/permissions
 
 Fetches command permissions for all commands for your application in a guild. Returns an array of [guild application command permissions](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-permissions-object-guild-application-command-permissions-structure) objects.
 


### PR DESCRIPTION
This PR changes `Get Guild Application Command Permissions` to `Get Guild Application Commands Permissions`.