### PR TITLE
Replace dtesters with the bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -13,8 +13,8 @@ contact_links:
     url: https://feedback.discord.com
     about: Have feedback that isn't related to the API? Head over to Discord's feedback website.
   - name: Discord Bug Reports
-    url: https://discord.gg/discord-testers
-    about: Have bugs that aren't related to the API? Head over to the Discord Testers server.
+    url: https://dis.gd/bugreport
+    about: Have bugs that aren't related to the API? Head over to the Discord's bugreport form.
   - name: Discord Support
     url: https://dis.gd/contact
     about: Need something else? Submit a ticket to Discord's support team.


### PR DESCRIPTION
As the Discord Testers is closed for a good while now, the bug report form became the official way to report bugs to Discord that are not related to the api. This pull request replaces the link in the issue templates accordingly.