### PR TITLE
Add thread member pagination and details changes

### DIFF
--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## Thread Member Details and Pagination
+
+> danger
+> This entry includes breaking changes
+
+#### Jan 09, 2023
+
+A new `member` field was added to the [thread member object](#DOCS_RESOURCES_CHANNEL/thread-member-object). `member` is a [guild member object](#DOCS_RESOURCES_GUILD/guild-member-object) that will be included within returned thread member objects when the new `with_member` field is set to `true` in the [List Thread Members](#DOCS_RESOURCES_CHANNEL/list-thread-members) (`GET /channels/<channel_id>/thread-members`) and [Get Thread Member](#DOCS_RESOURCES_CHANNEL/get-thread-member) (`GET /channels/<channel_id>/thread-members/<user_id>`) endpoints.
+
+Setting `with_member` to `true` will also make enable pagination for the [List Thread Members](#DOCS_RESOURCES_CHANNEL/list-thread-members) endpoint. When the results are paginated, you can use the new `after` and `limit` fields to fetch additional thread members and limit the number of thread members returned. By default, `limit` is 100.
+
+#### Upcoming Changes
+
+Starting in API v11, [List Thread Members](#DOCS_RESOURCES_CHANNEL/list-thread-members) (`GET /channels/<channel_id>/thread-members`) will *always* return paginated results, regardless of whether `with_member` is passed or not.
+
 ## Add Default Layout setting for Forum channels
 
 #### Dec 13, 2022

--- a/docs/Change_Log.md
+++ b/docs/Change_Log.md
@@ -9,7 +9,7 @@
 
 A new `member` field was added to the [thread member object](#DOCS_RESOURCES_CHANNEL/thread-member-object). `member` is a [guild member object](#DOCS_RESOURCES_GUILD/guild-member-object) that will be included within returned thread member objects when the new `with_member` field is set to `true` in the [List Thread Members](#DOCS_RESOURCES_CHANNEL/list-thread-members) (`GET /channels/<channel_id>/thread-members`) and [Get Thread Member](#DOCS_RESOURCES_CHANNEL/get-thread-member) (`GET /channels/<channel_id>/thread-members/<user_id>`) endpoints.
 
-Setting `with_member` to `true` will also make enable pagination for the [List Thread Members](#DOCS_RESOURCES_CHANNEL/list-thread-members) endpoint. When the results are paginated, you can use the new `after` and `limit` fields to fetch additional thread members and limit the number of thread members returned. By default, `limit` is 100.
+Setting `with_member` to `true` will also enable pagination for the [List Thread Members](#DOCS_RESOURCES_CHANNEL/list-thread-members) endpoint. When the results are paginated, you can use the new `after` and `limit` fields to fetch additional thread members and limit the number of thread members returned. By default, `limit` is 100.
 
 #### Upcoming Changes
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -569,7 +569,7 @@ A thread member object contains information about a user that has joined a threa
 | user_id? \*    | snowflake                                                   | ID of the user                                                  |
 | join_timestamp | ISO8601 timestamp                                           | Time the user last joined the thread                            |
 | flags          | integer                                                     | Any user-thread settings, currently only used for notifications |
-| member? \*     | [guild member](#RESOURCES_GUILD/guild-member-object) object | Additional information about the user                           |
+| member? \*     | [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object | Additional information about the user                           |
 
 **\* These fields are omitted on the member sent within each thread in the [GUILD_CREATE](#DOCS_TOPICS_GATEWAY_EVENTS/guild-create) event**
 
@@ -1303,13 +1303,13 @@ Removes another member from a thread. Requires the `MANAGE_THREADS` permission, 
 
 Returns a [thread member](#DOCS_RESOURCES_CHANNEL/thread-member-object) object for the specified user if they are a member of the thread, returns a 404 response otherwise.
 
-When `with_member` is set to `true`, the thread member object will include a `member` field containing a [guild member](#RESOURCES_GUILD/guild-member-object) object.
+When `with_member` is set to `true`, the thread member object will include a `member` field containing a [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object.
 
 ###### Query String Params
 
 | Field        | Type      | Description                                                                                            |
 | ------------ | --------- | ------------------------------------------------------------------------------------------------------ |
-| with_member? | boolean   | Whether to include a [guild member](#RESOURCES_GUILD/guild-member-object) object for the thread member |
+| with_member? | boolean   | Whether to include a [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object for the thread member |
 
 ## List Thread Members % GET /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/thread-members
 
@@ -1318,7 +1318,7 @@ When `with_member` is set to `true`, the thread member object will include a `me
 
 Returns array of [thread members](#DOCS_RESOURCES_CHANNEL/thread-member-object) objects that are members of the thread.
 
-When `with_member` is set to `true`, the results will be paginated and each thread member object will include a `member` field containing a [guild member](#RESOURCES_GUILD/guild-member-object) object.
+When `with_member` is set to `true`, the results will be paginated and each thread member object will include a `member` field containing a [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object.
 
 > warn
 > This endpoint is restricted according to whether the `GUILD_MEMBERS` [Privileged Intent](#DOCS_TOPICS_GATEWAY/privileged-intents) is enabled for your application.
@@ -1327,7 +1327,7 @@ When `with_member` is set to `true`, the results will be paginated and each thre
 
 | Field        | Type      | Description                                                                                             |
 | ------------ | --------- | ------------------------------------------------------------------------------------------------------- |
-| with_member? | boolean   | Whether to include a [guild member](#RESOURCES_GUILD/guild-member-object) object for each thread member |
+| with_member? | boolean   | Whether to include a [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object for each thread member |
 | after?       | snowflake | Get thread members after this user ID                                                                   |
 | limit?       | integer   | Max number of thread members to return (1-100). Defaults to 100.                                        |
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -1309,8 +1309,8 @@ When `with_member` is set to `true`, the thread member object will include a `me
 
 ###### Query String Params
 
-| Field        | Type      | Description                                                                                            |
-| ------------ | --------- | ------------------------------------------------------------------------------------------------------ |
+| Field        | Type      | Description                                                                                                 |
+| ------------ | --------- | ----------------------------------------------------------------------------------------------------------- |
 | with_member? | boolean   | Whether to include a [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object for the thread member |
 
 ## List Thread Members % GET /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/thread-members
@@ -1327,11 +1327,11 @@ When `with_member` is set to `true`, the results will be paginated and each thre
 
 ###### Query String Params
 
-| Field        | Type      | Description                                                                                             |
-| ------------ | --------- | ------------------------------------------------------------------------------------------------------- |
+| Field        | Type      | Description                                                                                                  |
+| ------------ | --------- | ------------------------------------------------------------------------------------------------------------ |
 | with_member? | boolean   | Whether to include a [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object for each thread member |
-| after?       | snowflake | Get thread members after this user ID                                                                   |
-| limit?       | integer   | Max number of thread members to return (1-100). Defaults to 100.                                        |
+| after?       | snowflake | Get thread members after this user ID                                                                        |
+| limit?       | integer   | Max number of thread members to return (1-100). Defaults to 100.                                             |
 
 ## List Public Archived Threads % GET /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/threads/archived/public
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -563,15 +563,17 @@ A thread member object contains information about a user that has joined a threa
 
 ###### Thread Member Structure
 
-| Field          | Type                                                        | Description                                                     |
-| -------------- | ----------------------------------------------------------- | --------------------------------------------------------------- |
-| id? \*         | snowflake                                                   | ID of the thread                                                |
-| user_id? \*    | snowflake                                                   | ID of the user                                                  |
-| join_timestamp | ISO8601 timestamp                                           | Time the user last joined the thread                            |
-| flags          | integer                                                     | Any user-thread settings, currently only used for notifications |
-| member? \*     | [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object | Additional information about the user                           |
+| Field           | Type                                                             | Description                                                     |
+| --------------- | ---------------------------------------------------------------- | --------------------------------------------------------------- |
+| id? \*          | snowflake                                                        | ID of the thread                                                |
+| user_id? \*     | snowflake                                                        | ID of the user                                                  |
+| join_timestamp  | ISO8601 timestamp                                                | Time the user last joined the thread                            |
+| flags           | integer                                                          | Any user-thread settings, currently only used for notifications |
+| member? \* \*\* | [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object | Additional information about the user                           |
 
-**\* These fields are omitted on the member sent within each thread in the [GUILD_CREATE](#DOCS_TOPICS_GATEWAY_EVENTS/guild-create) event**
+\* These fields are omitted on the member sent within each thread in the [GUILD_CREATE](#DOCS_TOPICS_GATEWAY_EVENTS/guild-create) event.
+
+\*\* The `member` field is only present when `with_member` is set to `true` when calling [List Thread Members](#DOCS_RESOURCES_CHANNEL/list-thread-members) or [Get Thread Member](#DOCS_RESOURCES_CHANNEL/get-thread-member).
 
 ### Default Reaction Object
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -559,16 +559,17 @@ The thread metadata object contains a number of thread-specific channel fields t
 
 ### Thread Member Object
 
-A thread member is used to indicate whether a user has joined a thread or not.
+A thread member object contains information about a user that has joined a thread.
 
 ###### Thread Member Structure
 
-| Field          | Type              | Description                                                     |
-| -------------- | ----------------- | --------------------------------------------------------------- |
-| id? \*         | snowflake         | the id of the thread                                            |
-| user_id? \*    | snowflake         | the id of the user                                              |
-| join_timestamp | ISO8601 timestamp | the time the current user last joined the thread                |
-| flags          | integer           | any user-thread settings, currently only used for notifications |
+| Field          | Type                                                        | Description                                                     |
+| -------------- | ----------------------------------------------------------- | --------------------------------------------------------------- |
+| id? \*         | snowflake                                                   | ID of the thread                                                |
+| user_id? \*    | snowflake                                                   | ID of the user                                                  |
+| join_timestamp | ISO8601 timestamp                                           | Time the user last joined the thread                            |
+| flags          | integer                                                     | Any user-thread settings, currently only used for notifications |
+| member? \*     | [guild member](#RESOURCES_GUILD/guild-member-object) object | Additional information about the user                           |
 
 **\* These fields are omitted on the member sent within each thread in the [GUILD_CREATE](#DOCS_TOPICS_GATEWAY_EVENTS/guild-create) event**
 
@@ -1302,12 +1303,33 @@ Removes another member from a thread. Requires the `MANAGE_THREADS` permission, 
 
 Returns a [thread member](#DOCS_RESOURCES_CHANNEL/thread-member-object) object for the specified user if they are a member of the thread, returns a 404 response otherwise.
 
+When `with_member` is set to `true`, the thread member object will include a `member` field containing a [guild member](#RESOURCES_GUILD/guild-member-object) object.
+
+###### Query String Params
+
+| Field        | Type      | Description                                                                                            |
+| ------------ | --------- | ------------------------------------------------------------------------------------------------------ |
+| with_member? | boolean   | Whether to include a [guild member](#RESOURCES_GUILD/guild-member-object) object for the thread member |
+
 ## List Thread Members % GET /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/thread-members
+
+> warn
+> Starting in API v11, this endpoint will always return paginated results. Paginated results can be enabled before API v11 by setting `with_member` to `true`. Read [the changelog](#DOCS_CHANGE_LOG/thread-member-details-and-pagination) for details.
 
 Returns array of [thread members](#DOCS_RESOURCES_CHANNEL/thread-member-object) objects that are members of the thread.
 
+When `with_member` is set to `true`, the results will be paginated and each thread member object will include a `member` field containing a [guild member](#RESOURCES_GUILD/guild-member-object) object.
+
 > warn
 > This endpoint is restricted according to whether the `GUILD_MEMBERS` [Privileged Intent](#DOCS_TOPICS_GATEWAY/privileged-intents) is enabled for your application.
+
+###### Query String Params
+
+| Field        | Type      | Description                                                                                             |
+| ------------ | --------- | ------------------------------------------------------------------------------------------------------- |
+| with_member? | boolean   | Whether to include a [guild member](#RESOURCES_GUILD/guild-member-object) object for each thread member |
+| after?       | snowflake | Get thread members after this user ID                                                                   |
+| limit?       | integer   | Max number of thread members to return (1-100). Defaults to 100.                                        |
 
 ## List Public Archived Threads % GET /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/threads/archived/public
 


### PR DESCRIPTION
Adds new information about the `with_member`, `after`, and `limit` fields for the `GET /channels/<channel_id>/thread-members` and `GET /channels/<channel_id>/thread-members/<user_id>` endpoints