### PR TITLE
Clarify sticker constraints

### DIFF
--- a/docs/resources/Sticker.md
+++ b/docs/resources/Sticker.md
@@ -133,7 +133,7 @@ Every guilds has five free sticker slots by default, and each Boost level will g
 > Lottie stickers can only be uploaded on guilds that have either the `VERIFIED` and/or the `PARTNERED` [guild feature](#DOCS_RESOURCES_GUILD/guild-object-guild-features). 
 
 > warn
-> Uploaded stickers are constrained to 5 seconds in length for animated stickers, and 256 x 256 pixels.
+> Uploaded stickers are constrained to 5 seconds in length for animated stickers, and 320 x 320 pixels.
 ###### Form Params
 
 | Field       | Type          | Description                                                                                  |

--- a/docs/resources/Sticker.md
+++ b/docs/resources/Sticker.md
@@ -141,7 +141,7 @@ Every guilds has five free sticker slots by default, and each Boost level will g
 | name        | string        | name of the sticker (2-30 characters)                                                        |
 | description | string        | description of the sticker (empty or 2-100 characters)                                       |
 | tags        | string        | autocomplete/suggestion tags for the sticker (max 200 characters)                            |
-| file        | file contents | the sticker file to upload, must be a PNG, APNG, or Lottie JSON file, max 512 KB             |
+| file        | file contents | the sticker file to upload, must be a PNG, GIF, APNG, or Lottie JSON file, max 512 KB        |
 
 ## Modify Guild Sticker % PATCH /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/stickers/{sticker.id#DOCS_RESOURCES_STICKER/sticker-object}
 

--- a/docs/resources/Sticker.md
+++ b/docs/resources/Sticker.md
@@ -132,6 +132,8 @@ Every guilds has five free sticker slots by default, and each Boost level will g
 > warn
 > Lottie stickers can only be uploaded on guilds that have either the `VERIFIED` and/or the `PARTNERED` [guild feature](#DOCS_RESOURCES_GUILD/guild-object-guild-features). 
 
+> warn
+> Uploaded stickers are constrained to 5 seconds in length for animated stickers, and 256 x 256 pixels.
 ###### Form Params
 
 | Field       | Type          | Description                                                                                  |
@@ -139,7 +141,7 @@ Every guilds has five free sticker slots by default, and each Boost level will g
 | name        | string        | name of the sticker (2-30 characters)                                                        |
 | description | string        | description of the sticker (empty or 2-100 characters)                                       |
 | tags        | string        | autocomplete/suggestion tags for the sticker (max 200 characters)                            |
-| file        | file contents | the sticker file to upload, must be a PNG, APNG, GIF, or Lottie JSON file, max 500 KB        |
+| file        | file contents | the sticker file to upload, must be a PNG, APNG, or Lottie JSON file, max 512 KB             |
 
 ## Modify Guild Sticker % PATCH /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/stickers/{sticker.id#DOCS_RESOURCES_STICKER/sticker-object}
 

--- a/docs/resources/Sticker.md
+++ b/docs/resources/Sticker.md
@@ -141,7 +141,7 @@ Every guilds has five free sticker slots by default, and each Boost level will g
 | name        | string        | name of the sticker (2-30 characters)                                                        |
 | description | string        | description of the sticker (empty or 2-100 characters)                                       |
 | tags        | string        | autocomplete/suggestion tags for the sticker (max 200 characters)                            |
-| file        | file contents | the sticker file to upload, must be a PNG, GIF, APNG, or Lottie JSON file, max 512 KB        |
+| file        | file contents | the sticker file to upload, must be a PNG, APNG, GIF, or Lottie JSON file, max 512 KB        |
 
 ## Modify Guild Sticker % PATCH /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/stickers/{sticker.id#DOCS_RESOURCES_STICKER/sticker-object}
 


### PR DESCRIPTION
The current documentation does not note the 'hidden constraints' of uploading stickers.

Also as a note, the API actually accepts stickers uploaded up to **320 x 320** but that's a very strange size when it comes to graphics and computing (since everything else on the CDN comes in some power of 2).

Uploading a gif as a sticker seemingly always returns 50046, so that has also been removed.