### PR TITLE
Clarify that USER_UPDATE is dispatched only for the current user

### DIFF
--- a/docs/topics/Gateway_Events.md
+++ b/docs/topics/Gateway_Events.md
@@ -1152,7 +1152,7 @@ Sent when a user starts typing in a channel.
 
 #### User Update
 
-Sent when properties about the user change. Inner payload is a [user](#DOCS_RESOURCES_USER/user-object) object.
+Sent when properties about the current bot's user change. Inner payload is a [user](#DOCS_RESOURCES_USER/user-object) object.
 
 ### Voice
 


### PR DESCRIPTION
This wasn't very clear, and one could guess this can be sent when an update is made to any user.