### PR TITLE
Update the message component data structure

### DIFF
--- a/docs/interactions/Message_Components.md
+++ b/docs/interactions/Message_Components.md
@@ -215,13 +215,21 @@ There are 5 different [select menu components](#DOCS_INTERACTIONS_MESSAGE_COMPON
 
 The string select menu (type `3`) is the *only* select type that allows (and *requires*) apps to define the `options` that appear in the dropdown list. The other 4 select menu components (users, roles, mentionables, and channels) are auto-populated with options corresponding to the resource type—similar to [command option types](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-object-application-command-option-type).
 
-[Select menu interaction payloads](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object-select-menu-interaction) include a `values` array,
-which contains any values selected by the user. In the case of string select menus, this may be any of the defined `options`. For user, role,
-mentionable and channel select menus, the values will contain the ID of the selected resource.
-
-Additionally, auto-populated select menu components (users, roles, mentionables, and channels) also include a [`resolved` object](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object-select-menu-resolved-object) that provides additional details about the user's selected resource.
+The interaction response for auto-populated select menu components also includes a [`resolved` object](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object-select-menu-resolved-object) that provides additional details about the user's selected resource.
 
 The payloads for the select menu components are detailed in the [select menu structure](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object-select-menu-structure).
+
+### Select Menu Interaction Values
+
+[Select menu interaction payloads](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object-select-menu-interaction) include a `values` array,
+which contains any values selected by the user. The underlying type of this array varies depending on the type of select menu used.
+
+| Select Menu Type                                         | `values` Array Type | Description                                          |
+| -------------------------------------------------------- | ------------------- | ---------------------------------------------------- |
+| String (`3`)                                             | strings             | The `value` field from any of the selected `options` |
+| User (`5`), Role (`6`), Mentionable (`7`), Channel (`8`) | snowflakes          | The IDs of any of the selected resources             |
+
+- String select menus (type `3`) will
 
 ###### Select Menu Example
 

--- a/docs/interactions/Message_Components.md
+++ b/docs/interactions/Message_Components.md
@@ -215,7 +215,11 @@ There are 5 different [select menu components](#DOCS_INTERACTIONS_MESSAGE_COMPON
 
 The string select menu (type `3`) is the *only* select type that allows (and *requires*) apps to define the `options` that appear in the dropdown list. The other 4 select menu components (users, roles, mentionables, and channels) are auto-populated with options corresponding to the resource type—similar to [command option types](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-object-application-command-option-type).
 
-In addition to the `values` array in all [select menu interaction payloads](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object-select-menu-interaction), auto-populated select menu components (users, roles, mentionables, and channels) also include an additional [`resolved` object](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object-select-menu-resolved-object) that provides additional details about the user's selected resource.
+[Select menu interaction payloads](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object-select-menu-interaction) include a `values` array,
+which contains any values selected by the user. In the case of string select menus, this may be any of the defined `options`. For user, role,
+mentionable and channel select menus, the values will contain the ID of the selected resource.
+
+Additionally, auto-populated select menu components (users, roles, mentionables, and channels) also include a [`resolved` object](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object-select-menu-resolved-object) that provides additional details about the user's selected resource.
 
 The payloads for the select menu components are detailed in the [select menu structure](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object-select-menu-structure).
 

--- a/docs/interactions/Receiving_and_Responding.md
+++ b/docs/interactions/Receiving_and_Responding.md
@@ -68,11 +68,12 @@ While the `data` field is guaranteed to be present for all [interaction types](#
 
 ###### Message Component Data Structure
 
-| Field          | Type                                                                                                              | Description                                                                                                     |
-| -------------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| custom_id      | string                                                                                                            | the [`custom_id`](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/custom-id) of the component                             |
-| component_type | integer                                                                                                           | the [type](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/component-object-component-types) of the component             |
-| values?\*      | array of [select option values](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object-select-option-structure) | values the user selected in a [select menu](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object) component |
+| Field          | Type                                                                                                    | Description                                                                                                                                                  |
+|----------------|---------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| custom_id      | string                                                                                                  | the [`custom_id`](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/custom-id) of the component                                                                          |
+| component_type | integer                                                                                                 | the [type](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/component-object-component-types) of the component                                                          |
+| values?\*      | array of strings                                                                                        | values the user selected in a [select menu](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object) component                                              |
+| resolved?      | [resolved data](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-object-resolved-data-structure) | details of any users/roles/mentionables/channels selected by the user in a [select menu](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object) component |
 
 \* This is always present for select menu components
 

--- a/docs/interactions/Receiving_and_Responding.md
+++ b/docs/interactions/Receiving_and_Responding.md
@@ -68,12 +68,12 @@ While the `data` field is guaranteed to be present for all [interaction types](#
 
 ###### Message Component Data Structure
 
-| Field          | Type                                                                                                    | Description                                                                                                                                                  |
-|----------------|---------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| custom_id      | string                                                                                                  | the [`custom_id`](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/custom-id) of the component                                                                          |
-| component_type | integer                                                                                                 | the [type](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/component-object-component-types) of the component                                                          |
-| values?\*      | array of strings                                                                                        | values the user selected in a [select menu](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object) component                                              |
-| resolved?      | [resolved data](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-object-resolved-data-structure) | details of any users/roles/mentionables/channels selected by the user in a [select menu](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object) component |
+| Field          | Type                                                                                                                   | Description                                                                                                                                                  |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| custom_id      | string                                                                                                                 | the [`custom_id`](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/custom-id) of the component                                                                          |
+| component_type | integer                                                                                                                | the [type](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/component-object-component-types) of the component                                                          |
+| values?\*      | array of one of [select menu interaction values](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-interaction-values) | values the user selected in a [select menu](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object) component                                              |
+| resolved?      | [resolved data](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-object-resolved-data-structure)                | details of any users/roles/mentionables/channels selected by the user in a [select menu](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/select-menu-object) component |
 
 \* This is always present for select menu components
 


### PR DESCRIPTION
This PR updates the message component data structure to:

1. Correctly type the `values` field as an array of strings/snowflakes, rather than an array of select options. Incidentally, this is already shown in the interaction response sample for select menus.
2. Add the `resolved` field, which is sent with interactions on user, role, mentionable and channel select menus.

Further, I've described what the `values` field can be expected to contain; any of the defined options for string selects, and IDs of the selected resources for other select menu types.