### PR TITLE
Remove outdated notice of interaction @everyone mention permissions

### DIFF
--- a/docs/interactions/Receiving_and_Responding.md
+++ b/docs/interactions/Receiving_and_Responding.md
@@ -255,7 +255,7 @@ Not all message fields are currently supported.
 | components | array of [components](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/) | between 1 and 5 (inclusive) components that make up the modal        |
 
 > warn
-> If your application responds with user data, you should use [`allowed_mentions`](#DOCS_RESOURCES_CHANNEL/allowed-mentions-object) to filter which mentions in the content actually ping. As interaction responses are a special form of webhooks, they offer the ability to send named links in the message content (`[text](url)`).
+> If your application responds with user data, you should use [`allowed_mentions`](#DOCS_RESOURCES_CHANNEL/allowed-mentions-object) to filter which mentions in the content actually ping.
 
 When responding to an interaction received **via webhook**, your server can simply respond to the received `POST` request. You'll want to respond with a `200` status code (if everything went well), as well as specifying a `type` and `data`, which is an [Interaction Response](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-response-object) object:
 

--- a/docs/interactions/Receiving_and_Responding.md
+++ b/docs/interactions/Receiving_and_Responding.md
@@ -255,7 +255,7 @@ Not all message fields are currently supported.
 | components | array of [components](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/) | between 1 and 5 (inclusive) components that make up the modal        |
 
 > warn
-> While interaction responses and followups are webhooks, they respect @everyone's ability to ping @everyone / @here . Nonetheless if your application responds with user data, you should still use [`allowed_mentions`](#DOCS_RESOURCES_CHANNEL/allowed-mentions-object) to filter which mentions in the content actually ping. Other differences include the ability to send named links in the message content (`[text](url)`).
+> If your application responds with user data, you should use [`allowed_mentions`](#DOCS_RESOURCES_CHANNEL/allowed-mentions-object) to filter which mentions in the content actually ping. As interaction responses are a special form of webhooks, they offer the ability to send named links in the message content (`[text](url)`).
 
 When responding to an interaction received **via webhook**, your server can simply respond to the received `POST` request. You'll want to respond with a `200` status code (if everything went well), as well as specifying a `type` and `data`, which is an [Interaction Response](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-response-object) object:
 


### PR DESCRIPTION
As of some time ago, interaction responses use the bot's permissions for everyone mentions.

Honestly though I'm not sure if that warning box should even stay where it currently is. Right now at first sight it appears as if it's referring to table above it, and then below that it suddenly talks about responding to an interaction, unrelated to modals. There should probably be some divider, or the tables moved to the bottom of the section, or something else.

![](https://im-a-dolphin.de/s/42ba0fb.png)