### PR TITLE
Use question marks instead of 'Required' column

### DIFF
--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -179,11 +179,11 @@ Returns a list of partial [guild](#DOCS_RESOURCES_GUILD/guild-object) objects th
 
 ###### Query String Params
 
-| Field  | Type      | Description                            | Required | Default |
-| ------ | --------- | -------------------------------------- | -------- | ------- |
-| before | snowflake | get guilds before this guild ID        | false    | absent  |
-| after  | snowflake | get guilds after this guild ID         | false    | absent  |
-| limit  | integer   | max number of guilds to return (1-200) | false    | 200     |
+| Field   | Type      | Description                            | Default |
+| ------- | --------- | -------------------------------------- | ------- |
+| before? | snowflake | get guilds before this guild ID        | absent  |
+| after?  | snowflake | get guilds after this guild ID         | absent  |
+| limit?  | integer   | max number of guilds to return (1-200) | 200     |
 
 ## Get Current User Guild Member % GET /users/@me/guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/member
 


### PR DESCRIPTION
Get 'Current User Guilds' > 'Query String Params' uses a 'Required' column instead of marking optional fields with a question mark like the rest of the docs.