### PR TITLE
Update locale table to better reflect in-app languages

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -468,9 +468,9 @@ For example:
 | bg     | Bulgarian             | български           |
 | ru     | Russian               | Pусский             |
 | uk     | Ukrainian             | Українська          |
-| hi     | Hindi                 | हिन्दी                 |
+| hi     | Hindi                 | हिन्दी              |
 | th     | Thai                  | ไทย                 |
-| zh-CN  | Chinese, China        | 中文                |
-| ja     | Japanese              | 日本語              |
-| zh-TW  | Chinese, Taiwan       | 繁體中文            |
-| ko     | Korean                | 한국어              |
+| zh-CN  | Chinese, China        | 中文                  |
+| ja     | Japanese              | 日本語                 |
+| zh-TW  | Chinese, Taiwan       | 繁體中文                |
+| ko     | Korean                | 한국어                 |

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -442,35 +442,35 @@ For example:
 
 ## Locales
 
-| Locale | Language Name           |
-| ------ | ----------------------- |
-| en-US  | English (United States) |
-| en-GB  | English (Great Britain) |
-| bg     | Bulgarian               |
-| zh-CN  | Chinese (China)         |
-| zh-TW  | Chinese (Taiwan)        |
-| hr     | Croatian                |
-| cs     | Czech                   |
-| da     | Danish                  |
-| nl     | Dutch                   |
-| fi     | Finnish                 |
-| fr     | French                  |
-| de     | German                  |
-| el     | Greek                   |
-| hi     | Hindi                   |
-| hu     | Hungarian               |
-| it     | Italian                 |
-| ja     | Japanese                |
-| ko     | Korean                  |
-| lt     | Lithuanian              |
-| no     | Norwegian               |
-| pl     | Polish                  |
-| pt-BR  | Portuguese (Brazil)     |
-| ro     | Romanian                |
-| ru     | Russian                 |
-| es-ES  | Spanish (Spain)         |
-| sv-SE  | Swedish                 |
-| th     | Thai                    |
-| tr     | Turkish                 |
-| uk     | Ukrainian               |
-| vi     | Vietnamese              |
+| Locale | Language Name         | Native Name         |
+| ------ | --------------------- | ------------------- |
+| da     | Danish                | Dansk               |
+| de     | German                | Deutsch             |
+| en-GB  | English, UK           | English, UK         |
+| en-US  | English, US           | English, US         |
+| es-ES  | Spanish               | Español             |
+| fr     | French                | Français            |
+| hr     | Croatian              | Hrvatski            |
+| it     | Italian               | Italiano            |
+| lt     | Lithuanian            | Lietuviškai         |
+| hu     | Hungarian             | Magyar              |
+| nl     | Dutch                 | Nederlands          |
+| no     | Norwegian             | Norsk               |
+| pl     | Polish                | Polski              |
+| pt-BR  | Portuguese, Brazilian | Português do Brasil |
+| ro     | Romanian, Romania     | Română              |
+| fi     | Finnish               | Suomi               |
+| sv-SE  | Swedish               | Svenska             |
+| vi     | Vietnamese            | Tiếng Việt          |
+| tr     | Turkish               | Türkçe              |
+| cs     | Czech                 | Čeština             |
+| el     | Greek                 | Ελληνικά            |
+| bg     | Bulgarian             | български           |
+| ru     | Russian               | Pусский             |
+| uk     | Ukrainian             | Українська          |
+| hi     | Hindi                 | हिन्दी                 |
+| th     | Thai                  | ไทย                 |
+| zh-CN  | Chinese, China        | 中文                |
+| ja     | Japanese              | 日本語              |
+| zh-TW  | Chinese, Taiwan       | 繁體中文            |
+| ko     | Korean                | 한국어              |


### PR DESCRIPTION
This PR:
- adds native name
- changes language name to reflect the in-app name (`English (Great Britain)` -> `English, UK`)
- changes order to reflect in-app ordering
