### PR TITLE
correct interaction creation success response code

### DIFF
--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -1055,7 +1055,7 @@ Fetch all of the global commands for your application. Returns an array of [appl
 > danger
 > Creating a command with the same name as an existing command for your application will overwrite the old command.
 
-Create a new global command. Returns `201` and an [application command](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-object) object.
+Create a new global command. Returns `201` if the command does not already exist, a `200` if it does, and an [application command](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-object) object.
 
 ###### JSON Params
 
@@ -1124,7 +1124,7 @@ Fetch all of the guild commands for your application for a specific guild. Retur
 > danger
 > Creating a command with the same name as an existing command for your application will overwrite the old command.
 
-Create a new guild command. New guild commands will be available in the guild immediately. Returns `201` and an [application command](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-object) object. If the command did not already exist, it will count toward daily application command create limits.
+Create a new guild command. New guild commands will be available in the guild immediately. Returns `201` if the command does not already exist, a `200` if it does, and an [application command](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-object) object. If the command did not already exist, it will count toward daily application command create limits.
 
 ###### JSON Params
 

--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -1124,7 +1124,7 @@ Fetch all of the guild commands for your application for a specific guild. Retur
 > danger
 > Creating a command with the same name as an existing command for your application will overwrite the old command.
 
-Create a new guild command. New guild commands will be available in the guild immediately. Returns `201` if the command does not already exist, a `200` if it does, and an [application command](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-object) object. If the command did not already exist, it will count toward daily application command create limits.
+Create a new guild command. New guild commands will be available in the guild immediately. Returns `201` if a command with the same name does not already exist, or a `200` if it does (in which case the previous command will be overwritten). Both responses include an [application command](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-object) object.
 
 ###### JSON Params
 

--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -1055,7 +1055,7 @@ Fetch all of the global commands for your application. Returns an array of [appl
 > danger
 > Creating a command with the same name as an existing command for your application will overwrite the old command.
 
-Create a new global command. Returns `201` if the command does not already exist, a `200` if it does, and an [application command](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-object) object.
+Create a new global command. Returns `201` if a command with the same name does not already exist, or a `200` if it does (in which case the previous command will be overwritten). Both responses include an [application command](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-object) object.
 
 ###### JSON Params
 


### PR DESCRIPTION
The docs say that successfully creating an interaction returns a `201 CREATED` response code. I have observed that this is not correct, and instead it returns a `200 OK`.

```
[I] david@darvid-pc ~/scripts [3]> curl -v -d '{"name": "slash-example", "type": 1, "description": "Example slash interaction", "options": []}' -H 'Content-Type: application/json' -H 'Authorization: Bearer {{TOKEN}}' 'https://discord.com/api/v10/applications/{{CLIENT_ID}}/commands'
*   Trying 162.159.137.232:443...
* Connected to discord.com (162.159.137.232) port 443 (#0)
* ...
* We are completely uploaded and fine
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
* Connection state changed (MAX_CONCURRENT_STREAMS == 256)!
< HTTP/2 200 
< ...
* Connection #0 to host discord.com left intact
{"id": "...", "application_id": "...", "version": "...", "default_permission": true, "default_member_permissions": null, "type": 1, "name": "slash-example", "name_localizations": null, "description": "Example slash interaction", "description_localizations": null, "dm_permission": true}
```
