### PR TITLE
Add warning about boolean metadata fields

### DIFF
--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -250,6 +250,9 @@ Returns the [application role connection](#DOCS_RESOURCES_USER/application-role-
 
 Updates and returns the [application role connection](#DOCS_RESOURCES_USER/application-role-connection-object) for the user. Requires an OAuth2 access token with `role_connections.write` scope for the application specified in the path.
 
+> warn
+> For Boolean metadata fields, the value should be set to 1 or 0, not true or false.
+
 ###### JSON Params
 
 | Field              | Type    | Description                                                                                                                                                                                                                                                      |


### PR DESCRIPTION
When setting metadata on a user, you would assume that you need to set boolean fields to true or false, but you actually need to use 1 or 0. This has caused problems (especially because no error is returned) so I added a warning box to make it clear.
