### PR TITLE
docs: some small wording changes to the Gateway document

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -104,7 +104,7 @@ When connecting to the URL, it's a good idea to explicitly pass the [API Version
 
 #### Hello Event
 
-Once connected to the Gateway, your app will receive a [Hello (opcode `10`)](#DOCS_TOPICS_GATEWAY/hello-event) event that contains your connection's heartbeat interval (`hearbeat_interval`).
+Once connected to the Gateway, your app will receive a [Hello (opcode `10`)](#DOCS_TOPICS_GATEWAY/hello-event) event that contains your connection's heartbeat interval (`heartbeat_interval`).
 
 The heartbeat interval indicates a length of time in milliseconds that you should use to determine how often you app needs to send a Heartbeat event in order to maintain the active connection. Heartbeating is detailed in the [Sending Heartbeats](#DOCS_TOPICS_GATEWAY/sending-heartbeats) section.
 
@@ -166,7 +166,7 @@ Apps have a limited amount of `IDENTIFY` calls they can do in a 24-hour period, 
 > warn
 > Upon hitting this limit, all active sessions for the app will be terminated, the bot token will be reset, and the owner will receive an email and in-app notification. It's up to the owner to update their application with the new token.
 
-Alongside that, apps have a maximum concurrency which dictates how many shards they can `IDENTIFY` every 5 seconds. You can see that fron the `max_concurrency` property in the [session start limit object](#DOCS_TOPICS_GATEWAY/session-start-limit-object). If your app exceeds this limit, Discord will respond with a [Invalid Session (opcode `9`)](#DOCS_TOPICS_GATEWAY_EVENTS/invalid-session) event.
+Alongside that, apps have a maximum concurrency which dictates how many shards they can `IDENTIFY` every 5 seconds. You can see that from the `max_concurrency` property in the [session start limit object](#DOCS_TOPICS_GATEWAY/session-start-limit-object). If your app exceeds this limit, Discord will respond with a [Invalid Session (opcode `9`)](#DOCS_TOPICS_GATEWAY_EVENTS/invalid-session) event.
 
 After your app sends a valid Identify payload, Discord will respond with a [Ready](#DOCS_TOPICS_GATEWAY_EVENTS/ready) event which indicates that your app is in a successfully-connected state with the Gateway. The Ready event is sent as a standard [Dispatch (opcode `0`)](#DOCS_TOPICS_OPCODES_AND_STATUS_CODES/gateway-gateway-opcodes).
 
@@ -271,7 +271,7 @@ Intents are bitwise values passed in the `intents` parameter when [Identifying](
 
 Two types of intents exist:
 - **Standard intents** can be passed by default. You don't need any additional permissions or configurations.
-- [**Priviledged intents**](#DOCS_TOPICS_GATEWAY/privileged-intents) require you to toggle the intent for your app in your app's settings within the Developer Portal before passing said intent. For verified apps (required for apps in 100+ guilds), the intent must also be approved after the verification process to use the intent. More information about privileged intents can be found [in the section below](#DOCS_TOPICS_GATEWAY/privileged-intents).
+- [**Privileged intents**](#DOCS_TOPICS_GATEWAY/privileged-intents) require you to toggle the intent for your app in your app's settings within the Developer Portal before passing said intent. For verified apps (required for apps in 100+ guilds), the intent must also be approved after the verification process to use the intent. More information about privileged intents can be found [in the section below](#DOCS_TOPICS_GATEWAY/privileged-intents).
 
 The connection with your app will be closed if it passes invalid intents ([`4013` close code](#DOCS_TOPICS_OPCODES_AND_STATUS_CODES/gateway-gateway-close-event-codes)), or a privileged intent that hasn't been configured or approved for your app ([`4014` close code](#DOCS_TOPICS_OPCODES_AND_STATUS_CODES/gateway-gateway-close-event-codes)).
 
@@ -415,7 +415,7 @@ Before you specify privileged intents in your `IDENTIFY` payload, you must enabl
 
 In addition to the gateway restrictions described here, Discord's REST API is also affected by Privileged Intents. For example, to use the [List Guild Members](#DOCS_RESOURCES_GUILD/list-guild-members) endpoint, you must have the `GUILD_MEMBERS` intent enabled for your application. This behavior is independent of whether the intent is set during `IDENTIFY`.
 
-#### Enabling Priviledged Intents
+#### Enabling Privileged Intents
 
 Before using privileged intents, you must enable them in your app's settings. In the [Developer Portal](#APPLICATIONS), you can navigate to your app's settings then toggle the privileged intents on the **Bots** page under the "Privileged Gateway Intents" section. You should only toggle privileged intents that your bot *requires to function*.
 
@@ -423,7 +423,7 @@ If your app qualifies for [verification](https://dis.gd/bot-verification), you m
 
 #### Gateway Restrictions
 
-Priviledged intents affect which Gateway events your app is permitted to receive. When using **API v8** and above, all intents (privileged and not) must be specified in the `intents` parameter when Identifying. If you pass a privileged intent in the `intents` parameter without configuring it in your app's settings, or being approved for it during verification, your Gateway connection will be closed with a ([`4014` close code](#DOCS_TOPICS_OPCODES_AND_STATUS_CODES/gateway-gateway-close-event-codes)).
+Privileged intents affect which Gateway events your app is permitted to receive. When using **API v8** and above, all intents (privileged and not) must be specified in the `intents` parameter when Identifying. If you pass a privileged intent in the `intents` parameter without configuring it in your app's settings, or being approved for it during verification, your Gateway connection will be closed with a ([`4014` close code](#DOCS_TOPICS_OPCODES_AND_STATUS_CODES/gateway-gateway-close-event-codes)).
 
 > info
 > For **API v6**, you will receive events associated with the privileged intents your app has configured and is authorized to receive *without* passing those intents into the `intents` parameter when Identifying.

--- a/docs/topics/Gateway_Events.md
+++ b/docs/topics/Gateway_Events.md
@@ -219,7 +219,7 @@ Details about resuming are in the [Gateway documentation](#DOCS_TOPICS_GATEWAY/r
 
 #### Heartbeat
 
-Used to maintain an active gateway connection. Must be sent every `heartbeat_interval` milliseconds after the [Opcode 10 Hello](#DOCS_TOPICS_GATEWAY_EVENTS/hello) payload is received. The inner `d` key is the last sequence number—`s`—received by the client. If you have not yet received one, send `null`.
+Used to maintain an active gateway connection. Must be sent every `heartbeat_interval` milliseconds after the [Opcode 10 Hello](#DOCS_TOPICS_GATEWAY_EVENTS/hello) payload is received. The inner `d` key is the last sequence number — `s` — received by the client. If you have not yet received one, send `null`.
 
 Details about heartbeats are in the [Gateway documentation](#DOCS_TOPICS_GATEWAY/sending-heartbeats).
 
@@ -239,7 +239,7 @@ Used to request all members for a guild or a list of guilds. When initially conn
 Due to our privacy and infrastructural concerns with this feature, there are some limitations that apply:
 
 - `GUILD_PRESENCES` intent is required to set `presences = true`. Otherwise, it will always be false
-- `GUILD_MEMBERS` intent is required to request the entire member list—`(query=‘’, limit=0<=n)`
+- `GUILD_MEMBERS` intent is required to request the entire member list — `(query=‘’, limit=0<=n)`
 - You will be limited to requesting 1 `guild_id` per request
 - Requesting a prefix (`query` parameter) will return a maximum of 100 members
 - Requesting `user_ids` will continue to be limited to returning 100 members
@@ -277,12 +277,12 @@ Sent when a client wants to join, move, or disconnect from a voice channel.
 
 ###### Gateway Voice State Update Structure
 
-| Field      | Type       | Description                                                          |
-| ---------- | ---------- | -------------------------------------------------------------------- |
-| guild_id   | snowflake  | ID of the guild                                                      |
-| channel_id | ?snowflake | ID of the voice channel client wants to join (null if disconnecting) |
-| self_mute  | boolean    | Whether the client is muted                                          |
-| self_deaf  | boolean    | Whether the client deafened                                          |
+| Field      | Type       | Description                                                            |
+| ---------- | ---------- | ---------------------------------------------------------------------- |
+| guild_id   | snowflake  | ID of the guild                                                        |
+| channel_id | ?snowflake | ID of the voice channel client wants to join (`null` if disconnecting) |
+| self_mute  | boolean    | Whether the client is muted                                            |
+| self_deaf  | boolean    | Whether the client deafened                                            |
 
 ###### Example Gateway Voice State Update
 


### PR DESCRIPTION
I'd love some input for the `Identifying` section - the maximum concurrency is mentioned 3 times in the document: once in `Identifying`, once in `Rate Limits` and once in its own section `Max concurrency`. What would be the ideal move to hopefully remove some of this duplication (or at least move it closer so you don't skip half the page to read about it)? 😅 