### PR TITLE
Component only messages

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -934,7 +934,7 @@ Files must be attached using a `multipart/form-data` body as described in [Uploa
 ###### JSON/Form Params
 
 > info
-> When creating a message, apps must provide a value for **at least one of** `content`, `embeds`, `sticker_ids`, or `files[n]`.
+> When creating a message, apps must provide a value for **at least one of** `content`, `embeds`, `sticker_ids`, `components`, or `files[n]`.
 
 | Field              | Type                                                                                              | Description                                                                                                                                                                 |
 | ------------------ | ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -943,14 +943,14 @@ Files must be attached using a `multipart/form-data` body as described in [Uploa
 | embeds?\*          | array of [embed](#DOCS_RESOURCES_CHANNEL/embed-object) objects                                    | Embedded `rich` content (up to 6000 characters)                                                                                                                             |
 | allowed_mentions?  | [allowed mention object](#DOCS_RESOURCES_CHANNEL/allowed-mentions-object)                         | Allowed mentions for the message                                                                                                                                            |
 | message_reference? | [message reference](#DOCS_RESOURCES_CHANNEL/message-reference-object-message-reference-structure) | Include to make your message a reply                                                                                                                                        |
-| components?        | array of [message component](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/component-object) objects      | Components to include with the message                                                                                                                                      |
+| components?\*      | array of [message component](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/component-object) objects      | Components to include with the message                                                                                                                                      |
 | sticker_ids?\*     | array of snowflakes                                                                               | IDs of up to 3 [stickers](#DOCS_RESOURCES_STICKER/sticker-object) in the server to send in the message                                                                      |
 | files[n]?\*        | file contents                                                                                     | Contents of the file being sent. See [Uploading Files](#DOCS_REFERENCE/uploading-files)                                                                                     |
 | payload_json?      | string                                                                                            | JSON-encoded body of non-file params, only for `multipart/form-data` requests. See [Uploading Files](#DOCS_REFERENCE/uploading-files)                                       |
 | attachments?       | array of partial [attachment](#DOCS_RESOURCES_CHANNEL/attachment-object) objects                  | Attachment objects with filename and description. See [Uploading Files](#DOCS_REFERENCE/uploading-files)                                                                    |
 | flags?             | integer                                                                                           | [Message flags](#DOCS_RESOURCES_CHANNEL/message-object-message-flags) combined as a [bitfield](https://en.wikipedia.org/wiki/Bit_field) (only `SUPPRESS_EMBEDS` can be set) |
 
-\* At least one of `content`, `embeds`, `sticker_ids`, or `files[n]` is required.
+\* At least one of `content`, `embeds`, `sticker_ids`, `components`, or `files[n]` is required.
 
 ###### Example Request Body (application/json)
 

--- a/docs/resources/Webhook.md
+++ b/docs/resources/Webhook.md
@@ -169,7 +169,7 @@ Same as above, except this call does not require authentication.
 Refer to [Uploading Files](#DOCS_REFERENCE/uploading-files) for details on attachments and `multipart/form-data` requests. Returns a message or `204 No Content` depending on the `wait` query parameter.
 
 > info
-> Note that when sending a message, you must provide a value for at **least one of** `content`, `embeds`, or `file`.
+> Note that when sending a message, you must provide a value for at **least one of** `content`, `embeds`, `components`, or `file`.
 
 > info
 > If the webhook channel is a forum channel, you must provide either `thread_id` in the query string params, or `thread_name` in the JSON/form params. If `thread_id` is provided, the message will send in that thread. If `thread_name` is provided, a thread with that name will be created in the forum channel.


### PR DESCRIPTION
You can now send component-only messages:

![image](https://user-images.githubusercontent.com/18090140/188483132-f9d3e283-76d4-44e1-94f0-6709feed9432.png)
