### PR TITLE
docs: Add Mineral framework to community resources

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -33,6 +33,11 @@ Discord does not maintain official SDKs.  The following table is an inexhaustive
 | [discordrb](https://github.com/shardlab/discordrb)            | Ruby       |
 | [Serenity](https://github.com/serenity-rs/serenity)           | Rust       |
 
+## Frameworks
+| Name                                                          | Language   |
+| ------------------------------------------------------------- | ---------- |
+| [Mineral](https://github.com/mineral-dart)                    | Dart       |
+
 ## Interactions
 
 [Interactions](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/) are the great, new way of making a Discord bot. The following open-source libraries provide help for the security and authentication checks that are mandatory if you are receiving Interactions via outgoing webhook. They also include some types for the Interactions data models.


### PR DESCRIPTION
Good evening,

I'm opening this PR to propose the addition of one of my projects.

Mineral is a framework for designing Discord bots in the Dart language.
The project includes a total management of the dispatching of events, commands or context menus.

I would like to know if you accept the addition of such projects in your documentation at this time.
If you would like more information about the project, please do not hesitate to contact me.

If there are any missing features in order to be able to use the resources, could you please tell me ?

Thank you in advance and have a great evening

`📚` Documentation : https://mineral-foundation.org/
`📌` Github : https://github.com/mineral-dart
`📌` Dart pub : https://pub.dev/publishers/mineral-foundation.org/packages