### PR TITLE
add role name limits

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -9,49 +9,49 @@ Guilds in Discord represent an isolated collection of users and channels, and ar
 > info
 > Fields specific to the `GUILD_CREATE` event are listed in the [Gateway Events documentation](#DOCS_TOPICS_GATEWAY_EVENTS/guild-create).
 
-| Field                         | Type                                                                                                         | Description                                                                                                                                                            |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| id                            | snowflake                                                                                                    | guild id                                                                                                                                                               |
-| name                          | string                                                                                                       | guild name (2-100 characters, excluding trailing and leading whitespace)                                                                                               |
-| icon                          | ?string                                                                                                      | [icon hash](#DOCS_REFERENCE/image-formatting)                                                                                                                          |
-| icon_hash?                    | ?string                                                                                                      | [icon hash](#DOCS_REFERENCE/image-formatting), returned when in the template object                                                                                    |
-| splash                        | ?string                                                                                                      | [splash hash](#DOCS_REFERENCE/image-formatting)                                                                                                                        |
-| discovery_splash              | ?string                                                                                                      | [discovery splash hash](#DOCS_REFERENCE/image-formatting); only present for guilds with the "DISCOVERABLE" feature                                                     |
-| owner? \*                     | boolean                                                                                                      | true if [the user](#DOCS_RESOURCES_USER/get-current-user-guilds) is the owner of the guild                                                                             |
-| owner_id                      | snowflake                                                                                                    | id of owner                                                                                                                                                            |
-| permissions? \*               | string                                                                                                       | total permissions for [the user](#DOCS_RESOURCES_USER/get-current-user-guilds) in the guild (excludes overwrites)                                                      |
-| region? \*\*                  | ?string                                                                                                      | [voice region](#DOCS_RESOURCES_VOICE/voice-region-object) id for the guild (deprecated)                                                                                |
-| afk_channel_id                | ?snowflake                                                                                                   | id of afk channel                                                                                                                                                      |
-| afk_timeout                   | integer                                                                                                      | afk timeout in seconds, can be set to: 60, 300, 900, 1800, 3600                                                                                                        |
-| widget_enabled?               | boolean                                                                                                      | true if the server widget is enabled                                                                                                                                   |
-| widget_channel_id?            | ?snowflake                                                                                                   | the channel id that the widget will generate an invite to, or `null` if set to no invite                                                                               |
-| verification_level            | integer                                                                                                      | [verification level](#DOCS_RESOURCES_GUILD/guild-object-verification-level) required for the guild                                                                     |
-| default_message_notifications | integer                                                                                                      | default [message notifications level](#DOCS_RESOURCES_GUILD/guild-object-default-message-notification-level)                                                           |
-| explicit_content_filter       | integer                                                                                                      | [explicit content filter level](#DOCS_RESOURCES_GUILD/guild-object-explicit-content-filter-level)                                                                      |
-| roles                         | array of [role](#DOCS_TOPICS_PERMISSIONS/role-object) objects                                                | roles in the guild                                                                                                                                                     |
-| emojis                        | array of [emoji](#DOCS_RESOURCES_EMOJI/emoji-object) objects                                                 | custom guild emojis                                                                                                                                                    |
-| features                      | array of [guild feature](#DOCS_RESOURCES_GUILD/guild-object-guild-features) strings                          | enabled guild features                                                                                                                                                 |
-| mfa_level                     | integer                                                                                                      | required [MFA level](#DOCS_RESOURCES_GUILD/guild-object-mfa-level) for the guild                                                                                       |
-| application_id                | ?snowflake                                                                                                   | application id of the guild creator if it is bot-created                                                                                                               |
-| system_channel_id             | ?snowflake                                                                                                   | the id of the channel where guild notices such as welcome messages and boost events are posted                                                                         |
-| system_channel_flags          | integer                                                                                                      | [system channel flags](#DOCS_RESOURCES_GUILD/guild-object-system-channel-flags)                                                                                        |
-| rules_channel_id              | ?snowflake                                                                                                   | the id of the channel where Community guilds can display rules and/or guidelines                                                                                       |
-| max_presences?                | ?integer                                                                                                     | the maximum number of presences for the guild (`null` is always returned, apart from the largest of guilds)                                                            |
-| max_members?                  | integer                                                                                                      | the maximum number of members for the guild                                                                                                                            |
-| vanity_url_code               | ?string                                                                                                      | the vanity url code for the guild                                                                                                                                      |
-| description                   | ?string                                                                                                      | the description of a guild                                                                                                                                             |
-| banner                        | ?string                                                                                                      | [banner hash](#DOCS_REFERENCE/image-formatting)                                                                                                                        |
-| premium_tier                  | integer                                                                                                      | [premium tier](#DOCS_RESOURCES_GUILD/guild-object-premium-tier) (Server Boost level)                                                                                   |
-| premium_subscription_count?   | integer                                                                                                      | the number of boosts this guild currently has                                                                                                                          |
-| preferred_locale              | string                                                                                                       | the preferred [locale](#DOCS_REFERENCE/locales) of a Community guild; used in server discovery and notices from Discord, and sent in interactions; defaults to "en-US" |
-| public_updates_channel_id     | ?snowflake                                                                                                   | the id of the channel where admins and moderators of Community guilds receive notices from Discord                                                                     |
-| max_video_channel_users?      | integer                                                                                                      | the maximum amount of users in a video channel                                                                                                                         |
-| approximate_member_count?     | integer                                                                                                      | approximate number of members in this guild, returned from the `GET /guilds/<id>` endpoint when `with_counts` is `true`                                                |
-| approximate_presence_count?   | integer                                                                                                      | approximate number of non-offline members in this guild, returned from the `GET /guilds/<id>` endpoint when `with_counts` is `true`                                    |
-| welcome_screen?               | [welcome screen](#DOCS_RESOURCES_GUILD/welcome-screen-object) object                                         | the welcome screen of a Community guild, shown to new members, returned in an [Invite](#DOCS_RESOURCES_INVITE/invite-object)'s guild object                            |
-| nsfw_level                    | integer                                                                                                      | [guild NSFW level](#DOCS_RESOURCES_GUILD/guild-object-guild-nsfw-level)                                                                                                |
-| stickers?                     | array of [sticker](#DOCS_RESOURCES_STICKER/sticker-object) objects                                           | custom guild stickers                                                                                                                                                  |
-| premium_progress_bar_enabled  | boolean                                                                                                      | whether the guild has the boost progress bar enabled                                                                                                                   |
+| Field                         | Type                                                                                | Description                                                                                                                                                            |
+| ----------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| id                            | snowflake                                                                           | guild id                                                                                                                                                               |
+| name                          | string                                                                              | guild name (2-100 characters, excluding trailing and leading whitespace)                                                                                               |
+| icon                          | ?string                                                                             | [icon hash](#DOCS_REFERENCE/image-formatting)                                                                                                                          |
+| icon_hash?                    | ?string                                                                             | [icon hash](#DOCS_REFERENCE/image-formatting), returned when in the template object                                                                                    |
+| splash                        | ?string                                                                             | [splash hash](#DOCS_REFERENCE/image-formatting)                                                                                                                        |
+| discovery_splash              | ?string                                                                             | [discovery splash hash](#DOCS_REFERENCE/image-formatting); only present for guilds with the "DISCOVERABLE" feature                                                     |
+| owner? \*                     | boolean                                                                             | true if [the user](#DOCS_RESOURCES_USER/get-current-user-guilds) is the owner of the guild                                                                             |
+| owner_id                      | snowflake                                                                           | id of owner                                                                                                                                                            |
+| permissions? \*               | string                                                                              | total permissions for [the user](#DOCS_RESOURCES_USER/get-current-user-guilds) in the guild (excludes overwrites)                                                      |
+| region? \*\*                  | ?string                                                                             | [voice region](#DOCS_RESOURCES_VOICE/voice-region-object) id for the guild (deprecated)                                                                                |
+| afk_channel_id                | ?snowflake                                                                          | id of afk channel                                                                                                                                                      |
+| afk_timeout                   | integer                                                                             | afk timeout in seconds, can be set to: 60, 300, 900, 1800, 3600                                                                                                        |
+| widget_enabled?               | boolean                                                                             | true if the server widget is enabled                                                                                                                                   |
+| widget_channel_id?            | ?snowflake                                                                          | the channel id that the widget will generate an invite to, or `null` if set to no invite                                                                               |
+| verification_level            | integer                                                                             | [verification level](#DOCS_RESOURCES_GUILD/guild-object-verification-level) required for the guild                                                                     |
+| default_message_notifications | integer                                                                             | default [message notifications level](#DOCS_RESOURCES_GUILD/guild-object-default-message-notification-level)                                                           |
+| explicit_content_filter       | integer                                                                             | [explicit content filter level](#DOCS_RESOURCES_GUILD/guild-object-explicit-content-filter-level)                                                                      |
+| roles                         | array of [role](#DOCS_TOPICS_PERMISSIONS/role-object) objects                       | roles in the guild                                                                                                                                                     |
+| emojis                        | array of [emoji](#DOCS_RESOURCES_EMOJI/emoji-object) objects                        | custom guild emojis                                                                                                                                                    |
+| features                      | array of [guild feature](#DOCS_RESOURCES_GUILD/guild-object-guild-features) strings | enabled guild features                                                                                                                                                 |
+| mfa_level                     | integer                                                                             | required [MFA level](#DOCS_RESOURCES_GUILD/guild-object-mfa-level) for the guild                                                                                       |
+| application_id                | ?snowflake                                                                          | application id of the guild creator if it is bot-created                                                                                                               |
+| system_channel_id             | ?snowflake                                                                          | the id of the channel where guild notices such as welcome messages and boost events are posted                                                                         |
+| system_channel_flags          | integer                                                                             | [system channel flags](#DOCS_RESOURCES_GUILD/guild-object-system-channel-flags)                                                                                        |
+| rules_channel_id              | ?snowflake                                                                          | the id of the channel where Community guilds can display rules and/or guidelines                                                                                       |
+| max_presences?                | ?integer                                                                            | the maximum number of presences for the guild (`null` is always returned, apart from the largest of guilds)                                                            |
+| max_members?                  | integer                                                                             | the maximum number of members for the guild                                                                                                                            |
+| vanity_url_code               | ?string                                                                             | the vanity url code for the guild                                                                                                                                      |
+| description                   | ?string                                                                             | the description of a guild                                                                                                                                             |
+| banner                        | ?string                                                                             | [banner hash](#DOCS_REFERENCE/image-formatting)                                                                                                                        |
+| premium_tier                  | integer                                                                             | [premium tier](#DOCS_RESOURCES_GUILD/guild-object-premium-tier) (Server Boost level)                                                                                   |
+| premium_subscription_count?   | integer                                                                             | the number of boosts this guild currently has                                                                                                                          |
+| preferred_locale              | string                                                                              | the preferred [locale](#DOCS_REFERENCE/locales) of a Community guild; used in server discovery and notices from Discord, and sent in interactions; defaults to "en-US" |
+| public_updates_channel_id     | ?snowflake                                                                          | the id of the channel where admins and moderators of Community guilds receive notices from Discord                                                                     |
+| max_video_channel_users?      | integer                                                                             | the maximum amount of users in a video channel                                                                                                                         |
+| approximate_member_count?     | integer                                                                             | approximate number of members in this guild, returned from the `GET /guilds/<id>` endpoint when `with_counts` is `true`                                                |
+| approximate_presence_count?   | integer                                                                             | approximate number of non-offline members in this guild, returned from the `GET /guilds/<id>` endpoint when `with_counts` is `true`                                    |
+| welcome_screen?               | [welcome screen](#DOCS_RESOURCES_GUILD/welcome-screen-object) object                | the welcome screen of a Community guild, shown to new members, returned in an [Invite](#DOCS_RESOURCES_INVITE/invite-object)'s guild object                            |
+| nsfw_level                    | integer                                                                             | [guild NSFW level](#DOCS_RESOURCES_GUILD/guild-object-guild-nsfw-level)                                                                                                |
+| stickers?                     | array of [sticker](#DOCS_RESOURCES_STICKER/sticker-object) objects                  | custom guild stickers                                                                                                                                                  |
+| premium_progress_bar_enabled  | boolean                                                                             | whether the guild has the boost progress bar enabled                                                                                                                   |
 
 \* These fields are only sent when using the [GET Current User Guilds](#DOCS_RESOURCES_USER/get-current-user-guilds) endpoint and are relative to the requested user
 
@@ -91,12 +91,12 @@ Guilds in Discord represent an isolated collection of users and channels, and ar
 
 ###### Guild NSFW Level
 
-| Level          | Value   |
-| -------------- | ------- |
-| DEFAULT        | 0       |
-| EXPLICIT       | 1       |
-| SAFE           | 2       |
-| AGE_RESTRICTED | 3       |
+| Level          | Value |
+| -------------- | ----- |
+| DEFAULT        | 0     |
+| EXPLICIT       | 1     |
+| SAFE           | 2     |
+| AGE_RESTRICTED | 3     |
 
 ###### Premium Tier
 
@@ -145,11 +145,11 @@ Guilds in Discord represent an isolated collection of users and channels, and ar
 
 ###### Mutable Guild Features
 
-| Features         | Required Permissions  | Effects                                                   |
-| ---------------- | --------------------- | --------------------------------------------------------- |
-| COMMUNITY        | Administrator         | Enables Community Features in the guild                   |
-| INVITES_DISABLED | Manage Guild          | Pauses all invites/access to the server                   |
-| DISCOVERABLE     | Administrator*        | Enables discovery in the guild, making it publicly listed |
+| Features         | Required Permissions | Effects                                                   |
+| ---------------- | -------------------- | --------------------------------------------------------- |
+| COMMUNITY        | Administrator        | Enables Community Features in the guild                   |
+| INVITES_DISABLED | Manage Guild         | Pauses all invites/access to the server                   |
+| DISCOVERABLE     | Administrator*       | Enables discovery in the guild, making it publicly listed |
 
 \* Server also must be passing all discovery requirements 
 
@@ -218,19 +218,19 @@ A partial [guild](#DOCS_RESOURCES_GUILD/guild-object) object. Represents an Offl
 
 ###### Guild Preview Structure
 
-| Field                      | Type                                                                                | Description                                                 |
-| -------------------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| id                         | snowflake                                                                           | guild id                                                    |
-| name                       | string                                                                              | guild name (2-100 characters)                               |
-| icon                       | ?string                                                                             | [icon hash](#DOCS_REFERENCE/image-formatting)               |
-| splash                     | ?string                                                                             | [splash hash](#DOCS_REFERENCE/image-formatting)             |
-| discovery_splash           | ?string                                                                             | [discovery splash hash](#DOCS_REFERENCE/image-formatting)   |
-| emojis                     | array of [emoji](#DOCS_RESOURCES_EMOJI/emoji-object) objects                        | custom guild emojis                                         |
-| features                   | array of [guild feature](#DOCS_RESOURCES_GUILD/guild-object-guild-features) strings | enabled guild features                                      |
-| approximate_member_count   | integer                                                                             | approximate number of members in this guild                 |
-| approximate_presence_count | integer                                                                             | approximate number of online members in this guild          |
-| description                | ?string                                                                             | the description for the guild                               |
-| stickers                   | array of [sticker](#DOCS_RESOURCES_STICKER/sticker-object) objects                   | custom guild stickers                                      |
+| Field                      | Type                                                                                | Description                                               |
+| -------------------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| id                         | snowflake                                                                           | guild id                                                  |
+| name                       | string                                                                              | guild name (2-100 characters)                             |
+| icon                       | ?string                                                                             | [icon hash](#DOCS_REFERENCE/image-formatting)             |
+| splash                     | ?string                                                                             | [splash hash](#DOCS_REFERENCE/image-formatting)           |
+| discovery_splash           | ?string                                                                             | [discovery splash hash](#DOCS_REFERENCE/image-formatting) |
+| emojis                     | array of [emoji](#DOCS_RESOURCES_EMOJI/emoji-object) objects                        | custom guild emojis                                       |
+| features                   | array of [guild feature](#DOCS_RESOURCES_GUILD/guild-object-guild-features) strings | enabled guild features                                    |
+| approximate_member_count   | integer                                                                             | approximate number of members in this guild               |
+| approximate_presence_count | integer                                                                             | approximate number of online members in this guild        |
+| description                | ?string                                                                             | the description for the guild                             |
+| stickers                   | array of [sticker](#DOCS_RESOURCES_STICKER/sticker-object) objects                  | custom guild stickers                                     |
 
 ###### Example Guild Preview
 
@@ -282,14 +282,14 @@ A partial [guild](#DOCS_RESOURCES_GUILD/guild-object) object. Represents an Offl
 
 ###### Guild Widget Structure
 
-| Field                      | Type                                                                                | Description                                                 |
-| -------------------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| id                 | snowflake                                                                         | guild id                                                             |
-| name               | string                                                                            | guild name (2-100 characters)                                        |
-| instant_invite     | ?string                                                                           | instant invite for the guilds specified widget invite channel        |
-| channels           | array of partial [channel](#DOCS_RESOURCES_CHANNEL/channel-object) objects        | voice and stage channels which are accessible by @everyone           |
-| members            | array of partial [user](#DOCS_RESOURCES_USER/user-object) objects                 | special widget user objects that includes users presence (Limit 100) |
-| presence_count     | integer                                                                           | number of online members in this guild                               |
+| Field          | Type                                                                       | Description                                                          |
+| -------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| id             | snowflake                                                                  | guild id                                                             |
+| name           | string                                                                     | guild name (2-100 characters)                                        |
+| instant_invite | ?string                                                                    | instant invite for the guilds specified widget invite channel        |
+| channels       | array of partial [channel](#DOCS_RESOURCES_CHANNEL/channel-object) objects | voice and stage channels which are accessible by @everyone           |
+| members        | array of partial [user](#DOCS_RESOURCES_USER/user-object) objects          | special widget user objects that includes users presence (Limit 100) |
+| presence_count | integer                                                                    | number of online members in this guild                               |
 
 > warn
 > The fields `id`, `discriminator` and `avatar` are anonymized to prevent abuse.
@@ -410,13 +410,13 @@ A partial [guild](#DOCS_RESOURCES_GUILD/guild-object) object. Represents an Offl
 
 ###### Integration Application Structure
 
-| Field       | Type                                            | Description                                                            |
-| ----------- | ----------------------------------------------- | ---------------------------------------------------------------------- |
-| id          | snowflake                                       | the id of the app                                                      |
-| name        | string                                          | the name of the app                                                    |
-| icon        | ?string                                         | the [icon hash](#DOCS_REFERENCE/image-formatting) of the app           |
-| description | string                                          | the description of the app                                             |
-| bot?        | [user](#DOCS_RESOURCES_USER/user-object) object | the bot associated with this application                               |
+| Field       | Type                                            | Description                                                  |
+| ----------- | ----------------------------------------------- | ------------------------------------------------------------ |
+| id          | snowflake                                       | the id of the app                                            |
+| name        | string                                          | the name of the app                                          |
+| icon        | ?string                                         | the [icon hash](#DOCS_REFERENCE/image-formatting) of the app |
+| description | string                                          | the description of the app                                   |
+| bot?        | [user](#DOCS_RESOURCES_USER/user-object) object | the bot associated with this application                     |
 
 ### Ban Object
 
@@ -521,7 +521,7 @@ Create a new guild. Returns a [guild](#DOCS_RESOURCES_GUILD/guild-object) object
 | Field                          | Type                                                                       | Description                                                                                                 |
 | ------------------------------ | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | name                           | string                                                                     | name of the guild (2-100 characters)                                                                        |
-| region?                        | ?string                                                                    | [voice region](#DOCS_RESOURCES_VOICE/voice-region-object) id (deprecated)                                    |
+| region?                        | ?string                                                                    | [voice region](#DOCS_RESOURCES_VOICE/voice-region-object) id (deprecated)                                   |
 | icon?                          | [image data](#DOCS_REFERENCE/image-data)                                   | base64 128x128 image for the guild icon                                                                     |
 | verification_level?            | integer                                                                    | [verification level](#DOCS_RESOURCES_GUILD/guild-object-verification-level)                                 |
 | default_message_notifications? | integer                                                                    | default [message notification level](#DOCS_RESOURCES_GUILD/guild-object-default-message-notification-level) |
@@ -529,7 +529,7 @@ Create a new guild. Returns a [guild](#DOCS_RESOURCES_GUILD/guild-object) object
 | roles?                         | array of [role](#DOCS_TOPICS_PERMISSIONS/role-object) objects              | new guild roles                                                                                             |
 | channels?                      | array of partial [channel](#DOCS_RESOURCES_CHANNEL/channel-object) objects | new guild's channels                                                                                        |
 | afk_channel_id?                | snowflake                                                                  | id for afk channel                                                                                          |
-| afk_timeout?                   | integer                                                                    | afk timeout in seconds, can be set to: 60, 300, 900, 1800, 3600                                            |
+| afk_timeout?                   | integer                                                                    | afk timeout in seconds, can be set to: 60, 300, 900, 1800, 3600                                             |
 | system_channel_id?             | snowflake                                                                  | the id of the channel where guild notices such as welcome messages and boost events are posted              |
 | system_channel_flags?          | integer                                                                    | [system channel flags](#DOCS_RESOURCES_GUILD/guild-object-system-channel-flags)                             |
 
@@ -680,7 +680,7 @@ Modify a guild's settings. Requires the `MANAGE_GUILD` permission. Returns the u
 | default_message_notifications | ?integer                                                                            | default [message notification level](#DOCS_RESOURCES_GUILD/guild-object-default-message-notification-level)                                                       |
 | explicit_content_filter       | ?integer                                                                            | [explicit content filter level](#DOCS_RESOURCES_GUILD/guild-object-explicit-content-filter-level)                                                                 |
 | afk_channel_id                | ?snowflake                                                                          | id for afk channel                                                                                                                                                |
-| afk_timeout                   | integer                                                                             | afk timeout in seconds, can be set to: 60, 300, 900, 1800, 3600                                                                                                  |
+| afk_timeout                   | integer                                                                             | afk timeout in seconds, can be set to: 60, 300, 900, 1800, 3600                                                                                                   |
 | icon                          | ?[image data](#DOCS_REFERENCE/image-data)                                           | base64 1024x1024 png/jpeg/gif image for the guild icon (can be animated gif when the server has the `ANIMATED_ICON` feature)                                      |
 | owner_id                      | snowflake                                                                           | user id to transfer guild ownership to (must be owner)                                                                                                            |
 | splash                        | ?[image data](#DOCS_REFERENCE/image-data)                                           | base64 16:9 png/jpeg image for the guild splash (when the server has the `INVITE_SPLASH` feature)                                                                 |
@@ -762,10 +762,10 @@ Returns all active threads in the guild, including public and private threads. T
 
 ###### Response Body
 
-| Field    | Type                                                                            | Description                                                                                  |
-|----------|---------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-| threads  | array of [channel](#DOCS_RESOURCES_CHANNEL/channel-object) objects              | the active threads                                                                           |
-| members  | array of [thread members](#DOCS_RESOURCES_CHANNEL/thread-member-object) objects | a thread member object for each returned thread the current user has joined                  |
+| Field   | Type                                                                            | Description                                                                 |
+| ------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| threads | array of [channel](#DOCS_RESOURCES_CHANNEL/channel-object) objects              | the active threads                                                          |
+| members | array of [thread members](#DOCS_RESOURCES_CHANNEL/thread-member-object) objects | a thread member object for each returned thread the current user has joined |
 
 ## Get Guild Member % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/members/{user.id#DOCS_RESOURCES_USER/user-object}
 
@@ -839,14 +839,14 @@ Modify attributes of a [guild member](#DOCS_RESOURCES_GUILD/guild-member-object)
 
 ###### JSON Params
 
-| Field                        | Type                | Description                                                                                                                                                                                                                              | Permission       |
-| ---------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| nick                         | string              | value to set user's nickname to                                                                                                                                                                                                                                                                                                                   | MANAGE_NICKNAMES |
-| roles                        | array of snowflakes | array of role ids the member is assigned                                                                                                                                                                                                                                                                                                         | MANAGE_ROLES     |
-| mute                         | boolean             | whether the user is muted in voice channels. Will throw a 400 error if the user is not in a voice channel                                                                                                                                                                                                                                         | MUTE_MEMBERS     |
-| deaf                         | boolean             | whether the user is deafened in voice channels. Will throw a 400 error if the user is not in a voice channel                                                                                                                                                                                                                                     | DEAFEN_MEMBERS   |
-| channel_id                   | snowflake           | id of channel to move user to (if they are connected to voice)                                                                                                                                                                                                                                                                                   | MOVE_MEMBERS     |
-| communication_disabled_until | ISO8601 timestamp  | when the user's [timeout](https://support.discord.com/hc/en-us/articles/4413305239191-Time-Out-FAQ) will expire and the user will be able to communicate in the guild again (up to 28 days in the future), set to null to remove timeout. Will throw a 403 error if the user has the ADMINISTRATOR permission or is the owner of the guild | MODERATE_MEMBERS |
+| Field                        | Type                | Description                                                                                                                                                                                                                                                                                                                                | Permission       |
+| ---------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| nick                         | string              | value to set user's nickname to                                                                                                                                                                                                                                                                                                            | MANAGE_NICKNAMES |
+| roles                        | array of snowflakes | array of role ids the member is assigned                                                                                                                                                                                                                                                                                                   | MANAGE_ROLES     |
+| mute                         | boolean             | whether the user is muted in voice channels. Will throw a 400 error if the user is not in a voice channel                                                                                                                                                                                                                                  | MUTE_MEMBERS     |
+| deaf                         | boolean             | whether the user is deafened in voice channels. Will throw a 400 error if the user is not in a voice channel                                                                                                                                                                                                                               | DEAFEN_MEMBERS   |
+| channel_id                   | snowflake           | id of channel to move user to (if they are connected to voice)                                                                                                                                                                                                                                                                             | MOVE_MEMBERS     |
+| communication_disabled_until | ISO8601 timestamp   | when the user's [timeout](https://support.discord.com/hc/en-us/articles/4413305239191-Time-Out-FAQ) will expire and the user will be able to communicate in the guild again (up to 28 days in the future), set to null to remove timeout. Will throw a 403 error if the user has the ADMINISTRATOR permission or is the owner of the guild | MODERATE_MEMBERS |
 
 ## Modify Current Member % PATCH /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/members/@me
 
@@ -904,11 +904,11 @@ Returns a list of [ban](#DOCS_RESOURCES_GUILD/ban-object) objects for the users 
 
 ###### Query String Params
 
-| Field        | Type      | Description                                                                    | Default |
-| ------------ | -------   | ------------------------------------------------------------------------------ | ------- |
-| limit?       | number    | number of users to return (up to maximum 1000)                                 | 1000    |
-| before? *    | snowflake | consider only users before given user id                                       | null    |
-| after? *     | snowflake | consider only users after given user id                                        | null    |
+| Field     | Type      | Description                                    | Default |
+| --------- | --------- | ---------------------------------------------- | ------- |
+| limit?    | number    | number of users to return (up to maximum 1000) | 1000    |
+| before? * | snowflake | consider only users before given user id       | null    |
+| after? *  | snowflake | consider only users after given user id        | null    |
 
 \* Provide a user id to `before` and `after` for pagination. Users will always be returned in ascending order by `user.id`. If both `before` and `after` are provided, only `before` is respected.
 
@@ -952,7 +952,7 @@ Create a new [role](#DOCS_TOPICS_PERMISSIONS/role-object) for the guild. Require
 
 | Field         | Type                                      | Description                                                                                                                    | Default                        |
 | ------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------ |
-| name          | string                                    | name of the role                                                                                                               | "new role"                     |
+| name          | string                                    | name of the role, max 100 characters                                                                                           | "new role"                     |
 | permissions   | string                                    | bitwise value of the enabled/disabled permissions                                                                              | @everyone permissions in guild |
 | color         | integer                                   | RGB color value                                                                                                                | 0                              |
 | hoist         | boolean                                   | whether the role should be displayed separately in the sidebar                                                                 | false                          |
@@ -990,7 +990,7 @@ Modify a guild role. Requires the `MANAGE_ROLES` permission. Returns the updated
 
 | Field         | Type                                     | Description                                                                                                                    |
 | ------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| name          | string                                   | name of the role                                                                                                               |
+| name          | string                                   | name of the role, max 100 characters                                                                                           |
 | permissions   | string                                   | bitwise value of the enabled/disabled permissions                                                                              |
 | color         | integer                                  | RGB color value                                                                                                                |
 | hoist         | boolean                                  | whether the role should be displayed separately in the sidebar                                                                 |
@@ -1007,9 +1007,9 @@ Modify a guild's MFA level. Requires guild ownership. Returns the updated [level
 
 ###### JSON Params
 
-| Field         | Type                                     | Description                                                                                                                    |
-| ------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| level         | integer                                  | [MFA level](#DOCS_RESOURCES_GUILD/guild-object-mfa-level)                                                                      |
+| Field | Type    | Description                                               |
+| ----- | ------- | --------------------------------------------------------- |
+| level | integer | [MFA level](#DOCS_RESOURCES_GUILD/guild-object-mfa-level) |
 
 ## Delete Guild Role % DELETE /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/roles/{role.id#DOCS_TOPICS_PERMISSIONS/role-object}
 


### PR DESCRIPTION
another PR introduced, i think fine to include since there's precedence. also formattttt

fun fact—if you `post`/`patch` a role with empty name, it'll name it "new role", so there's no min 