### PR TITLE
Remove nonexistent samsunggalaxy connection

### DIFF
--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -118,7 +118,6 @@ The connection object that the user has attached.
 | leagueoflegends *  | League of Legends   |
 | playstation        | PlayStation Network |
 | reddit             | Reddit              |
-| samsunggalaxy *    | Samsung Galaxy      |
 | spotify            | Spotify             |
 | skype *            | Skype               |
 | steam              | Steam               |


### PR DESCRIPTION
The connection service list includes a `samsunggalaxy` connection which seems to not actually exist. There is a Samsung galaxy activity, but that works through OAuth2, not a Discord connection.

from @Jupith:
```json
{
    "code": "BASE_TYPE_CHOICES",
    "message": "Value must be one of ('skype', 'spotify', 'leagueoflegends', 'steam', 'battlenet', 'twitch', 'epicgames', 'twitter', 'youtube', 'github', 'reddit', 'facebook', 'contacts', 'playstation', 'xbox')."
}
```