### PR TITLE
Clarify `suppress` description in Voice State

### DIFF
--- a/docs/resources/Voice.md
+++ b/docs/resources/Voice.md
@@ -6,21 +6,21 @@ Used to represent a user's voice connection status.
 
 ###### Voice State Structure
 
-| Field                      | Type                                                             | Description                                    |
-| -------------------------- | ---------------------------------------------------------------- | ---------------------------------------------- |
-| guild_id?                  | snowflake                                                        | the guild id this voice state is for           |
-| channel_id                 | ?snowflake                                                       | the channel id this user is connected to       |
-| user_id                    | snowflake                                                        | the user id this voice state is for            |
-| member?                    | [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object | the guild member this voice state is for       |
-| session_id                 | string                                                           | the session id for this voice state            |
-| deaf                       | boolean                                                          | whether this user is deafened by the server    |
-| mute                       | boolean                                                          | whether this user is muted by the server       |
-| self_deaf                  | boolean                                                          | whether this user is locally deafened          |
-| self_mute                  | boolean                                                          | whether this user is locally muted             |
-| self_stream?               | boolean                                                          | whether this user is streaming using "Go Live" |
-| self_video                 | boolean                                                          | whether this user's camera is enabled          |
-| suppress                   | boolean                                                          | whether this user is denied to speak           |
-| request_to_speak_timestamp | ?ISO8601 timestamp                                               | the time at which the user requested to speak  |
+| Field                      | Type                                                             | Description                                       |
+| -------------------------- | ---------------------------------------------------------------- | ------------------------------------------------- |
+| guild_id?                  | snowflake                                                        | the guild id this voice state is for              |
+| channel_id                 | ?snowflake                                                       | the channel id this user is connected to          |
+| user_id                    | snowflake                                                        | the user id this voice state is for               |
+| member?                    | [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object | the guild member this voice state is for          |
+| session_id                 | string                                                           | the session id for this voice state               |
+| deaf                       | boolean                                                          | whether this user is deafened by the server       |
+| mute                       | boolean                                                          | whether this user is muted by the server          |
+| self_deaf                  | boolean                                                          | whether this user is locally deafened             |
+| self_mute                  | boolean                                                          | whether this user is locally muted                |
+| self_stream?               | boolean                                                          | whether this user is streaming using "Go Live"    |
+| self_video                 | boolean                                                          | whether this user's camera is enabled             |
+| suppress                   | boolean                                                          | whether this user's permission to speak is denied |
+| request_to_speak_timestamp | ?ISO8601 timestamp                                               | the time at which the user requested to speak     |
 
 ###### Example Voice State
 

--- a/docs/resources/Voice.md
+++ b/docs/resources/Voice.md
@@ -6,21 +6,21 @@ Used to represent a user's voice connection status.
 
 ###### Voice State Structure
 
-| Field                      | Type                                                             | Description                                    |
-| -------------------------- | ---------------------------------------------------------------- | ---------------------------------------------- |
-| guild_id?                  | snowflake                                                        | the guild id this voice state is for           |
-| channel_id                 | ?snowflake                                                       | the channel id this user is connected to       |
-| user_id                    | snowflake                                                        | the user id this voice state is for            |
-| member?                    | [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object | the guild member this voice state is for       |
-| session_id                 | string                                                           | the session id for this voice state            |
-| deaf                       | boolean                                                          | whether this user is deafened by the server    |
-| mute                       | boolean                                                          | whether this user is muted by the server       |
-| self_deaf                  | boolean                                                          | whether this user is locally deafened          |
-| self_mute                  | boolean                                                          | whether this user is locally muted             |
-| self_stream?               | boolean                                                          | whether this user is streaming using "Go Live" |
-| self_video                 | boolean                                                          | whether this user's camera is enabled          |
-| suppress                   | boolean                                                          | whether this user is muted by the current user |
-| request_to_speak_timestamp | ?ISO8601 timestamp                                               | the time at which the user requested to speak  |
+| Field                      | Type                                                             | Description                                         |
+| -------------------------- | ---------------------------------------------------------------- | --------------------------------------------------- |
+| guild_id?                  | snowflake                                                        | the guild id this voice state is for                |
+| channel_id                 | ?snowflake                                                       | the channel id this user is connected to            |
+| user_id                    | snowflake                                                        | the user id this voice state is for                 |
+| member?                    | [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object | the guild member this voice state is for            |
+| session_id                 | string                                                           | the session id for this voice state                 |
+| deaf                       | boolean                                                          | whether this user is deafened by the server         |
+| mute                       | boolean                                                          | whether this user is muted by the server            |
+| self_deaf                  | boolean                                                          | whether this user is locally deafened               |
+| self_mute                  | boolean                                                          | whether this user is locally muted                  |
+| self_stream?               | boolean                                                          | whether this user is streaming using "Go Live"      |
+| self_video                 | boolean                                                          | whether this user's camera is enabled               |
+| suppress                   | boolean                                                          | whether this user does not have permission to speak |
+| request_to_speak_timestamp | ?ISO8601 timestamp                                               | the time at which the user requested to speak       |
 
 ###### Example Voice State
 

--- a/docs/resources/Voice.md
+++ b/docs/resources/Voice.md
@@ -6,21 +6,21 @@ Used to represent a user's voice connection status.
 
 ###### Voice State Structure
 
-| Field                      | Type                                                             | Description                                         |
-| -------------------------- | ---------------------------------------------------------------- | --------------------------------------------------- |
-| guild_id?                  | snowflake                                                        | the guild id this voice state is for                |
-| channel_id                 | ?snowflake                                                       | the channel id this user is connected to            |
-| user_id                    | snowflake                                                        | the user id this voice state is for                 |
-| member?                    | [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object | the guild member this voice state is for            |
-| session_id                 | string                                                           | the session id for this voice state                 |
-| deaf                       | boolean                                                          | whether this user is deafened by the server         |
-| mute                       | boolean                                                          | whether this user is muted by the server            |
-| self_deaf                  | boolean                                                          | whether this user is locally deafened               |
-| self_mute                  | boolean                                                          | whether this user is locally muted                  |
-| self_stream?               | boolean                                                          | whether this user is streaming using "Go Live"      |
-| self_video                 | boolean                                                          | whether this user's camera is enabled               |
-| suppress                   | boolean                                                          | whether this user does not have permission to speak |
-| request_to_speak_timestamp | ?ISO8601 timestamp                                               | the time at which the user requested to speak       |
+| Field                      | Type                                                             | Description                                    |
+| -------------------------- | ---------------------------------------------------------------- | ---------------------------------------------- |
+| guild_id?                  | snowflake                                                        | the guild id this voice state is for           |
+| channel_id                 | ?snowflake                                                       | the channel id this user is connected to       |
+| user_id                    | snowflake                                                        | the user id this voice state is for            |
+| member?                    | [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object | the guild member this voice state is for       |
+| session_id                 | string                                                           | the session id for this voice state            |
+| deaf                       | boolean                                                          | whether this user is deafened by the server    |
+| mute                       | boolean                                                          | whether this user is muted by the server       |
+| self_deaf                  | boolean                                                          | whether this user is locally deafened          |
+| self_mute                  | boolean                                                          | whether this user is locally muted             |
+| self_stream?               | boolean                                                          | whether this user is streaming using "Go Live" |
+| self_video                 | boolean                                                          | whether this user's camera is enabled          |
+| suppress                   | boolean                                                          | whether this user is denied to speak           |
+| request_to_speak_timestamp | ?ISO8601 timestamp                                               | the time at which the user requested to speak  |
 
 ###### Example Voice State
 


### PR DESCRIPTION
It was confusing to `mute` and `self_mute`

`suppress` is `true` when the user does not have "Speak" permission in the voice channel, and also indicated in the client when connecting to voice channel:
![suppressed](https://user-images.githubusercontent.com/87897282/179906459-dda4696f-ae6f-44f3-8712-24ae898ba8f1.png)

It is also `true` when user is in stage event as audience (non-speaker) but it's already explained in the stage instance page.