### PR TITLE
Update generic bug report link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -13,8 +13,8 @@ contact_links:
     url: https://feedback.discord.com
     about: Have feedback that isn't related to the API? Head over to Discord's feedback website.
   - name: Discord Bug Reports
-    url: https://discord.gg/discord-testers
-    about: Have bugs that aren't related to the API? Head over to the Discord Testers server.
+    url: https://dis.gd/bugreport
+    about: Have bugs that aren't related to the API? Submit a ticket to Discord's support team.
   - name: Discord Support
     url: https://dis.gd/contact
     about: Need something else? Submit a ticket to Discord's support team.


### PR DESCRIPTION
[discord.gg/discord-testers](discord.gg/discord-testers) was archived and the new one is no longer public. Bug reports are now reported on [support.discord.com](https://dis.gd/contact).