### PR TITLE
Fix type in Autocomplete section

### DIFF
--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -872,7 +872,7 @@ An autocomplete interaction **can return partial data** for option values. Your 
       {
         "type": 3,
         "name": "variant",
-        "value": "data a user is typ",
+        "value": "data a user is type",
         "focused": true
       }
     ]


### PR DESCRIPTION
Fixed typo here https://discord.com/developers/docs/interactions/application-commands#autocomplete
![](https://i.mrxbox98.me/2022/02/chrome_pAMFCNFYNm.png)