### PR TITLE
resume_gateway_url changelog

### DIFF
--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -1,5 +1,7 @@
 # Change Log
+
 ## Zone-specific Gateway Resume URLs
+
 #### Aug 9, 2022
 
 > warn

--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -1,4 +1,13 @@
 # Change Log
+## Zone-specific Gateway Resume URLs
+#### Aug 9, 2022
+
+> warn
+> Starting on **October 3, 2022**, apps that aren’t using the new `resume_gateway_url` field to resume gateway sessions will be disconnected significantly faster than normal.
+
+A new `resume_gateway_url` field has been added to the Ready gateway event to support zone-specific gateway connections. The value of `resume_gateway_url` is a zone-specific URL that should be used when resuming the gateway session after disconnects. Previously, `wss://gateway.discord.gg` was used to connect *and* resume sessions, but should now only be used during the connection.
+
+At the moment, the value of `resume_gateway_url` will always be `wss://gateway.discord.gg` to give developers more time to adopt the new field. In the near future, the value will change to the zone-specific URLs.
 
 ## Upcoming Permissions Change to Webhook Routes
 

--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -1,15 +1,15 @@
 # Change Log
 
-## Zone-specific Gateway Resume URLs
+## Session-specific Gateway Resume URLs
 
 #### Aug 9, 2022
 
 > warn
-> Starting on **October 3, 2022**, apps that aren’t using the new `resume_gateway_url` field to resume gateway sessions will be disconnected significantly faster than normal.
+> Starting on **September 12, 2022**, apps that aren’t using the new `resume_gateway_url` field to resume gateway sessions will be disconnected significantly faster than normal.
 
-A new `resume_gateway_url` field has been added to the Ready gateway event to support zone-specific gateway connections. The value of `resume_gateway_url` is a zone-specific URL that should be used when resuming the gateway session after disconnects. Previously, `wss://gateway.discord.gg` was used to connect *and* resume sessions, but should now only be used during the connection.
+A new `resume_gateway_url` field has been added to the Ready gateway event to support session-specific gateway connections. The value of `resume_gateway_url` is a session-specific URL that should be used when resuming the gateway session after a disconnect. Previously, `wss://gateway.discord.gg` was used to connect *and* resume sessions, but should now only be used during the connection.
 
-At the moment, the value of `resume_gateway_url` will always be `wss://gateway.discord.gg` to give developers more time to adopt the new field. In the near future, the value will change to the zone-specific URLs.
+At the moment, the value of `resume_gateway_url` will always be `wss://gateway.discord.gg` to give developers more time to adopt the new field. In the near future, the value will change to the session-specific URLs.
 
 ## Upcoming Permissions Change to Webhook Routes
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -789,7 +789,7 @@ The ready event is dispatched when a client has completed the initial handshake 
 
 | Field              | Type                                                                                 | Description                                                                                                   |
 | ------------------ | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| v i                | integer                                                                              | [API version](#DOCS_REFERENCE/api-versioning-api-versions)                                                   |
+| v                  | integer                                                                              | [API version](#DOCS_REFERENCE/api-versioning-api-versions)                                                    |
 | user               | [user](#DOCS_RESOURCES_USER/user-object) object                                      | information about the user including email                                                                    |
 | guilds             | array of [Unavailable Guild](#DOCS_RESOURCES_GUILD/unavailable-guild-object) objects | the guilds the user is in                                                                                     |
 | session_id         | string                                                                               | used for resuming connections                                                                                 |

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -171,7 +171,7 @@ If the payload is valid, the gateway will respond with a [Ready](#DOCS_TOPICS_GA
 
 The Internet is a scary place. Disconnections happen, especially with persistent connections. Due to Discord's architecture, this is a semi-regular event and should be expected and handled. Discord has a process for "resuming" (or reconnecting) a connection that allows the client to replay any lost events from the last sequence number they received in the exact same way they would receive them normally.
 
-Your client should store the `session_id` and `resume_gateway_url` from the [Ready](#DOCS_TOPICS_GATEWAY/ready), and the sequence number of the last event it received. When your client detects that it has been disconnected, it should completely close the connection and open a new one (following the same strategy as [Connecting](#DOCS_TOPICS_GATEWAY/connecting)). Once the new connection has been opened, the client should send a [Gateway Resume](#DOCS_TOPICS_GATEWAY/resume) to the `resume_gateway_url`:
+Your client should store the `session_id` and `resume_gateway_url` from the [Ready](#DOCS_TOPICS_GATEWAY/ready), and the sequence number of the last event it received. When your client detects that it has been disconnected, it should completely close the connection and open a new one (following the same strategy as [Connecting](#DOCS_TOPICS_GATEWAY/connecting)) to `resume_gateway_url`. Once the new connection has been opened, the client should send a [Gateway Resume](#DOCS_TOPICS_GATEWAY/resume):
 
 ###### Example Gateway Resume
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -188,7 +188,7 @@ Your client should store the `session_id` and `resume_gateway_url` from the [Rea
 
 If successful, the gateway will respond by replaying all missed events in order, finishing with a [Resumed](#DOCS_TOPICS_GATEWAY/resumed) event to signal replay has finished, and all subsequent events are new. It's also possible that your client cannot reconnect in time to resume, in which case the client will receive a [Opcode 9 Invalid Session](#DOCS_TOPICS_GATEWAY/invalid-session) and is expected to wait a random amount of time—between 1 and 5 seconds—then send a fresh [Opcode 2 Identify](#DOCS_TOPICS_GATEWAY/identify).
 
-Failure to respect the `resume_gateway_url` may result in your session being forced to reconnect again after a short period of time.
+Failure to respect the `resume_gateway_url` may result in your client being forced to reconnect again after a short period of time.
 
 ### Disconnections
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -171,7 +171,7 @@ If the payload is valid, the gateway will respond with a [Ready](#DOCS_TOPICS_GA
 
 The Internet is a scary place. Disconnections happen, especially with persistent connections. Due to Discord's architecture, this is a semi-regular event and should be expected and handled. Discord has a process for "resuming" (or reconnecting) a connection that allows the client to replay any lost events from the last sequence number they received in the exact same way they would receive them normally.
 
-Your client should store the `session_id` from the [Ready](#DOCS_TOPICS_GATEWAY/ready), and the sequence number of the last event it received. When your client detects that it has been disconnected, it should completely close the connection and open a new one (following the same strategy as [Connecting](#DOCS_TOPICS_GATEWAY/connecting)). Once the new connection has been opened, the client should send a [Gateway Resume](#DOCS_TOPICS_GATEWAY/resume):
+Your client should store the `session_id` and `resume_gateway_url` from the [Ready](#DOCS_TOPICS_GATEWAY/ready), and the sequence number of the last event it received. When your client detects that it has been disconnected, it should completely close the connection and open a new one (following the same strategy as [Connecting](#DOCS_TOPICS_GATEWAY/connecting)). Once the new connection has been opened, the client should send a [Gateway Resume](#DOCS_TOPICS_GATEWAY/resume) to the `resume_gateway_url`:
 
 ###### Example Gateway Resume
 
@@ -187,6 +187,8 @@ Your client should store the `session_id` from the [Ready](#DOCS_TOPICS_GATEWAY/
 ```
 
 If successful, the gateway will respond by replaying all missed events in order, finishing with a [Resumed](#DOCS_TOPICS_GATEWAY/resumed) event to signal replay has finished, and all subsequent events are new. It's also possible that your client cannot reconnect in time to resume, in which case the client will receive a [Opcode 9 Invalid Session](#DOCS_TOPICS_GATEWAY/invalid-session) and is expected to wait a random amount of time—between 1 and 5 seconds—then send a fresh [Opcode 2 Identify](#DOCS_TOPICS_GATEWAY/identify).
+
+Failure to respect the `resume_gateway_url` may result in your session being forced to reconnect again after a short period of time.
 
 ### Disconnections
 
@@ -785,14 +787,15 @@ The ready event is dispatched when a client has completed the initial handshake 
 
 ###### Ready Event Fields
 
-| Field       | Type                                                                                 | Description                                                                                                   |
-| ----------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| v           | integer                                                                              | [API version](#DOCS_REFERENCE/api-versioning-api-versions)                                                   |
-| user        | [user](#DOCS_RESOURCES_USER/user-object) object                                      | information about the user including email                                                                    |
-| guilds      | array of [Unavailable Guild](#DOCS_RESOURCES_GUILD/unavailable-guild-object) objects | the guilds the user is in                                                                                     |
-| session_id  | string                                                                               | used for resuming connections                                                                                 |
-| shard?      | array of two integers (shard_id, num_shards)                                         | the [shard information](#DOCS_TOPICS_GATEWAY/sharding) associated with this session, if sent when identifying |
-| application | partial [application object](#DOCS_RESOURCES_APPLICATION/application-object)         | contains `id` and `flags`                                                                                     |
+| Field              | Type                                                                                 | Description                                                                                                   |
+| ------------------ | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| v i                | integer                                                                              | [API version](#DOCS_REFERENCE/api-versioning-api-versions)                                                   |
+| user               | [user](#DOCS_RESOURCES_USER/user-object) object                                      | information about the user including email                                                                    |
+| guilds             | array of [Unavailable Guild](#DOCS_RESOURCES_GUILD/unavailable-guild-object) objects | the guilds the user is in                                                                                     |
+| session_id         | string                                                                               | used for resuming connections                                                                                 |
+| resume_gateway_url | string                                                                               | gateway url for resuming connections                                                                          |
+| shard?             | array of two integers (shard_id, num_shards)                                         | the [shard information](#DOCS_TOPICS_GATEWAY/sharding) associated with this session, if sent when identifying |
+| application        | partial [application object](#DOCS_RESOURCES_APPLICATION/application-object)         | contains `id` and `flags`                                                                                     |
 
 #### Resumed
 


### PR DESCRIPTION
Builds off of #5282 to include a changelog for `resume_gateway_url`