### PR TITLE
fix infobox in application commands page

### DIFF
--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -62,7 +62,7 @@ Application commands are native ways to interact with apps in the Discord client
 
 \* `autocomplete` may not be set to true if `choices` are present.
 
-> note
+> info
 > Options using `autocomplete` are not confined to only use choices given by the application.
 
 ###### Application Command Option Type


### PR DESCRIPTION
`note` isn't a keyword for infoboxes
![image](https://user-images.githubusercontent.com/79790819/174898888-c38ceb6a-a63f-41ef-b8dc-316cdb6a0658.png)
