### PR TITLE
`name` field in activity object is optional

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -1326,7 +1326,7 @@ Active sessions are indicated with an "online", "idle", or "dnd" string per plat
 | flags?          | integer                                                                       | [activity flags](#DOCS_TOPICS_GATEWAY/activity-object-activity-flags) `OR`d together, describes what the payload includes |
 | buttons?        | array of [buttons](#DOCS_TOPICS_GATEWAY/activity-object-activity-buttons)     | the custom buttons shown in the Rich Presence (max 2)                                                                     |
 
-\* `name` will be missing if the activity is of type `4`.
+\* This field will be missing if the activity is of type `4`.
 
 > info
 > Bots are only able to send `name`, `type`, and optionally `url`.

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -1310,7 +1310,7 @@ Active sessions are indicated with an "online", "idle", or "dnd" string per plat
 
 | Field           | Type                                                                          | Description                                                                                                               |
 |-----------------|-------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| name?           | string                                                                        | the activity's name                                                                                                       |
+| name?\*         | string                                                                        | the activity's name                                                                                                       |
 | type            | integer                                                                       | [activity type](#DOCS_TOPICS_GATEWAY/activity-object-activity-types)                                                      |
 | url?            | ?string                                                                       | stream url, is validated when type is 1                                                                                   |
 | created_at      | integer                                                                       | unix timestamp (in milliseconds) of when the activity was added to the user's session                                     |
@@ -1325,6 +1325,8 @@ Active sessions are indicated with an "online", "idle", or "dnd" string per plat
 | instance?       | boolean                                                                       | whether or not the activity is an instanced game session                                                                  |
 | flags?          | integer                                                                       | [activity flags](#DOCS_TOPICS_GATEWAY/activity-object-activity-flags) `OR`d together, describes what the payload includes |
 | buttons?        | array of [buttons](#DOCS_TOPICS_GATEWAY/activity-object-activity-buttons)     | the custom buttons shown in the Rich Presence (max 2)                                                                     |
+
+\* `name` will be missing if the activity is of type `4`.
 
 > info
 > Bots are only able to send `name`, `type`, and optionally `url`.

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -1310,10 +1310,10 @@ Active sessions are indicated with an "online", "idle", or "dnd" string per plat
 
 | Field           | Type                                                                          | Description                                                                                                               |
 |-----------------|-------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| name            | string                                                                        | the activity's name                                                                                                       |
+| name?           | string                                                                        | the activity's name                                                                                                       |
 | type            | integer                                                                       | [activity type](#DOCS_TOPICS_GATEWAY/activity-object-activity-types)                                                      |
 | url?            | ?string                                                                       | stream url, is validated when type is 1                                                                                   |
-| created_at      | integer                                                                       | unix timestamp (in milliseconds) of when the activity was added to the user's session                                                       |
+| created_at      | integer                                                                       | unix timestamp (in milliseconds) of when the activity was added to the user's session                                     |
 | timestamps?     | [timestamps](#DOCS_TOPICS_GATEWAY/activity-object-activity-timestamps) object | unix timestamps for start and/or end of the game                                                                          |
 | application_id? | snowflake                                                                     | application id for the game                                                                                               |
 | details?        | ?string                                                                       | what the player is currently doing                                                                                        |


### PR DESCRIPTION
`name` field seems to be missing in custom activities.

~~Also, I found this fields in Spotify activities, but I don't know what they're for.~~

~~- `id`~~
~~- `session_id`~~
~~- `sync_id`~~