### PR TITLE
Added more-cores/discord-commands to PHP Interactions resources

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -56,6 +56,7 @@ Discord does not maintain official SDKs.  The following table is an inexhaustive
   - [flask-discord-interactions](https://github.com/breqdev/flask-discord-interactions)
 - PHP
   - [discord-interactions-php](https://github.com/discord/discord-interactions-php)
+  - [discord-commands](https://github.com/more-cores/discord-commands)
 - Other
   - [caddy-discord-interactions-verifier](https://github.com/CarsonHoffman/caddy-discord-interactions-verifier)
   - [Rauf's Slash Command Generator](https://rauf.wtf/slash)


### PR DESCRIPTION
This pull request adds https://github.com/more-cores/discord-commands to the PHP Interactions library list.  This library includes:
 - factories for building messages, embeds, commands, nested menus/options/buttons, etc.
 - inbound request signature verification for verifying interaction requests are from Discord
 - extensive documentation/examples, including using the Laravel framework
 - test coverage and a github-action-based test suite UI
 
While the project has no stars at the moment I understand some hesitation with adding this project.  I'm the maintainer for a bot that's within 300k+ guilds, so I have vested interest in keeping this library up-to-date and maintained.  I've actually used this in my bot for over 3 years.