### PR TITLE
Remove audit log reference under Modify Guild Channel Positions

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -730,9 +730,6 @@ Modify the positions of a set of [channel](#DOCS_RESOURCES_CHANNEL/channel-objec
 > info
 > Only channels to be modified are required.
 
-> info
-> This endpoint supports the `X-Audit-Log-Reason` header.
-
 This endpoint takes a JSON array of parameters in the following format:
 
 ###### JSON Params


### PR DESCRIPTION
From #4345, the Modify Guild Channel Positions endpoint intentionally doesn't create audit log entries, so it doesn't seem to use `X-Audit-Log-Reason`