### PR TITLE
Document `guild_scheduled_event_id` field in stage instances

### DIFF
--- a/docs/resources/Stage_Instance.md
+++ b/docs/resources/Stage_Instance.md
@@ -6,14 +6,15 @@ A _Stage Instance_ holds information about a live stage.
 
 ###### Stage Instance Structure
 
-| Field                 | Type      | Description                                                                                                   |
-| --------------------- | --------- | ------------------------------------------------------------------------------------------------------------- |
-| id                    | snowflake | The id of this Stage instance                                                                                 |
-| guild_id              | snowflake | The guild id of the associated Stage channel                                                                  |
-| channel_id            | snowflake | The id of the associated Stage channel                                                                        |
-| topic                 | string    | The topic of the Stage instance (1-120 characters)                                                            |
-| privacy_level         | integer   | The [privacy level](#DOCS_RESOURCES_STAGE_INSTANCE/stage-instance-object-privacy-level) of the Stage instance |
-| discoverable_disabled | boolean   | Whether or not Stage Discovery is disabled (deprecated)                                                       |
+| Field                    | Type       | Description                                                                                                   |
+| ------------------------ | ---------- | ------------------------------------------------------------------------------------------------------------- |
+| id                       | snowflake  | The id of this Stage instance                                                                                 |
+| guild_id                 | snowflake  | The guild id of the associated Stage channel                                                                  |
+| channel_id               | snowflake  | The id of the associated Stage channel                                                                        |
+| topic                    | string     | The topic of the Stage instance (1-120 characters)                                                            |
+| privacy_level            | integer    | The [privacy level](#DOCS_RESOURCES_STAGE_INSTANCE/stage-instance-object-privacy-level) of the Stage instance |
+| discoverable_disabled    | boolean    | Whether or not Stage Discovery is disabled (deprecated)                                                       |
+| guild_scheduled_event_id | ?snowflake | The id of the scheduled event for this Stage instance                                                         |
 
 ###### Privacy Level
 
@@ -31,7 +32,8 @@ A _Stage Instance_ holds information about a live stage.
   "channel_id": "733488538393510049",
   "topic": "Testing Testing, 123",
   "privacy_level": 1,
-  "discoverable_disabled": false
+  "discoverable_disabled": false,
+  "guild_scheduled_event_id": "947656305244532806"
 }
 ```
 


### PR DESCRIPTION
This field is available when the stage instance is from a guild scheduled event, otherwise, it will be `null`.