### PR TITLE
Bot permissions calculation changes

### DIFF
--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -7,6 +7,8 @@
 
 #### Jun 29, 2022
 
+#### Upcoming Changes
+
 Starting **July 28, 2022**, the way a bot's [permissions](#DOCS_TOPICS_PERMISSIONS/permissions) are calculated is changing in two cases:
 - When **responding to an [interaction](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING)** (like application commands or message components)
 - When **executing a [webhook](#DOCS_RESOURCES_WEBHOOK) that the bot created**
@@ -17,7 +19,7 @@ At the time of the change, **Attach Files** (`ATTACH_FILES`), **Embed Links** (`
 
 This change *only* applies to bots. The permissions for an app without a bot user (or without the `bot` scope) will still be the same as `@everyone`.
 
-#### Updating your app
+#### Updating Your App
 
 If your bot depends on any of the affected permissions (`ATTACH_FILES`, `EMBED_LINKS`, `MENTION_EVERYONE`, or `USE_EXTERNAL_EMOJIS`) when responding to interactions or executing a webhook, **ensure that the bot was installed with them**. If it wasn’t, your app with the bot will need to be reauthenticated with its required permissions before July 28.
 

--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -1,5 +1,27 @@
 # Change Log
 
+## Changes to Bot Permissions for Interactions
+
+#### Jun 29, 2022
+
+#### Breaking Changes
+
+Starting **July 28, 2022**, the way a bot's [permissions](#DOCS_TOPICS_PERMISSIONS/permissions) are calculated when responding to interactions (like application commands or message components) will change. Going forward, **a bot’s permission will be calculated based on the permissions it was installed with and any permission overrides in the channel where the interaction occurred**.
+
+Previously, a bot’s permissions matched `@everyone` when responding to interactions, regardless of the permissions it was installed with.
+
+At the time of the change, the following permissions may be impacted:
+- Attach Files (`ATTACH_FILES`)
+- Embed Links (`EMBED_LINKS`)
+- Mention Everyone (`MENTION_EVERYONE`)
+- Use External Emojis (`USE_EXTERNAL_EMOJIS`)
+
+This change only applies to bots. The permissions for an app without a bot will still be the same as `@everyone`.
+
+#### Updating your app
+
+If your bot depends on any of the affected permissions (`ATTACH_FILES`, `EMBED_LINKS`, `MENTION_EVERYONE`, or `USE_EXTERNAL_EMOJIS`) when responding to interactions, ensure that the bot was installed with them. If it wasn’t, your app will need to be reauthenticated with the permissions it requires.
+
 ## Calculated Permissions in Interaction Payloads
 
 #### Jun 29, 2022

--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -6,21 +6,21 @@
 
 #### Breaking Changes
 
-Starting **July 28, 2022**, the way a bot's [permissions](#DOCS_TOPICS_PERMISSIONS/permissions) are calculated when **responding to interactions** (like application commands or message components) or when **executing a webhook that the bot created**. Going forward, a bot’s permission will be calculated based on the permissions it was installed with and any permission overrides in the relevant channel.
+Starting **July 28, 2022**, the way a bot's [permissions](#DOCS_TOPICS_PERMISSIONS/permissions) are calculated is changing in two cases:
+- When **responding to an [interaction](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING)** (like application commands or message components)
+- When **executing a [webhook](#DOCS_RESOURCES_WEBHOOK) that the bot created**
 
-Previously, a bot’s permissions matched `@everyone` when responding to interactions or executing a webhook, regardless of the permissions it was installed with.
+Going forward, a bot’s permission will be calculated based on the permissions it was installed with and any permission overrides in the associated channel for interactions and the bot's webhooks.
 
-At the time of the change, the following permissions may be impacted:
-- Attach Files (`ATTACH_FILES`)
-- Embed Links (`EMBED_LINKS`)
-- Mention Everyone (`MENTION_EVERYONE`)
-- Use External Emojis (`USE_EXTERNAL_EMOJIS`)
+At the time of the change, Attach Files (**`ATTACH_FILES`**), Embed Links (**`EMBED_LINKS`**), Mention Everyone (**`MENTION_EVERYONE`**), and Use External Emojis (**`USE_EXTERNAL_EMOJIS`**) are the permissions that will be affected.
 
-This change only applies to bots. The permissions for an app without a bot will still be the same as `@everyone`.
+Previously, a bot’s permissions matched `@everyone`, regardless of the permissions it was installed with.
+
+This change *only* applies to bots. The permissions for an app without a bot user (or without the `bot` scope) will still be the same as `@everyone`.
 
 #### Updating your app
 
-If your bot depends on any of the affected permissions (`ATTACH_FILES`, `EMBED_LINKS`, `MENTION_EVERYONE`, or `USE_EXTERNAL_EMOJIS`) when responding to interactions, **ensure that the bot was installed with them**. If it wasn’t, your app will need to be reauthenticated with the permissions it requires.
+If your bot depends on any of the affected permissions (`ATTACH_FILES`, `EMBED_LINKS`, `MENTION_EVERYONE`, or `USE_EXTERNAL_EMOJIS`) when responding to interactions or executing a webhook, **ensure that the bot was installed with them**. If it wasn’t, your app with the bot will need to be reauthenticated with the permissions it requires before July 28.
 
 ## Calculated Permissions in Interaction Payloads
 

--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -13,15 +13,17 @@ Starting **July 28, 2022**, the way a bot's [permissions](#DOCS_TOPICS_PERMISSIO
 - When **responding to an [interaction](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING)** (like application commands or message components)
 - When **executing a [webhook](#DOCS_RESOURCES_WEBHOOK) that the bot created**
 
-Going forward, in the above cases, a bot’s permission will be calculated based on the permissions it was installed with and any overrides in the associated channel. Previously, a bot’s permissions matched `@everyone`, regardless of the permissions it was installed with.
+Going forward, in the above cases, a bot’s permissions will be calculated using the permissions granted to it, including any [overwrites](#DOCS_TOPICS_PERMISSIONS/permission-overwrites). This change makes a bot's permissions for interactions and webhooks the same as those for [posting a message to a channel](#DOCS_RESOURCES_CHANNEL/create-message). Previously, a bot’s permissions in these cases relied only on those granted to `@everyone`.
 
-At the time of the change, **Attach Files** (`ATTACH_FILES`), **Embed Links** (`EMBED_LINKS`), **Mention Everyone** (`MENTION_EVERYONE`), and **Use External Emojis** (`USE_EXTERNAL_EMOJIS`) are the permissions that will be affected.
+At the time of the change, **Attach Files** (`ATTACH_FILES`), **Embed Links** (`EMBED_LINKS`), **Mention Everyone** (`MENTION_EVERYONE`), and **Use External Emojis** (`USE_EXTERNAL_EMOJIS`) are the permissions that may be affected.
 
-This change *only* applies to bots. The permissions for an app without a bot user (or without the `bot` scope) will still be the same as `@everyone`.
+This change *only* applies to bots. The permissions for an app without a bot user (or without the `bot` scope) will still depend on `@everyone`.
 
 #### Updating Your App
 
-If your bot depends on any of the affected permissions (`ATTACH_FILES`, `EMBED_LINKS`, `MENTION_EVERYONE`, or `USE_EXTERNAL_EMOJIS`) when responding to interactions or executing a webhook, **ensure that the bot was installed with them**. If it wasn’t, your app with the bot will need to be reauthenticated with its required permissions before July 28.
+If your bot wants to use any affected permissions (`ATTACH_FILES`, `EMBED_LINKS`, `MENTION_EVERYONE`, or `USE_EXTERNAL_EMOJIS`) when responding to interactions or executing a webhook, **ensure that the bot was installed with them**. If it wasn’t, your app with the bot should be reauthenticated with them before July 28.
+
+Note that even if your bot is installed with certain permissions, they can be changed using overwrites. For interactions, you can use the [`app_permissions` field](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-object-interaction-structure) to determine your app or bot's contextual permissions before replying.
 
 ## Calculated Permissions in Interaction Payloads
 

--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -2,25 +2,24 @@
 
 ## Changes to Bot Permissions for Interactions and Webhooks
 
-#### Jun 29, 2022
+> danger
+> This entry includes breaking changes
 
-#### Breaking Changes
+#### Jun 29, 2022
 
 Starting **July 28, 2022**, the way a bot's [permissions](#DOCS_TOPICS_PERMISSIONS/permissions) are calculated is changing in two cases:
 - When **responding to an [interaction](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING)** (like application commands or message components)
 - When **executing a [webhook](#DOCS_RESOURCES_WEBHOOK) that the bot created**
 
-Going forward, a bot’s permission will be calculated based on the permissions it was installed with and any permission overrides in the associated channel for interactions and the bot's webhooks.
+Going forward, in the above cases, a bot’s permission will be calculated based on the permissions it was installed with and any overrides in the associated channel. Previously, a bot’s permissions matched `@everyone`, regardless of the permissions it was installed with.
 
-At the time of the change, Attach Files (**`ATTACH_FILES`**), Embed Links (**`EMBED_LINKS`**), Mention Everyone (**`MENTION_EVERYONE`**), and Use External Emojis (**`USE_EXTERNAL_EMOJIS`**) are the permissions that will be affected.
-
-Previously, a bot’s permissions matched `@everyone`, regardless of the permissions it was installed with.
+At the time of the change, **Attach Files** (`ATTACH_FILES`), **Embed Links** (`EMBED_LINKS`), **Mention Everyone** (`MENTION_EVERYONE`), and **Use External Emojis** (`USE_EXTERNAL_EMOJIS`) are the permissions that will be affected.
 
 This change *only* applies to bots. The permissions for an app without a bot user (or without the `bot` scope) will still be the same as `@everyone`.
 
 #### Updating your app
 
-If your bot depends on any of the affected permissions (`ATTACH_FILES`, `EMBED_LINKS`, `MENTION_EVERYONE`, or `USE_EXTERNAL_EMOJIS`) when responding to interactions or executing a webhook, **ensure that the bot was installed with them**. If it wasn’t, your app with the bot will need to be reauthenticated with the permissions it requires before July 28.
+If your bot depends on any of the affected permissions (`ATTACH_FILES`, `EMBED_LINKS`, `MENTION_EVERYONE`, or `USE_EXTERNAL_EMOJIS`) when responding to interactions or executing a webhook, **ensure that the bot was installed with them**. If it wasn’t, your app with the bot will need to be reauthenticated with its required permissions before July 28.
 
 ## Calculated Permissions in Interaction Payloads
 

--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -1,14 +1,14 @@
 # Change Log
 
-## Changes to Bot Permissions for Interactions
+## Changes to Bot Permissions for Interactions and Webhooks
 
 #### Jun 29, 2022
 
 #### Breaking Changes
 
-Starting **July 28, 2022**, the way a bot's [permissions](#DOCS_TOPICS_PERMISSIONS/permissions) are calculated when responding to interactions (like application commands or message components) will change. Going forward, a bot’s permission will be calculated based on the permissions it was installed with and any permission overrides in the channel where the interaction occurred.
+Starting **July 28, 2022**, the way a bot's [permissions](#DOCS_TOPICS_PERMISSIONS/permissions) are calculated when **responding to interactions** (like application commands or message components) or when **executing a webhook that the bot created**. Going forward, a bot’s permission will be calculated based on the permissions it was installed with and any permission overrides in the relevant channel.
 
-Previously, a bot’s permissions matched `@everyone` when responding to interactions, regardless of the permissions it was installed with.
+Previously, a bot’s permissions matched `@everyone` when responding to interactions or executing a webhook, regardless of the permissions it was installed with.
 
 At the time of the change, the following permissions may be impacted:
 - Attach Files (`ATTACH_FILES`)

--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -6,7 +6,7 @@
 
 #### Breaking Changes
 
-Starting **July 28, 2022**, the way a bot's [permissions](#DOCS_TOPICS_PERMISSIONS/permissions) are calculated when responding to interactions (like application commands or message components) will change. Going forward, **a bot’s permission will be calculated based on the permissions it was installed with and any permission overrides in the channel where the interaction occurred**.
+Starting **July 28, 2022**, the way a bot's [permissions](#DOCS_TOPICS_PERMISSIONS/permissions) are calculated when responding to interactions (like application commands or message components) will change. Going forward, a bot’s permission will be calculated based on the permissions it was installed with and any permission overrides in the channel where the interaction occurred.
 
 Previously, a bot’s permissions matched `@everyone` when responding to interactions, regardless of the permissions it was installed with.
 
@@ -20,13 +20,13 @@ This change only applies to bots. The permissions for an app without a bot will 
 
 #### Updating your app
 
-If your bot depends on any of the affected permissions (`ATTACH_FILES`, `EMBED_LINKS`, `MENTION_EVERYONE`, or `USE_EXTERNAL_EMOJIS`) when responding to interactions, ensure that the bot was installed with them. If it wasn’t, your app will need to be reauthenticated with the permissions it requires.
+If your bot depends on any of the affected permissions (`ATTACH_FILES`, `EMBED_LINKS`, `MENTION_EVERYONE`, or `USE_EXTERNAL_EMOJIS`) when responding to interactions, **ensure that the bot was installed with them**. If it wasn’t, your app will need to be reauthenticated with the permissions it requires.
 
 ## Calculated Permissions in Interaction Payloads
 
 #### Jun 29, 2022
 
-Interaction payloads now contain an `app_permissions` field whose value is the computed [permissions](#DOCS_TOPICS_PERMISSIONS/permissions-bitwise-permission-flags) for a bot or app in the context of a specific interaction (including any custom permissions for the origin channel). Similar to other permission fields, the value of `app_permissions` is a bitwise OR-ed set of permissions expressed as a string. Read details in the [interactions documentation](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-object).
+Interaction payloads now contain an `app_permissions` field whose value is the computed [permissions](#DOCS_TOPICS_PERMISSIONS/permissions-bitwise-permission-flags) for a bot or app in the context of a specific interaction (including any channel overwrites). Similar to other permission fields, the value of `app_permissions` is a bitwise OR-ed set of permissions expressed as a string. Read details in the [interactions documentation](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-object).
 
 For apps without a bot user (or without the `bot` scope), the value of `app_permissions` will be the same as the permissions for `@everyone`, but limited to the permissions that can be used in interaction responses (currently `ATTACH_FILES`, `EMBED_LINKS`, `MENTION_EVERYONE`, and `USE_EXTERNAL_EMOJIS`).
 


### PR DESCRIPTION
Adds changelog for some upcoming changes to how a bot's permissions are calculated for interactions and bot-created webhooks (which opens up use cases like posting external emojis).

Docs won't be updated until the change goes live on July 28.