### PR TITLE
[automod] Increase max keyword rule per guild limit

### DIFF
--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -4,9 +4,9 @@
 
 #### Nov 22, 2022
 
-- Automod rules with [trigger_type](#DOCS_RESOURCES_AUTO_MODERATION/auto-moderation-rule-object-trigger-types) `KEYWORD` now support an `allow_list` field in its [trigger_metadata](#DOCS_RESOURCES_AUTO_MODERATION/auto-moderation-rule-object-trigger-types). Any message content that matches an `allow_list` keyword will be ignored by the Automod `KEYWORD` rule. Each `allow_list` keyword can be a multi-word phrase and can contain [wildcard symbols](#DOCS_RESOURCES_AUTO_MODERATION/auto-moderation-rule-object-keyword-matching-strategies).
+- Automod rules with [trigger_type](#DOCS_RESOURCES_AUTO_MODERATION/auto-moderation-rule-object-trigger-types) `KEYWORD` now support an `allow_list` field in its [trigger_metadata](#DOCS_RESOURCES_AUTO_MODERATION/auto-moderation-rule-object-trigger-metadata). Any message content that matches an `allow_list` keyword will be ignored by the Automod `KEYWORD` rule. Each `allow_list` keyword can be a multi-word phrase and can contain [wildcard symbols](#DOCS_RESOURCES_AUTO_MODERATION/auto-moderation-rule-object-keyword-matching-strategies).
 - Increase maximum number of rules with `KEYWORD` [trigger_type](#DOCS_RESOURCES_AUTO_MODERATION/auto-moderation-rule-object-trigger-types) per guild from 3 to 5
-- Increase maximum length for each regex pattern in the `regex_patterns` [trigger_metadata](#DOCS_RESOURCES_AUTO_MODERATION/auto-moderation-rule-object-trigger-types) field from 75 to 260.
+- Increase maximum length for each regex pattern in the `regex_patterns` [trigger_metadata](#DOCS_RESOURCES_AUTO_MODERATION/auto-moderation-rule-object-trigger-metadata) field from 75 to 260.
 
 
 ## Upcoming Application Command Permission Changes

--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -1,11 +1,13 @@
 # Change Log
 
-## Add Automod Allow List for Keyword Rules
+## Add Automod Allow List for Keyword Rules and Increase Max Keyword Rules Per Guild Limit
 
 #### Nov 22, 2022
 
 - Automod rules with [trigger_type](#DOCS_RESOURCES_AUTO_MODERATION/auto-moderation-rule-object-trigger-types) `KEYWORD` now support an `allow_list` field in its [trigger_metadata](#DOCS_RESOURCES_AUTO_MODERATION/auto-moderation-rule-object-trigger-types). Any message content that matches an `allow_list` keyword will be ignored by the Automod `KEYWORD` rule. Each `allow_list` keyword can be a multi-word phrase and can contain [wildcard symbols](#DOCS_RESOURCES_AUTO_MODERATION/auto-moderation-rule-object-keyword-matching-strategies).
-- Increase maximum regex keyword length from 75 to 260.
+- Increase maximum number of rules with `KEYWORD` [trigger_type](#DOCS_RESOURCES_AUTO_MODERATION/auto-moderation-rule-object-trigger-types) per guild from 3 to 5
+- Increase maximum length for each regex pattern in the `regex_patterns` [trigger_metadata](#DOCS_RESOURCES_AUTO_MODERATION/auto-moderation-rule-object-trigger-types) field from 75 to 260.
+
 
 ## Upcoming Application Command Permission Changes
 

--- a/docs/resources/Auto_Moderation.md
+++ b/docs/resources/Auto_Moderation.md
@@ -63,7 +63,7 @@ Characterizes the type of content which can trigger the rule.
 
 | Trigger Type   | Value | Description                                                          | Max per Guild |
 | -------------- | ----- | -------------------------------------------------------------------- | ------------- |
-| KEYWORD        | 1     | check if content contains words from a user defined list of keywords | 3             |
+| KEYWORD        | 1     | check if content contains words from a user defined list of keywords | 5             |
 | SPAM           | 3     | check if content represents generic spam                             | 1             |
 | KEYWORD_PRESET | 4     | check if content contains words from internal pre-defined wordsets   | 1             |
 | MENTION_SPAM   | 5     | check if content contains more unique mentions than allowed          | 1             |


### PR DESCRIPTION
Bump max keyword rule per guild limit from 3 to 5.
