### PR TITLE
removed unnecessary import in Oauth.md

### DIFF
--- a/docs/topics/OAuth2.md
+++ b/docs/topics/OAuth2.md
@@ -198,7 +198,6 @@ You can specify scopes with the `scope` parameter, which is a list of [OAuth2 sc
 ###### Client Credentials Token Request Example
 
 ```python
-import base64
 import requests
 
 API_ENDPOINT = 'https://discord.com/api/v10'


### PR DESCRIPTION
In the snippet for the client credentials grant, the module `base64` is imported, but not used at all. This pr removes that import
