### PR TITLE
Fix description for HypeSquad flag

### DIFF
--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -67,7 +67,7 @@ There are other rules and restrictions not shared here for the sake of spam and 
 | 0       | None                     | None                                                                                                                                           |
 | 1 << 0  | STAFF                    | Discord Employee                                                                                                                               |
 | 1 << 1  | PARTNER                  | Partnered Server Owner                                                                                                                         |
-| 1 << 2  | HYPESQUAD                | HypeSquad Events                                                                                                                               |
+| 1 << 2  | HYPESQUAD                | HypeSquad Events Member                                                                                                                        |
 | 1 << 3  | BUG_HUNTER_LEVEL_1       | Bug Hunter Level 1                                                                                                                             |
 | 1 << 6  | HYPESQUAD_ONLINE_HOUSE_1 | House Bravery Member                                                                                                                           |
 | 1 << 7  | HYPESQUAD_ONLINE_HOUSE_2 | House Brilliance Member                                                                                                                        |

--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -67,7 +67,7 @@ There are other rules and restrictions not shared here for the sake of spam and 
 | 0       | None                     | None                                                                                                                                           |
 | 1 << 0  | STAFF                    | Discord Employee                                                                                                                               |
 | 1 << 1  | PARTNER                  | Partnered Server Owner                                                                                                                         |
-| 1 << 2  | HYPESQUAD                | HypeSquad Events Coordinator                                                                                                                   |
+| 1 << 2  | HYPESQUAD                | HypeSquad Events                                                                                                                               |
 | 1 << 3  | BUG_HUNTER_LEVEL_1       | Bug Hunter Level 1                                                                                                                             |
 | 1 << 6  | HYPESQUAD_ONLINE_HOUSE_1 | House Bravery Member                                                                                                                           |
 | 1 << 7  | HYPESQUAD_ONLINE_HOUSE_2 | House Brilliance Member                                                                                                                        |


### PR DESCRIPTION
Hi there,

I'm aware this is a very minor adjustment of #4036. However, there's a slight difference between a HypeSquad Event Coordinator and an Event Attendee:

- **Event Attendee** - "A world-traveler who attends events, local or abroad. You get an exclusive Discord HypeSquad shirt!"
- **Event Coordinator** - "A community leader who runs a school club, Convention or LAN event. These members get a box of swag once per quarter for an event."

Regardless, the `HYPESQUAD` flag is the same in both cases, meaning the suffix of "Coordinator" is slightly misleading. I hope you forgive me for this nitpick!

Thanks.