### PR TITLE
Mark Action and Trigger Metadata fields as optional

### DIFF
--- a/docs/resources/Auto_Moderation.md
+++ b/docs/resources/Auto_Moderation.md
@@ -169,8 +169,8 @@ value of [action type](#DOCS_RESOURCES_AUTO_MODERATION/auto-moderation-action-ob
 
 | Field            | Type       | Associated Action Types | Description                                    | 
 | ---------------- | ---------- | ----------------------- | ---------------------------------------------- |
-| channel_id       | snowflake  | SEND_ALERT_MESSAGE      | channel to which user content should be logged |
-| duration_seconds | integer    | TIMEOUT                 | timeout duration in seconds *                  |
+| channel_id?       | snowflake  | SEND_ALERT_MESSAGE      | channel to which user content should be logged |
+| duration_seconds? | integer    | TIMEOUT                 | timeout duration in seconds *                  |
 
 \* Maximum of 2419200 seconds (4 weeks)
 

--- a/docs/resources/Auto_Moderation.md
+++ b/docs/resources/Auto_Moderation.md
@@ -72,8 +72,8 @@ value of [trigger_type](#DOCS_RESOURCES_AUTO_MODERATION/auto-moderation-rule-obj
 
 | Field          | Type                                                                                                              | Associated Trigger Types | Description                                                               | 
 | -------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------- |
-| keyword_filter | array of strings *                                                                                                | KEYWORD                  | substrings which will be searched for in content                          |
-| presets        | array of [keyword preset types](#DOCS_RESOURCES_AUTO_MODERATION/auto-moderation-rule-object-keyword-preset-types) | KEYWORD_PRESET           | the internally pre-defined wordsets which will be searched for in content |
+| keyword_filter? | array of strings *                                                                                                | KEYWORD                  | substrings which will be searched for in content                          |
+| presets?        | array of [keyword preset types](#DOCS_RESOURCES_AUTO_MODERATION/auto-moderation-rule-object-keyword-preset-types) | KEYWORD_PRESET           | the internally pre-defined wordsets which will be searched for in content |
 
 
 \* A keyword can be a phrase which contains multiple words. Wildcard symbols can be used to customize how each keyword will be matched.


### PR DESCRIPTION
As the Action Metadata fields of `channel_id` and `duration_seconds` are only relevant to their associated action types, these fields are not required if neither associated action type is used. 

The same applies to Trigger Metadata's `keyword_filter` and `presets` fields.

I also noticed inconsistencies with this system as well. I may open an issue about this later.

<details>
<summary>Show Incosistenies</summary>
For example, with Action Metadata, even if I chose `TIMEOUT` as my action type, as long as a specify a `channel_id` without specifying `duration_seconds`, then the response will succeed and set the `duration_seconds` to 0. However, if I omit all fields within `metadata` or remove the `metada` field entirely, then it will error.

I'm not sure why it does this and is out of the scope of this PR. 

Request:
```json
"actions": [
    {
        "type": 3,
        "metadata": {
            "channel_id":902337497625935922
        }
    }
]
```

Response:
```json
"actions": [
        {
            "type": 3,
            "metadata": {
                "duration_seconds": 0
            }
        }
    ]
```
</details>