### PR TITLE
Reclarify guild admins having access to commands with `default_member_permission` set to `"0"`

### DIFF
--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -332,7 +332,7 @@ You can also use the `dm_permission` flag to control whether a global command ca
 
 ###### Example of editing permissions
 
-As an example, the following command would not be usable by anyone in any guilds by default:
+As an example, the following command would not be usable by anyone except admins in any guilds by default:
 
 ```json
 {


### PR DESCRIPTION
This was clarified before, wrongly stated afterward, and has now been corrected:
https://github.com/discord/discord-api-docs/blob/43b67450eae11173da0ebefec52dfb45cb073040/docs/interactions/Application_Commands.md?plain=1#L329

https://github.com/discord/discord-api-docs/blob/43b67450eae11173da0ebefec52dfb45cb073040/docs/interactions/Application_Commands.md?plain=1#L335