### PR TITLE
add gcp attachment docs

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -449,6 +449,61 @@ For example:
 }
 ```
 
+### Using GCP Attachments
+
+You can upload large attachments quickly directly to Discord's Google Cloud storage bucket, using the [Generate Attachment Upload URL](#DOCS_RESOURCES_CHANNEL/generate-attachment-upload-url) endpoint to generate an upload URL, and sending the generated URL a `PUT` request with the intended attachment as the body.
+
+An example implementation in Python pseudocode would be:
+
+```python
+import requests
+import os
+
+url = "https://discord.com/api/v10/channels/<my_channel_id>/attachments"
+
+headers = {
+    "Authorization": "Bot <my_bot_token>"
+}
+
+filename = "index.js"
+size = os.stat(filename).st_size
+
+json = {
+    "files": [{
+        "file_size": size,
+        "filename": filename
+    }]
+}
+
+r = requests.post(url, headers=headers, json=json)
+r.raise_for_status()
+
+upload = r.json()['attachments'][0]
+
+with open(filename, "r") as f:
+    data = f.read()
+
+    r = requests.put(upload['upload_url'], data=data)
+    r.raise_for_status()
+
+upload_filename = upload['upload_filename']
+```
+
+Now, instead of sending the attachment again in a form body in the request, you can just send the `upload_filename`! For example:
+
+```json
+{
+    "content": "look at my cute cat!",
+    "attachments": [
+        {
+            "id": "0",
+            "filename": "cat.png",
+            "uploaded_filename": "6a08e58a-265f-485a-8c85-5cd4df0edde0/cat.png"
+        }
+    ]
+}
+```
+
 ## Locales
 
 | Locale | Language Name         | Native Name         |

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -990,7 +990,7 @@ Crosspost a message in an Announcement Channel to following channels. This endpo
 
 Returns a [message](#DOCS_RESOURCES_CHANNEL/message-object) object.
 
-## Generate Attachment Upload URL % POST /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object/attachments}
+## Generate Attachment Upload URL % POST /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/attachments
 
 Create an attachment URL to upload the intended attachment directly to Discord's GCP storage bucket. Requires the same permissions as uploading an attachment inline with a message.
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -1011,6 +1011,20 @@ Create an attachment URL to upload the intended attachment directly to Discord's
 }
 ```
 
+###### Example Response Body (application/json)
+
+```json
+{
+    "attachments": [
+        {
+            "id": null,
+            "upload_url": "https://discord-attachments-uploads-prd.storage.googleapis.com/87e49c99-43f8-4a33-baad-5a834c94424c/cat.png?upload_id=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+            "upload_filename": "87e49c99-43f8-4a33-baad-5a834c94424c/cat.png"
+        }
+    ]
+}
+```
+
 ## Create Reaction % PUT /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/messages/{message.id#DOCS_RESOURCES_CHANNEL/message-object}/reactions/{emoji#DOCS_RESOURCES_EMOJI/emoji-object}/@me
 
 Create a reaction for the message. This endpoint requires the `READ_MESSAGE_HISTORY` permission to be present on the current user. Additionally, if nobody else has reacted to the message using this emoji, this endpoint requires the `ADD_REACTIONS` permission to be present on the current user. Returns a 204 empty response on success. Fires a [Message Reaction Add](#DOCS_TOPICS_GATEWAY_EVENTS/message-reaction-add) Gateway event.

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -990,6 +990,27 @@ Crosspost a message in an Announcement Channel to following channels. This endpo
 
 Returns a [message](#DOCS_RESOURCES_CHANNEL/message-object) object.
 
+## Generate Attachment Upload URL % POST /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object/attachments}
+
+Create an attachment URL to upload the intended attachment directly to Discord's GCP storage bucket. Requires the same permissions as uploading an attachment inline with a message.
+
+###### JSON params
+
+| Field | Type                        | Description                                                               |
+| ----- | --------------------------- | ------------------------------------------------------------------------- |
+| files | array of GCP upload objects | The target files to create a URL for, containing the file's name and size |
+
+###### Example Request Body (application/json)
+
+```json
+{
+  "files": [{
+    "file_size": 734955,
+    "filename": "my_awesome_file.png"
+  }]
+}
+```
+
 ## Create Reaction % PUT /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/messages/{message.id#DOCS_RESOURCES_CHANNEL/message-object}/reactions/{emoji#DOCS_RESOURCES_EMOJI/emoji-object}/@me
 
 Create a reaction for the message. This endpoint requires the `READ_MESSAGE_HISTORY` permission to be present on the current user. Additionally, if nobody else has reacted to the message using this emoji, this endpoint requires the `ADD_REACTIONS` permission to be present on the current user. Returns a 204 empty response on success. Fires a [Message Reaction Add](#DOCS_TOPICS_GATEWAY_EVENTS/message-reaction-add) Gateway event.


### PR DESCRIPTION
Adds documentation for the GCP upload feature recently added to the client and which bots can use. This is very much not finished and I would appreciate any feedback or corrections!