### PR TITLE
fix: document that content and matched_content are optional in AutoMod Execution events

### DIFF
--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -89,7 +89,7 @@ For apps without a bot user (or without the `bot` scope), the value of `app_perm
 
 #### Breaking Changes
 
-In API v10, the `MESSAGE_CONTENT` (`1 << 15`) intent is now required to receive non-empty values for the `content` and `matched_content` fields in [`AUTO_MODERATION_ACTION_EXECUTION`](#DOCS_TOPICS_GATEWAY/auto-moderation-action-execution) gateway events. This matches the intended behavior for message content across the API.
+In API v10, the `MESSAGE_CONTENT` (`1 << 15`) intent is now required to receive the `content` and `matched_content` fields in [`AUTO_MODERATION_ACTION_EXECUTION`](#DOCS_TOPICS_GATEWAY/auto-moderation-action-execution) gateway events. This matches the intended behavior for message content across the API. This is slightly different from other events which provide an empty field, so please be aware of this.
 
 ## Updated Connection Property Field Names
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -868,9 +868,9 @@ Sent when a rule is triggered and an action is executed (e.g. when a message is 
 | channel_id?              | snowflake                                                                                      | the id of the channel in which user content was posted                             |
 | message_id?              | snowflake                                                                                      | the id of any user message which content belongs to *                              |
 | alert_system_message_id? | snowflake                                                                                      | the id of any system auto moderation messages posted as a result of this action ** |
-| content ***              | string                                                                                         | the user generated text content                                                    |
+| content? ***             | string                                                                                         | the user generated text content                                                    |
 | matched_keyword          | ?string                                                                                        | the word or phrase configured in the rule that triggered the rule                  |
-| matched_content ***      | ?string                                                                                        | the substring in content that triggered the rule                                   |
+| matched_content? ***     | ?string                                                                                        | the substring in content that triggered the rule                                   |
 
 
 \* `message_id` will not exist if message was blocked by automod or content was not part of any message


### PR DESCRIPTION
closes #5241, continuation of https://github.com/discord/discord-api-docs/commit/a003d94dbd21af355703b4b3456e6fe09ff3e3dd