### PR TITLE
Add warning around user permissions and user interactions commands

### DIFF
--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -684,6 +684,9 @@ And, done! The JSON looks a bit complicated, but what we've ended up with is a s
 
 User commands are application commands that appear on the context menu (right click or tap) of users. They're a great way to surface quick actions for your app that target users. They don't take any arguments, and will return the user on whom you clicked or tapped in the interaction response.
 
+> warn
+> A user must have permission to send text messages in the channel they invoke a user command in. If they don't have this permission, they will receive a 'Permission Denied' error from the interaction.
+
 > danger
 > The `description` field is not allowed when creating user commands. However, to avoid breaking changes to data models, `description` will be an **empty string** (instead of `null`) when fetching commands.
 


### PR DESCRIPTION
It is currently undocumented that a user must be able to "Send Messages" as well as "Use Application Commands" in order to invoke a user command. This comes as an additional complication because of the intersection of channel permissions and user permissions.  Attempts to invoke a user command in a channel which the user cannot speak in (e.g., a rules channel) will result in a permission denied error, as if the underlying application command provider had insufficient permissions.

This is compounded by no error (or, indeed, no request) ever being sent to the underlying application command provider over the WS connection.