### PR TITLE
Document error code `50091`

### DIFF
--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -253,6 +253,7 @@ Along with the HTTP error code, our API can also return more detailed error code
 | 50084  | Invalid thread notification settings                                                                                          |
 | 50085  | `before` value is earlier than the thread creation date                                                                       |
 | 50086  | Community server channels must be text channels                                                                               |
+| 50091  | The entity type of the event is different from the entity you are trying to start the event for                               |
 | 50095  | This server is not available in your location                                                                                 |
 | 50097  | This server needs monetization enabled in order to perform this action                                                        |
 | 50101  | This server needs more boosts to perform this action                                                                          |


### PR DESCRIPTION
Error returned when trying to create stage instance with a `guild_scheduled_event_id` that has `entity_type` not for `STAGE_INSTANCE`