### PR TITLE
Add application commands to audit log structure

### DIFF
--- a/docs/resources/Audit_Log.md
+++ b/docs/resources/Audit_Log.md
@@ -10,6 +10,7 @@ Whenever an admin action is performed on the API, an entry is added to the respe
 
 | Field                  | Type                                                                                                         | Description                                           |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
+| application_commands   | array of [application command](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-object) objects   | list of application commands found in the audit log   |
 | audit_log_entries      | array of [audit log entry](#DOCS_RESOURCES_AUDIT_LOG/audit-log-entry-object) objects                         | list of audit log entries                             |
 | guild_scheduled_events | array of [guild scheduled event](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object) objects | list of guild scheduled events found in the audit log |
 | integrations           | array of partial [integration](#DOCS_RESOURCES_GUILD/integration-object) objects                             | list of partial integration objects                   |


### PR DESCRIPTION
Added `application_commands` field to the audit log structure.