### PR TITLE
Revert "fix automod message content wording"

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -880,7 +880,7 @@ Sent when a rule is triggered and an action is executed (e.g. when a message is 
 
 \*\* `alert_system_message_id` will not exist if this event does not correspond to an action with type `SEND_ALERT_MESSAGE`
 
-\*\*\* `MESSAGE_CONTENT` (`1 << 15`) [gateway intent](#DOCS_TOPICS_GATEWAY/gateway-intents) is required to receive the `content` and `matched_content` fields
+\*\*\* `MESSAGE_CONTENT` (`1 << 15`) [gateway intent](#DOCS_TOPICS_GATEWAY/gateway-intents) is required to receive non-empty values for the `content` and `matched_content` fields
 
 ### Channels
 


### PR DESCRIPTION
This reverts commit a003d94dbd21af355703b4b3456e6fe09ff3e3dd.

Continued continuation of https://github.com/discord/discord-api-docs/pull/5242 and https://github.com/discord/discord-api-docs/issues/5241

These keys are always provided, but for a period were not provided. This re-specifies they are always provided.