### PR TITLE
clarified choice localization

### DIFF
--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -79,13 +79,15 @@ Application commands are commands that an application can register to Discord. T
 
 If you specify `choices` for an option, they are the **only** valid values for a user to pick
 
-| Field               | Type                                                                  | Description                                                                                  |
-|---------------------|-----------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-| name                | string                                                                | 1-100 character choice name                                                                  |
-| name_localizations? | ?dictionary with keys in [available locales](#DOCS_REFERENCE/locales) | Localization dictionary for the `name` field. Values follow the same restrictions as `name`  |
-| value               | string, integer, or double \*                                         | value of the choice, up to 100 characters if string                                          |
+| Field                    | Type                                                                  | Description                                                                                  |
+|--------------------------|-----------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| name                     | string                                                                | 1-100 character choice name                                                                  |
+| name_localizations? \*\* | ?dictionary with keys in [available locales](#DOCS_REFERENCE/locales) | Localization dictionary for the `name` field. Values follow the same restrictions as `name`  |
+| value                    | string, integer, or double \*                                         | value of the choice, up to 100 characters if string                                          |
 
 \* Type of `value` depends on the [option type](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-object-application-command-option-type) that the choice belongs to.
+
+\*\* This field is ignored when responding to autocomplete interactions.
 
 ###### Application Command Interaction Data Option Structure
 


### PR DESCRIPTION
`name_localizations` for choices are ignored when responding to autocomplete interactions.