### PR TITLE
oauth2: clarify redirect_uri needs to be same as auth url

### DIFF
--- a/docs/topics/OAuth2.md
+++ b/docs/topics/OAuth2.md
@@ -87,7 +87,7 @@ https://nicememe.website/?code=NhhvTDYsFcdgNLnnLijcl7Ku7bEEeee&state=15773059ghq
 - `client_secret` - your application's client secret
 - `grant_type` - must be set to `authorization_code`
 - `code` - the code from the querystring
-- `redirect_uri` - your `redirect_uri`
+- `redirect_uri` - the `redirect_uri` from your authorization URL
 
 ###### Access Token Exchange Example
 

--- a/docs/topics/OAuth2.md
+++ b/docs/topics/OAuth2.md
@@ -87,7 +87,7 @@ https://nicememe.website/?code=NhhvTDYsFcdgNLnnLijcl7Ku7bEEeee&state=15773059ghq
 - `client_secret` - your application's client secret
 - `grant_type` - must be set to `authorization_code`
 - `code` - the code from the querystring
-- `redirect_uri` - the `redirect_uri` from your authorization URL
+- `redirect_uri` - the `redirect_uri` associated with this authorization, usually from your authorization URL
 
 ###### Access Token Exchange Example
 


### PR DESCRIPTION
This PR rewords the specification of `redirect_uri` at the code exchange in
the OAuth2 docs to clarify that it is shared between it and the authorization
URL.
