### PR TITLE
Removes obsolete/approval gated oauth2 scopes.

### DIFF
--- a/docs/topics/OAuth2.md
+++ b/docs/topics/OAuth2.md
@@ -19,22 +19,16 @@ The first step in implementing OAuth2 is [registering a developer application](#
 
 ###### OAuth2 Scopes
 
-These are a list of all the OAuth2 scopes that Discord supports. Some scopes require approval from Discord to use. Requesting them from a user without approval from Discord may cause errors or undocumented behavior in the OAuth2 flow.
+These are a list of all the publicly available OAuth2 scopes that Discord supports.
 
 | Name                                     | Description                                                                                                                                                                             |
 | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| activities.read                          | allows your app to fetch data from a user's "Now Playing/Recently Played" list - requires Discord approval                                                                              |
-| activities.write                         | allows your app to update a user's activity - requires Discord approval (NOT REQUIRED FOR [GAMESDK ACTIVITY MANAGER](#DOCS_GAME_SDK_ACTIVITIES/))                                       |
 | applications.builds.read                 | allows your app to read build data for a user's applications                                                                                                                            |
-| applications.builds.upload               | allows your app to upload/update builds for a user's applications - requires Discord approval                                                                                           |
 | applications.commands                    | allows your app to use [commands](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/) in a guild                                                                                                  |
 | applications.commands.update             | allows your app to update its [commands](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/) using a Bearer token - [client credentials grant](#DOCS_TOPICS_OAUTH2/client-credentials-grant) only |
 | applications.commands.permissions.update | allows your app to update [permissions for its commands](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/permissions) in a guild a user has permissions to                                      |
-| applications.entitlements                | allows your app to read entitlements for a user's applications                                                                                                                          |
-| applications.store.update                | allows your app to read and update store data (SKUs, store listings, achievements, etc.) for a user's applications                                                                      |
 | bot                                      | for oauth2 bots, this puts the bot in the user's selected guild by default                                                                                                              |
 | connections                              | allows [/users/@me/connections](#DOCS_RESOURCES_USER/get-user-connections) to return linked third-party accounts                                                                        |
-| dm_channels.read                         | allows your app to see information about the user's DMs and group DMs - requires Discord approval                                                                                       |
 | email                                    | enables [/users/@me](#DOCS_RESOURCES_USER/get-current-user) to return an `email`                                                                                                        |
 | gdm.join                                 | allows your app to [join users to a group dm](#DOCS_RESOURCES_CHANNEL/group-dm-add-recipient)                                                                                           |
 | guilds                                   | allows [/users/@me/guilds](#DOCS_RESOURCES_USER/get-current-user-guilds) to return basic information about all of a user's guilds                                                       |
@@ -42,13 +36,6 @@ These are a list of all the OAuth2 scopes that Discord supports. Some scopes req
 | guilds.members.read                      | allows [/users/@me/guilds/{guild.id}/member](#DOCS_RESOURCES_USER/get-current-user-guild-member) to return a user's member information in a guild                                       |
 | identify                                 | allows [/users/@me](#DOCS_RESOURCES_USER/get-current-user) without `email`                                                                                                              |
 | messages.read                            | for local rpc server api access, this allows you to read messages from all client channels (otherwise restricted to channels/guilds your app creates)                                   |
-| relationships.read                       | allows your app to know a user's friends and implicit relationships - requires Discord approval                                                                                         |
-| rpc                                      | for local rpc server access, this allows you to control a user's local Discord client - requires Discord approval                                                                       |
-| rpc.activities.write                     | for local rpc server access, this allows you to update a user's activity - requires Discord approval                                                                                    |
-| rpc.notifications.read                   | for local rpc server access, this allows you to receive notifications pushed out to the user - requires Discord approval                                                                |
-| rpc.voice.read                           | for local rpc server access, this allows you to read a user's voice settings and listen for voice events - requires Discord approval                                                    |
-| rpc.voice.write                          | for local rpc server access, this allows you to update a user's voice settings - requires Discord approval                                                                              |
-| voice                                    | allows your app to connect to voice on user's behalf and see all the voice members - requires Discord approval                                                                          |
 | webhook.incoming                         | this generates a webhook that is returned in the oauth token response for authorization code grants                                                                                     |
 
 > info


### PR DESCRIPTION
Removes the oauth2 scopes which: reference parts of the API which are no longer
usable; or require approval (which cannot currently be obtained) to use.