### PR TITLE
Clarify some Channel/Message Types' API Version availability

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -41,7 +41,7 @@ Represents a guild or DM channel within Discord.
 ###### Channel Types
 
 > warn
-> Type 10, 11 and 12 are only available in API v9.
+> Type 10, 11 and 12 are only available in API v9 and higher.
 
 | Type                    | ID  | Description                                                                                                                                          |
 | ----------------------- | --- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -281,7 +281,7 @@ Represents a message sent in a channel within Discord.
 ###### Message Types
 
 > warn
-> Type `19` and `20` are only in API v8. In v6, they are still type `0`.  Type `21` is only in API v9.
+> Type `19` and `20` are only in API v8 and higher. In v6, they are still type `0`.  Type `21` is only in API v9 and higher.
 
 | Type                                         | Value |
 |----------------------------------------------|-------|

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -41,7 +41,7 @@ Represents a guild or DM channel within Discord.
 ###### Channel Types
 
 > warn
-> Type 10, 11 and 12 are only available in API v9 and higher.
+> Type 10, 11 and 12 are only available in API v9 and above.
 
 | Type                    | ID  | Description                                                                                                                                          |
 | ----------------------- | --- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -281,7 +281,7 @@ Represents a message sent in a channel within Discord.
 ###### Message Types
 
 > warn
-> Type `19` and `20` are only in API v8 and higher. In v6, they are still type `0`.  Type `21` is only in API v9 and higher.
+> Type `19` and `20` are only available in API v8 and above. In v6, they are represented as type `0`.  Additionally, type `21` is only available in API v9 and above.
 
 | Type                                         | Value |
 |----------------------------------------------|-------|


### PR DESCRIPTION
Minor change to language in warnings above Channel and Message Types to indicate that some types are also available in newer API Versions, not only a single API version.