### PR TITLE
upload sticker is no longer only for boosted guilds

### DIFF
--- a/docs/resources/Sticker.md
+++ b/docs/resources/Sticker.md
@@ -29,7 +29,9 @@ Incidentally the client will always use a name generated from an emoji as the va
 | Type     | Value | Description                                                                   |
 | -------- | ----- | ----------------------------------------------------------------------------- |
 | STANDARD | 1     | an official sticker in a pack, part of Nitro or in a removed purchasable pack |
-| GUILD    | 2     | a sticker uploaded to a Boosted guild for the guild's members                 |
+| GUILD    | 2     | a sticker uploaded to a guild for the guild's members \*                      |
+
+\* Guilds have 5 free sticker slots by default, to add more the guild needs at least level 1 Boost.
 
 ###### Sticker Format Types
 

--- a/docs/resources/Sticker.md
+++ b/docs/resources/Sticker.md
@@ -29,9 +29,7 @@ Incidentally the client will always use a name generated from an emoji as the va
 | Type     | Value | Description                                                                   |
 | -------- | ----- | ----------------------------------------------------------------------------- |
 | STANDARD | 1     | an official sticker in a pack, part of Nitro or in a removed purchasable pack |
-| GUILD    | 2     | a sticker uploaded to a guild for the guild's members \*                      |
-
-\* Guilds have 5 free sticker slots by default, to add more the guild needs at least level 1 Boost.
+| GUILD    | 2     | a sticker uploaded to a guild for the guild's members                         |
 
 ###### Sticker Format Types
 
@@ -124,6 +122,8 @@ Returns a [sticker](#DOCS_RESOURCES_STICKER/sticker-object) object for the given
 ## Create Guild Sticker % POST /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/stickers
 
 Create a new sticker for the guild. Send a `multipart/form-data` body. Requires the `MANAGE_EMOJIS_AND_STICKERS` permission. Returns the new [sticker](#DOCS_RESOURCES_STICKER/sticker-object) object on success.
+
+Every guilds has five free sticker slots by default, and each Boost level will grant access to more slots.
 
 > info
 > This endpoint supports the `X-Audit-Log-Reason` header.


### PR DESCRIPTION
guilds with no boost are now able to upload stickers
![image](https://user-images.githubusercontent.com/79790819/173140570-20faa772-6a54-4e62-8753-1e6683eef4b7.png)
