### PR TITLE
Document role subscriptions

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -324,6 +324,7 @@ Represents a message sent in a channel within Discord.
 | GUILD_INVITE_REMINDER                        | 22    | true      |
 | CONTEXT_MENU_COMMAND                         | 23    | true      |
 | AUTO_MODERATION_ACTION                       | 24    | true*     |
+| ROLE_SUBSCRIPTION_PURCHASE                   | 25    | true      |
 
 \* Can only be deleted by members with `MANAGE_MESSAGES` permission
 

--- a/docs/resources/Emoji.md
+++ b/docs/resources/Emoji.md
@@ -11,13 +11,19 @@
 | --------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------- |
 | id              | ?snowflake                                                       | [emoji id](#DOCS_REFERENCE/image-formatting)                              |
 | name            | ?string (can be null only in reaction emoji objects)             | emoji name                                                                |
-| roles?          | array of [role](#DOCS_TOPICS_PERMISSIONS/role-object) object ids | roles allowed to use this emoji                                        |
+| roles?          | array of [role](#DOCS_TOPICS_PERMISSIONS/role-object) object ids | roles allowed to use this emoji                                           |
 | user?           | [user](#DOCS_RESOURCES_USER/user-object) object                  | user that created this emoji                                              |
 | require_colons? | boolean                                                          | whether this emoji must be wrapped in colons                              |
 | managed?        | boolean                                                          | whether this emoji is managed                                             |
 | animated?       | boolean                                                          | whether this emoji is animated                                            |
 | available?      | boolean                                                          | whether this emoji can be used, may be false due to loss of Server Boosts |
 
+###### Premium Emoji
+
+Roles with the `integration_id` tag being the guild's guild_subscription integration are considered subscription roles.  
+An emoji cannot have both subscription roles and non-subscription roles.  
+Emojis with subscription roles are considered premium emoji, and count toward a separate limit of 25.  
+Emojis cannot be converted between normal and premium after creation.
 
 ###### Emoji Example
 

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -118,31 +118,35 @@ Guilds in Discord represent an isolated collection of users and channels, and ar
 
 ###### Guild Features
 
-| Feature                            | Description                                                                                                                   |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| ANIMATED_BANNER                    | guild has access to set an animated guild banner image                                                                        |
-| ANIMATED_ICON                      | guild has access to set an animated guild icon                                                                                |
-| APPLICATION_COMMAND_PERMISSIONS_V2 | guild is using the [old permissions configuration behavior](#DOCS_CHANGE_LOG/upcoming-application-command-permission-changes) |
-| AUTO_MODERATION                    | guild has set up auto moderation rules                                                                                        |
-| BANNER                             | guild has access to set a guild banner image                                                                                  |
-| COMMUNITY                          | guild can enable welcome screen, Membership Screening, stage channels and discovery, and receives community updates           |
-| DEVELOPER_SUPPORT_SERVER           | guild has been set as a support server on the App Directory                                                                   |
-| DISCOVERABLE                       | guild is able to be discovered in the directory                                                                               |
-| FEATURABLE                         | guild is able to be featured in the directory                                                                                 |
-| INVITES_DISABLED                   | guild has paused invites, preventing new users from joining                                                                   |
-| INVITE_SPLASH                      | guild has access to set an invite splash background                                                                           |
-| MEMBER_VERIFICATION_GATE_ENABLED   | guild has enabled [Membership Screening](#DOCS_RESOURCES_GUILD/membership-screening-object)                                   |
-| MONETIZATION_ENABLED               | guild has enabled monetization                                                                                                |
-| MORE_STICKERS                      | guild has increased custom sticker slots                                                                                      |
-| NEWS                               | guild has access to create announcement channels                                                                              |
-| PARTNERED                          | guild is partnered                                                                                                            |
-| PREVIEW_ENABLED                    | guild can be previewed before joining via Membership Screening or the directory                                               |
-| ROLE_ICONS                         | guild is able to set role icons                                                                                               |
-| TICKETED_EVENTS_ENABLED            | guild has enabled ticketed events                                                                                             |
-| VANITY_URL                         | guild has access to set a vanity URL                                                                                          |
-| VERIFIED                           | guild is verified                                                                                                             |
-| VIP_REGIONS                        | guild has access to set 384kbps bitrate in voice (previously VIP voice servers)                                               |
-| WELCOME_SCREEN_ENABLED             | guild has enabled the welcome screen                                                                                          |
+| Feature                                   | Description                                                                                                                   |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| ANIMATED_BANNER                           | guild has access to set an animated guild banner image                                                                        |
+| ANIMATED_ICON                             | guild has access to set an animated guild icon                                                                                |
+| APPLICATION_COMMAND_PERMISSIONS_V2        | guild is using the [old permissions configuration behavior](#DOCS_CHANGE_LOG/upcoming-application-command-permission-changes) |
+| AUTO_MODERATION                           | guild has set up auto moderation rules                                                                                        |
+| BANNER                                    | guild has access to set a guild banner image                                                                                  |
+| COMMUNITY                                 | guild can enable welcome screen, Membership Screening, stage channels and discovery, and receives community updates           |
+| CREATOR_MONETIZABLE_PROVISIONAL           | guild has enabled monetization                                                                                                |
+| CREATOR_STORE_PAGE                        | guild has enabled the role subscription promo page                                                                            |
+| DEVELOPER_SUPPORT_SERVER                  | guild has been set as a support server on the App Directory                                                                   |
+| DISCOVERABLE                              | guild is able to be discovered in the directory                                                                               |
+| FEATURABLE                                | guild is able to be featured in the directory                                                                                 |
+| INVITES_DISABLED                          | guild has paused invites, preventing new users from joining                                                                   |
+| INVITE_SPLASH                             | guild has access to set an invite splash background                                                                           |
+| MEMBER_VERIFICATION_GATE_ENABLED          | guild has enabled [Membership Screening](#DOCS_RESOURCES_GUILD/membership-screening-object)                                   |
+| MONETIZATION_ENABLED                      | guild has enabled monetization                                                                                                |
+| MORE_STICKERS                             | guild has increased custom sticker slots                                                                                      |
+| NEWS                                      | guild has access to create announcement channels                                                                              |
+| PARTNERED                                 | guild is partnered                                                                                                            |
+| PREVIEW_ENABLED                           | guild can be previewed before joining via Membership Screening or the directory                                               |
+| ROLE_ICONS                                | guild is able to set role icons                                                                                               |
+| ROLE_SUBSCRIPTIONS_AVAILABLE_FOR_PURCHASE | guild has role subscriptions that can be purchased                                                                            |
+| ROLE_SUBSCRIPTIONS_ENABLED                | guild has enabled role subscriptions                                                                                          |
+| TICKETED_EVENTS_ENABLED                   | guild has enabled ticketed events                                                                                             |
+| VANITY_URL                                | guild has access to set a vanity URL                                                                                          |
+| VERIFIED                                  | guild is verified                                                                                                             |
+| VIP_REGIONS                               | guild has access to set 384kbps bitrate in voice (previously VIP voice servers)                                               |
+| WELCOME_SCREEN_ENABLED                    | guild has enabled the welcome screen                                                                                          |
 
 ###### Mutable Guild Features
 
@@ -374,7 +378,7 @@ A partial [guild](#DOCS_RESOURCES_GUILD/guild-object) object. Represents an Offl
 | ----------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
 | id                      | snowflake                                                                                            | integration id                                                                  |
 | name                    | string                                                                                               | integration name                                                                |
-| type                    | string                                                                                               | integration type (twitch, youtube, or discord)                                  |
+| type                    | string                                                                                               | integration type (twitch, youtube, discord, or guild_subscription)              |
 | enabled? \*             | boolean                                                                                              | is this integration enabled                                                     |
 | syncing? \*             | boolean                                                                                              | is this integration syncing                                                     |
 | role_id? \*             | snowflake                                                                                            | id that this integration uses for "subscribers"                                 |
@@ -1061,6 +1065,9 @@ Returns a list of [invite](#DOCS_RESOURCES_INVITE/invite-object) objects (with [
 ## Get Guild Integrations % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/integrations
 
 Returns a list of [integration](#DOCS_RESOURCES_GUILD/integration-object) objects for the guild. Requires the `MANAGE_GUILD` permission.
+
+> info
+> This endpoint returns a maximum of 50 integrations. If a guild has more integrations, they cannot be accessed.
 
 ## Delete Guild Integration % DELETE /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/integrations/{integration.id#DOCS_RESOURCES_GUILD/integration-object}
 

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -134,7 +134,6 @@ Guilds in Discord represent an isolated collection of users and channels, and ar
 | INVITES_DISABLED                          | guild has paused invites, preventing new users from joining                                                                   |
 | INVITE_SPLASH                             | guild has access to set an invite splash background                                                                           |
 | MEMBER_VERIFICATION_GATE_ENABLED          | guild has enabled [Membership Screening](#DOCS_RESOURCES_GUILD/membership-screening-object)                                   |
-| MONETIZATION_ENABLED                      | guild has enabled monetization                                                                                                |
 | MORE_STICKERS                             | guild has increased custom sticker slots                                                                                      |
 | NEWS                                      | guild has access to create announcement channels                                                                              |
 | PARTNERED                                 | guild is partnered                                                                                                            |

--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -191,6 +191,7 @@ Along with the HTTP error code, our API can also return more detailed error code
 | 30047  | Maximum number of pinned threads in a forum channel has been reached                                                          |
 | 30048  | Maximum number of tags in a forum channel has been reached                                                                    |
 | 30052  | Bitrate is too high for channel of this type                                                                                  |
+| 30056  | Maximum number of premium emojis reached (25)                                                                                 |
 | 40001  | Unauthorized. Provide a valid token and try again                                                                             |
 | 40002  | You need to verify your account in order to perform this action                                                               |
 | 40003  | You are opening direct messages too fast                                                                                      |
@@ -259,6 +260,8 @@ Along with the HTTP error code, our API can also return more detailed error code
 | 50109  | The request body contains invalid JSON.                                                                                       |
 | 50132  | Ownership cannot be transferred to a bot user                                                                                 |
 | 50138  | Failed to resize asset below the maximum size: 262144                                                                         |
+| 50144  | Cannot mix subscription and non subscription roles for an emoji                                                               |
+| 50145  | Cannot convert between premium emoji and normal emoji                                                                         |
 | 50146  | Uploaded file not found.                                                                                                      |
 | 50600  | You do not have permission to send this sticker.                                                                              |
 | 60003  | Two factor is required for this operation                                                                                     |

--- a/docs/topics/Permissions.md
+++ b/docs/topics/Permissions.md
@@ -205,11 +205,15 @@ Roles without colors (`color == 0`) do not count towards the final computed colo
 
 ###### Role Tags Structure
 
-| Field               | Type      | Description                                         |
-| ------------------- | --------- | --------------------------------------------------- |
-| bot_id?             | snowflake | the id of the bot this role belongs to              |
-| integration_id?     | snowflake | the id of the integration this role belongs to      |
-| premium_subscriber? | null      | whether this is the guild's premium subscriber role |
+Tags with type `null` represent booleans. They will be present and set to `null` if they are "true", and will be not present if they are "false".
+
+| Field                    | Type      | Description                                        |
+| ------------------------ | --------- | -------------------------------------------------- |
+| bot_id?                  | snowflake | the id of the bot this role belongs to             |
+| integration_id?          | snowflake | the id of the integration this role belongs to     |
+| premium_subscriber?      | null      | whether this is the guild's Booster role           |
+| subscription_listing_id? | snowflake | the id of this role's subscription sku and listing |
+| available_for_purchase?  | null      | whether this role is available for purchase        |
 
 ###### Example Role
 


### PR DESCRIPTION
Bots can't access the subscription-related endpoints but I documented the role tags, premium emoji stuff, integration type, message type, and publicly available guild features (not the testing guild features). I didn't document the subscription listing stuff in [/discovery/:slug](https://discord.com/api/v10/discovery/815369174096412692) since that endpoint is not documented yet (requires #1762).

resolves #5711
