### PR TITLE
Document how i18n interacts with the character limit

### DIFF
--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -390,7 +390,7 @@ Slash commands—the `CHAT_INPUT` type—are a type of application command. They
 Slash commands can also have groups and subcommands to further organize commands. More on those later.
 
 > warn
-> Slash commands can have a maximum of 4,000 characters for combined name, description, and value properties for each command, its subcommands and groups. When localization fields are set, only the longest string of the category counts towards this limit.
+> Slash commands can have a maximum of 4,000 characters for combined name, description, and value properties for each command, its subcommands and groups. When [localization fields](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/localization) are set, only the longest string of the category counts towards this limit.
 
 
 ###### Example Slash Command

--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -390,7 +390,7 @@ Slash commands—the `CHAT_INPUT` type—are a type of application command. They
 Slash commands can also have groups and subcommands to further organize commands. More on those later.
 
 > warn
-> Slash commands can have a maximum of 4000 characters for combined name, description, and value properties for each command and its subcommands and groups
+> Slash commands can have a maximum of 4,000 characters for combined name, description, and value properties for each command, its subcommands and groups. When localization fields are set, only the longest string of the category counts towards this limit.
 
 
 ###### Example Slash Command


### PR DESCRIPTION
Adds a mention of how only the longest string counts towards the 4k command character limit when localized strings are present