### PR TITLE
Improve the scope part of the application commands docs 

### DIFF
--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -98,14 +98,11 @@ If you specify `choices` for an option, they are the **only** valid values for a
 
 ## Authorizing Your Application
 
-Application commands do not depend on a bot user in the guild; they use the [interactions](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/) model. To create commands in a guild, your app must be authorized with the `applications.commands` scope.
-
-> danger
-> **In order to make commands work within a guild, the guild must authorize your application with the `applications.commands` scope. The `bot` scope is not enough.**
+Application commands do not depend on a bot user in the guild; they use the [interactions](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/) model. To create commands in a guild, your app must be authorized with the `applications.commands` scope which can be used independently, but is also automatically included with the `bot` scope.
 
 When requesting this scope, we "shortcut" the OAuth2 flow similar to adding a bot. You don't need to complete the flow, exchange for a token, or any of that.
 
-If your application does not require a bot user within the guild for its commands to work, **you no longer need to add for the bot scope or specific permissions**.
+If your application does not require a bot user in the guild for its commands to work, **you don't need to add the bot scope or a permission bitfield to the URL**.
 
 
 ## Registering a Command


### PR DESCRIPTION
I removed the warning about applications.commands being required even when using the bot scope (it's included in the bot scope now) and tweaked the text above to make it more clear that it can be used without a bot, but isn't required in the oauth URL when adding an actual bot account  