### PR TITLE
Added Discord Embed Previewer community resource

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -86,11 +86,12 @@ Using Discord's [Dispatch](#DOCS_DISPATCH_DISPATCH_AND_YOU) tool for game develo
 - [ziad87's Intent Calculator](https://ziad87.net/intents/)
 - [Larko's Intent Calculator](https://discord-intents-calculator.vercel.app/)
 
-## Embed Visualizer
+## Embed Visualizers
 
-Webhooks and embeds might seem like black magic. That's because they are, but let us help you demystify them a bit. This sweet embed visualizer lets you play around with JSON data and see exactly how it will look embedded in Discord. It even includes a webhook mode!
+Webhooks and embeds might seem like black magic. That's because they are, but let us help you demystify them a bit. These tools can help you test how embeds will appear inside of Discord:
 
 - [Autocode Embed Builder](https://autocode.com/tools/discord/embed-builder/)
+- [JohnyTheCarrot's Embed Previewer](https://github.com/JohnyTheCarrot/discord-embed-previewer) (Browser Extension)
 
 ## API Types
 


### PR DESCRIPTION
I added my extension to the community resources.
A description of the extension is available in the commit.

Here are some images that should quickly show the purpose of the extension:
![Screenshot 2022-04-25 at 12 07 1](https://user-images.githubusercontent.com/24935987/165074962-ffe939a0-53b2-4b36-9f28-ac5956d4c42e.png)
![Screenshot 2022-04-25 at 12 01](https://user-images.githubusercontent.com/24935987/165074977-04c65399-f086-4302-baf1-3cb51f8bc3d2.png)

