### PR TITLE
Update Embed Author Object Structure in Channel.md

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -666,7 +666,7 @@ Embed types are "loosely defined" and, for the most part, are not used by our cl
 | Field           | Type   | Description                                                |
 | --------------- | ------ | ---------------------------------------------------------- |
 | name            | string | name of author                                             |
-| url?            | string | url of author                                              |
+| url?            | string | url of author (only supports http(s))                      |
 | icon_url?       | string | url of author icon (only supports http(s) and attachments) |
 | proxy_icon_url? | string | a proxied url of author icon                               |
 


### PR DESCRIPTION
Adds a comment about supported schemas for the URL field of embed author boject similarly to how ICON_URL is commented.