### PR TITLE
Clarify webhook naming restrictions

### DIFF
--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -15,8 +15,8 @@ Discord enforces the following restrictions for usernames and nicknames:
 
 The following restrictions are additionally enforced for usernames:
 
-1.  Names cannot contain the following substrings: '@', '#', ':', '\```'.
-2.  Names cannot be: 'discordtag', 'everyone', 'here'.
+1.  Usernames cannot contain the following substrings: '@', '#', ':', '\```', 'discord'
+2.  Usernames cannot be: 'everyone', 'here'
 
 There are other rules and restrictions not shared here for the sake of spam and abuse mitigation, but the majority of users won't encounter them. It's important to properly handle all error messages returned by Discord when editing or updating names.
 

--- a/docs/resources/Webhook.md
+++ b/docs/resources/Webhook.md
@@ -99,9 +99,11 @@ Used to represent a webhook.
 
 ## Create Webhook % POST /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/webhooks
 
-Create a new webhook. Requires the `MANAGE_WEBHOOKS` permission. Returns a [webhook](#DOCS_RESOURCES_WEBHOOK/webhook-object) object on success. Webhook names follow our naming restrictions that can be found in our [Usernames and Nicknames](#DOCS_RESOURCES_USER/usernames-and-nicknames) documentation, with the following additional stipulations:
+Creates a new webhook and returns a [webhook](#DOCS_RESOURCES_WEBHOOK/webhook-object) object on success. Requires the `MANAGE_WEBHOOKS` permission.
 
-- Webhook names cannot be: 'clyde'
+An error will be returned if a webhook name (`name`) is invalid. A name is valid if it:
+- Does not contain the substring "**clyde**" (case-insensitive)
+- Follows the restrictions for nicknames in the [Usernames and Nicknames](#DOCS_RESOURCES_USER/usernames-and-nicknames) documentation, with the exception that webhook names can be up to 80 characters in length
 
 > info
 > This endpoint supports the `X-Audit-Log-Reason` header.

--- a/docs/resources/Webhook.md
+++ b/docs/resources/Webhook.md
@@ -101,9 +101,9 @@ Used to represent a webhook.
 
 Creates a new webhook and returns a [webhook](#DOCS_RESOURCES_WEBHOOK/webhook-object) object on success. Requires the `MANAGE_WEBHOOKS` permission.
 
-An error will be returned if a webhook name (`name`) is invalid. A name is valid if it:
-- Does not contain the substring "**clyde**" (case-insensitive)
-- Follows the restrictions for nicknames in the [Usernames and Nicknames](#DOCS_RESOURCES_USER/usernames-and-nicknames) documentation, with the exception that webhook names can be up to 80 characters in length
+An error will be returned if a webhook name (`name`) is not valid. A webhook name is valid if:
+- It does not contain the substring "**clyde**" (case-insensitive)
+- It follows the nickname guidelines in the [Usernames and Nicknames](#DOCS_RESOURCES_USER/usernames-and-nicknames) documentation, with an exception that webhook names can be up to 80 characters
 
 > info
 > This endpoint supports the `X-Audit-Log-Reason` header.

--- a/docs/resources/Webhook.md
+++ b/docs/resources/Webhook.md
@@ -102,7 +102,7 @@ Used to represent a webhook.
 Creates a new webhook and returns a [webhook](#DOCS_RESOURCES_WEBHOOK/webhook-object) object on success. Requires the `MANAGE_WEBHOOKS` permission.
 
 An error will be returned if a webhook name (`name`) is not valid. A webhook name is valid if:
-- It does not contain the substring "**clyde**" (case-insensitive)
+- It does not contain the substring '**clyde**' (case-insensitive)
 - It follows the nickname guidelines in the [Usernames and Nicknames](#DOCS_RESOURCES_USER/usernames-and-nicknames) documentation, with an exception that webhook names can be up to 80 characters
 
 > info


### PR DESCRIPTION
- small clarifications around webhook `name` field
- cleans up copy ordering to match the other webhook methods
- updates username substring restrictions

Addresses #4293