### PR TITLE
add warning box to user agent docs

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -231,6 +231,9 @@ User-Agent: DiscordBot ($url, $versionNumber)
 
 Clients may append more information and metadata to the _end_ of this string as they wish.
 
+>warn
+>Client requests that do not have a valid User Agent specified may or may not be blocked and lead to a CloudFlare error.
+
 ### Rate Limiting
 
 The HTTP API implements a process for limiting and preventing excessive requests in accordance with [RFC 6585](https://tools.ietf.org/html/rfc6585#section-4). API users that regularly hit and ignore rate limits will have their API keys revoked, and be blocked from the platform. For more information on rate limiting of requests, please see the [Rate Limits](#DOCS_TOPICS_RATE_LIMITS/rate-limits) section.

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -231,8 +231,8 @@ User-Agent: DiscordBot ($url, $versionNumber)
 
 Clients may append more information and metadata to the _end_ of this string as they wish.
 
->warn
->Client requests that do not have a valid User Agent specified may or may not be blocked and lead to a CloudFlare error.
+> warn
+> Client requests that do not have a valid User Agent specified may be blocked and lead to a CloudFlare error page.
 
 ### Rate Limiting
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -232,7 +232,7 @@ User-Agent: DiscordBot ($url, $versionNumber)
 Clients may append more information and metadata to the _end_ of this string as they wish.
 
 > warn
-> Client requests that do not have a valid User Agent specified may be blocked and lead to a Cloudflare error page.
+> Client requests that do not have a valid User Agent specified may be blocked and lead to a Cloudflare error response.
 
 ### Rate Limiting
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -232,7 +232,7 @@ User-Agent: DiscordBot ($url, $versionNumber)
 Clients may append more information and metadata to the _end_ of this string as they wish.
 
 > warn
-> Client requests that do not have a valid User Agent specified may be blocked and lead to a Cloudflare error response.
+> Client requests that do not have a valid User Agent specified may be blocked and return a [Cloudflare error](https://support.cloudflare.com/hc/en-us/articles/360029779472-Troubleshooting-Cloudflare-1XXX-errors).
 
 ### Rate Limiting
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -232,7 +232,7 @@ User-Agent: DiscordBot ($url, $versionNumber)
 Clients may append more information and metadata to the _end_ of this string as they wish.
 
 > warn
-> Client requests that do not have a valid User Agent specified may be blocked and lead to a CloudFlare error page.
+> Client requests that do not have a valid User Agent specified may be blocked and lead to a Cloudflare error page.
 
 ### Rate Limiting
 


### PR DESCRIPTION
Attempts to combat the documentation issue described in #4908 by adding a visible warning box