### PR TITLE
Update Forums and Thread Syncing docs

### DIFF
--- a/docs/topics/Threads.md
+++ b/docs/topics/Threads.md
@@ -4,6 +4,9 @@
 
 Threads have been designed to be very similar to [channel](#DOCS_RESOURCES_CHANNEL/channel-object) objects, and this topic aggregates all of the information about threads, which should all help to make migrating very straightforward.
 
+> warn
+> Threads are only available in API v9 and above. More information can be found in the [backwards compatibility](#DOCS_TOPICS_THREADS/backwards-compatibility) section.
+
 ## Thread Fields
 
 Since threads are a new [type of channel](#DOCS_RESOURCES_CHANNEL/channel-object-channel-types), they share and re-purpose a number of the existing fields on a [channel](#DOCS_RESOURCES_CHANNEL/channel-object) object:


### PR DESCRIPTION
- Split up Forum docs into sections—I think it should actually move onto its own page eventually, but that can come later.
- Split up the syncing/unsyncing. It was a little hard to quickly parse, so I tried to split up into different parts and change the language to be more specific to apps.
- Also _slightly_  reorganized the Threads page (I think compatibility and syncing details can go to the bottom, basically). I want to do a larger pass at this at some point, but not nowww