### PR TITLE
Add resolved to message component data

### DIFF
--- a/docs/interactions/Receiving_and_Responding.md
+++ b/docs/interactions/Receiving_and_Responding.md
@@ -69,10 +69,11 @@ While the `data` field is guaranteed to be present for all [interaction types](#
 ###### Message Component Data Structure
 
 | Field          | Type                                                                                                              | Description                                                                                                     |
-| -------------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+|----------------|-------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
 | custom_id      | string                                                                                                            | the [`custom_id`](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/custom-id) of the component                             |
 | component_type | integer                                                                                                           | the [type](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/component-object-component-types) of the component             |
 | values?\*      | array of [select option values](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object-select-option-structure) | values the user selected in a [select menu](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object) component |
+| resolved?      | [resolved data](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-object-resolved-data-structure)           | converted users + roles + channels + attachments                                                                |
 
 \* This is always present for select menu components
 

--- a/docs/interactions/Receiving_and_Responding.md
+++ b/docs/interactions/Receiving_and_Responding.md
@@ -73,7 +73,7 @@ While the `data` field is guaranteed to be present for all [interaction types](#
 | custom_id      | string                                                                                                            | the [`custom_id`](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/custom-id) of the component                             |
 | component_type | integer                                                                                                           | the [type](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/component-object-component-types) of the component             |
 | values?\*      | array of [select option values](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object-select-option-structure) | values the user selected in a [select menu](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object) component |
-| resolved?      | [resolved data](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-object-resolved-data-structure)           | converted users + roles + channels + attachments                                                                |
+| resolved?      | [resolved data](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-object-resolved-data-structure)           | resolved entities from selected options                                                                         |
 
 \* This is always present for select menu components
 


### PR DESCRIPTION
Add missing `resolved` field to message component data table. 
Due to recent addition of auto-populated selects, the components might receive `resolved` data structures. 