### PR TITLE
Update v10 changelog for historical accuracy

### DIFF
--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -204,6 +204,7 @@ The `GET /guilds/{guild.id}/bans` endpoint has been migrated to require paginati
 - Message routes (like [`POST /channels/{channel.id}/messages`](#DOCS_RESOURCES_CHANNEL/create-message)) now use the `embeds` field (an array of embed objects) instead of `embed`.
 - The `summary` field for [applications](#DOCS_RESOURCES_APPLICATION) now returns an empty string for all API versions.
 - The `name` and `description` fields for [Achievements](#DOCS_GAME_SDK_ACHIEVEMENTS/data-models-achievement-struct) are now strings, and localization info is now passed in new `name_localizations` and `description_localizations` dictionaries. This change standardizes localization to match [Application Commands](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/localization). Read details in the [Achievements documentation](#DOCS_GAME_SDK_ACHIEVEMENTS/data-models-achievement-struct).
+- Existing attachments must be specified when [`PATCH`ing messages with new attachments](#DOCS_REFERENCE/editing-message-attachments). Any attachments not specified will be removed and replaced with the specified list
 - Requests to v10 and higher will no longer be supported on `discordapp.com` (this does **not** affect `cdn.discordapp.com`)
 
 #### Upcoming changes


### PR DESCRIPTION
This has already been documented since before [v10 went live](https://github.com/discord/discord-api-docs/pull/4927/files#diff-9c0465597400a1bfff16968024a03ed3e42f9f35b43b9d4419bb0156d47ff9d2R362) and was included in the [v10 announcement](https://github.com/discord/discord-api-docs/discussions/4510), but wanted to explicitly include this in the changelog so that it's historically accurate about v10 changes.