### PR TITLE
Document `role_connections.write` Implicit grant incompatibility

### DIFF
--- a/docs/topics/OAuth2.md
+++ b/docs/topics/OAuth2.md
@@ -54,6 +54,7 @@ These are a list of all the OAuth2 scopes that Discord supports. Some scopes req
 
 > info
 > `guilds.join` and `bot` require you to have a bot account linked to your application. Also, in order to add a user to a guild, your bot has to already belong to that guild.
+> `role_connections.write` cannot be used with the [Implicit grant type](#DOCS_TOPICS_OAUTH2/implicit-grant).
 
 ## State and Security
 


### PR DESCRIPTION
Following fragement is provided:
`#error=invalid_scope&error_description=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed.`

As JSON:
```json
{
   "error": "invalid_scope",
   "error_description": "The requested scope is invalid, unknown, or malformed."
}
```