### PR TITLE
Update Select Menu placeholder max characters from 100 to 150

### DIFF
--- a/docs/interactions/Message_Components.md
+++ b/docs/interactions/Message_Components.md
@@ -266,7 +266,7 @@ Select menus support single-select and multi-select behavior, meaning you can pr
 | type         | integer                                                                                                     | `3` for a select menu                                                     |
 | custom_id    | string                                                                                                      | a developer-defined identifier for the button, max 100 characters         |
 | options      | array of [select options](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object-select-option-structure) | the choices in the select, max 25                                         |
-| placeholder? | string                                                                                                      | custom placeholder text if nothing is selected, max 100 characters        |
+| placeholder? | string                                                                                                      | custom placeholder text if nothing is selected, max 150 characters        |
 | min_values?  | integer                                                                                                     | the minimum number of items that must be chosen; default 1, min 0, max 25 |
 | max_values?  | integer                                                                                                     | the maximum number of items that can be chosen; default 1, max 25         |
 | disabled?    | boolean                                                                                                     | disable the select, default false                                         |


### PR DESCRIPTION
This updates the documented max character limit for Select Menu placeholders from 100 to 150, which is what the API actually enforces per the following response:

```
HTTPException: 400 Bad Request (error code: 50035): Invalid Form Body
In components.1.components.0.placeholder: Must be 150 or fewer in length.
```

I looked for other PRs and issues around this, but was unable to find anything. 

If this isn't intended and it's the API itself using the wrong limit, please feel free to close this.