### PR TITLE
Fix Invalid Session opcode description

### DIFF
--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -16,7 +16,7 @@ All gateway events in Discord are tagged with an opcode that denotes the payload
 | 6    | Resume                | Send          | Resume a previous session that was disconnected.                                        |
 | 7    | Reconnect             | Receive       | You should attempt to reconnect and resume immediately.                                 |
 | 8    | Request Guild Members | Send          | Request information about offline guild members in a large guild.                       |
-| 9    | Invalid Session       | Receive       | The session has been invalidated. You should reconnect and identify/resume accordingly. |
+| 9    | Invalid Session       | Receive       | The session has been invalidated. You should reidentify/resume accordingly.             |
 | 10   | Hello                 | Receive       | Sent immediately after connecting, contains the `heartbeat_interval` to use.            |
 | 11   | Heartbeat ACK         | Receive       | Sent in response to receiving a heartbeat to acknowledge that it has been received.     |
 


### PR DESCRIPTION
As noticed during a [conversation](https://discord.com/channels/81384788765712384/381887113391505410/1005960212722753597) on the Discord API server, there is currently an inconsistency between the "[Opcodes and Status Codes](https://discord.com/developers/docs/topics/opcodes-and-status-codes)" and "[Gateway](https://discord.com/developers/docs/topics/gateway)" pages.

The former says that we should reconnect on OP9 before reidentifying/resuming, while the later doesn't mention this.
The end of the [Gateway#resuming](https://discord.com/developers/docs/topics/gateway#resuming:~:text=the%20client%20will%20receive%20a%20Opcode%209%20Invalid%20Session%20and%20is%20expected%20to%20wait%20a%20random%20amount%20of%20time%E2%80%94between%201%20and%205%20seconds%E2%80%94then%20send%20a%20fresh%20Opcode%202%20Identify.) section even says that we should only wait a random amount of time before identifying, and doesn't mention reconnecting.

This inconsistency was introduced by #1373 (a user-made rewording/formatting cleanup of this page).

On our bot, we are always reidentifying/resuming over the existing gateway connection without any issue.
I've also looked at Eris, which also [reidentify over the existing connection](https://github.com/abalabahaha/eris/blob/dev/lib/gateway/Shard.js#L413-L419).

Therefore I believe that reconnecting is actually not necessary. The wording I'm removing has likely been added by error in the aforementioned PR.