### PR TITLE
remove unneeded parts of the status code docs 

### DIFF
--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -152,7 +152,6 @@ Along with the HTTP error code, our API can also return more detailed error code
 | 10071  | Unknown Guild Scheduled Event User                                                                                            |
 | 10087  | Unknown Tag                                                                                                                   |
 | 20001  | Bots cannot use this endpoint                                                                                                 |
-| 20002  | Only bots can use this endpoint                                                                                               |
 | 20009  | Explicit content cannot be sent to the desired recipient(s)                                                                   |
 | 20012  | You are not authorized to perform this action on this application                                                             |
 | 20016  | This action cannot be performed due to slowmode rate limit                                                                    |
@@ -163,7 +162,6 @@ Along with the HTTP error code, our API can also return more detailed error code
 | 20031  | Your Stage topic, server name, server description, or channel names contain words that are not allowed                        |
 | 20035  | Guild premium subscription level too low                                                                                      |
 | 30001  | Maximum number of guilds reached (100)                                                                                        |
-| 30002  | Maximum number of friends reached (1000)                                                                                      |
 | 30003  | Maximum number of pins reached for the channel (50)                                                                           |
 | 30004  | Maximum number of recipients reached (10)                                                                                     |
 | 30005  | Maximum number of guild roles reached (250)                                                                                   |
@@ -213,7 +211,6 @@ Along with the HTTP error code, our API can also return more detailed error code
 | 50012  | Invalid OAuth2 state                                                                                                          |
 | 50013  | You lack permissions to perform that action                                                                                   |
 | 50014  | Invalid authentication token provided                                                                                         |
-| 50015  | Note was too long                                                                                                             |
 | 50016  | Provided too few or too many messages to delete. Must provide at least 2 and fewer than 100 messages to delete                |
 | 50019  | A message can only be pinned to the channel it was sent in                                                                    |
 | 50020  | Invite code was either invalid or taken                                                                                       |
@@ -223,17 +220,14 @@ Along with the HTTP error code, our API can also return more detailed error code
 | 50026  | Missing required OAuth2 scope                                                                                                 |
 | 50027  | Invalid webhook token provided                                                                                                |
 | 50028  | Invalid role                                                                                                                  |
-| 50033  | Invalid Recipient(s)                                                                                                          |
+| 50033  | Invalid recipient(s)                                                                                                          |
 | 50034  | A message provided was too old to bulk delete                                                                                 |
 | 50035  | Invalid form body (returned for both `application/json` and `multipart/form-data` bodies), or invalid `Content-Type` provided |
-| 50036  | An invite was accepted to a guild the application's bot is not in                                                             |
 | 50041  | Invalid API version provided                                                                                                  |
 | 50045  | File uploaded exceeds the maximum size                                                                                        |
 | 50046  | Invalid file uploaded                                                                                                         |
-| 50054  | Cannot self-redeem this gift                                                                                                  |
 | 50055  | Invalid Guild                                                                                                                 |
 | 50068  | Invalid message type                                                                                                          |
-| 50070  | Payment source required to redeem gift                                                                                        |
 | 50074  | Cannot delete a channel required for Community guilds                                                                         |
 | 50081  | Invalid sticker sent                                                                                                          |
 | 50083  | Tried to perform an operation on an archived thread, such as editing a message or adding a user to the thread                 |

--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -34,7 +34,7 @@ In order to prevent broken reconnect loops, you should consider some close codes
 | 4004 | Authentication failed | The account token sent with your [identify payload](#DOCS_TOPICS_GATEWAY/identify) is incorrect.                                                                                                                                 | false     |
 | 4005 | Already authenticated | You sent more than one identify payload. Don't do that!                                                                                                                                                                          | true      |
 | 4007 | Invalid `seq`         | The sequence sent when [resuming](#DOCS_TOPICS_GATEWAY/resume) the session was invalid. Reconnect and start a new session.                                                                                                       | true      |
-| 4008 | Rate limited          | Woah nelly! You're sending payloads to us too quickly. Slow it down! You will be disconnected on receiving this.                                                                                                                 | true      |
+| 4008 | Rate limited          | Woah nelly! You're sending payloads to us too quickly. Slow it down!                                                                                                                                                             | true      |
 | 4009 | Session timed out     | Your session timed out. Reconnect and start a new one.                                                                                                                                                                           | true      |
 | 4010 | Invalid shard         | You sent us an invalid [shard when identifying](#DOCS_TOPICS_GATEWAY/sharding).                                                                                                                                                  | false     |
 | 4011 | Sharding required     | The session would have handled too many guilds - you are required to [shard](#DOCS_TOPICS_GATEWAY/sharding) your connection in order to connect.                                                                                 | false     |
@@ -60,7 +60,7 @@ Our voice gateways have their own set of opcodes and close codes.
 | 7    | Resume              | client            | Resume a connection.                                     |
 | 8    | Hello               | server            | Time to wait between sending heartbeats in milliseconds. |
 | 9    | Resumed             | server            | Acknowledge a successful session resume.                 |
-| 13   | Client Disconnect   | server            | A client has disconnected from the voice channel         |
+| 13   | Client Disconnect   | server            | A client has disconnected from the voice channel.        |
 
 ###### Voice Close Event Codes
 


### PR DESCRIPTION
The page contained inconsistencies in naming and contained user-only error codes.

I have some doubt some of these errors are in the bot API but left them in for review, in case they're important.