### PR TITLE
Corrected wrong description for Action Metadata channel_id field

### DIFF
--- a/docs/resources/Auto_Moderation.md
+++ b/docs/resources/Auto_Moderation.md
@@ -169,7 +169,7 @@ value of [action type](#DOCS_RESOURCES_AUTO_MODERATION/auto-moderation-action-ob
 
 | Field            | Type       | Associated Action Types | Description                                    | 
 | ---------------- | ---------- | ----------------------- | ---------------------------------------------- |
-| channel_id       | snowflake  | SEND_ALERT_MESSAGE      | channel to which user content should be logged |
+| channel_id       | snowflake  | SEND_ALERT_MESSAGE      | channel to which message content should be logged |
 | duration_seconds | integer    | TIMEOUT                 | timeout duration in seconds *                  |
 
 \* Maximum of 2419200 seconds (4 weeks)


### PR DESCRIPTION
### Corrected wrong description for [Action Metadata](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object-action-metadata) `channel_id` field

It says `user content`, but it is the `message content` that should be logged in the channel. So i updated this.


![image](https://user-images.githubusercontent.com/80390413/174459684-bb293376-bd12-4312-8aee-04c12851f643.png)
