### PR TITLE
Document stage bitrate error code

### DIFF
--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -187,6 +187,7 @@ Along with the HTTP error code, our API can also return more detailed error code
 | 30046  | Maximum number of edits to messages older than 1 hour reached. Try again later                                                |
 | 30047  | Maximum number of pinned threads in a forum channel has been reached                                                          |
 | 30048  | Maximum number of tags in a forum channel has been reached                                                                    |
+| 30052  | Bitrate is too high for channel of this type                                                                                  |
 | 40001  | Unauthorized. Provide a valid token and try again                                                                             |
 | 40002  | You need to verify your account in order to perform this action                                                               |
 | 40003  | You are opening direct messages too fast                                                                                      |


### PR DESCRIPTION
```json
{
    "message": "Bitrate is too high for channel of this type",
    "code": 30052
}
```