### PR TITLE
Document Silent Messages.

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -359,17 +359,18 @@ Represents a message sent in a channel within Discord.
 
 ###### Message Flags
 
-| Flag                                   | Value  | Description                                                                       |
-| -------------------------------------- | ------ | --------------------------------------------------------------------------------- |
-| CROSSPOSTED                            | 1 << 0 | this message has been published to subscribed channels (via Channel Following)    |
-| IS_CROSSPOST                           | 1 << 1 | this message originated from a message in another channel (via Channel Following) |
-| SUPPRESS_EMBEDS                        | 1 << 2 | do not include any embeds when serializing this message                           |
-| SOURCE_MESSAGE_DELETED                 | 1 << 3 | the source message for this crosspost has been deleted (via Channel Following)    |
-| URGENT                                 | 1 << 4 | this message came from the urgent message system                                  |
-| HAS_THREAD                             | 1 << 5 | this message has an associated thread, with the same id as the message            |
-| EPHEMERAL                              | 1 << 6 | this message is only visible to the user who invoked the Interaction              |
-| LOADING                                | 1 << 7 | this message is an Interaction Response and the bot is "thinking"                 |
-| FAILED_TO_MENTION_SOME_ROLES_IN_THREAD | 1 << 8 | this message failed to mention some roles and add their members to the thread     |
+| Flag                                   | Value   | Description                                                                       |
+| -------------------------------------- | ------  | --------------------------------------------------------------------------------- |
+| CROSSPOSTED                            | 1 << 0  | this message has been published to subscribed channels (via Channel Following)    |
+| IS_CROSSPOST                           | 1 << 1  | this message originated from a message in another channel (via Channel Following) |
+| SUPPRESS_EMBEDS                        | 1 << 2  | do not include any embeds when serializing this message                           |
+| SOURCE_MESSAGE_DELETED                 | 1 << 3  | the source message for this crosspost has been deleted (via Channel Following)    |
+| URGENT                                 | 1 << 4  | this message came from the urgent message system                                  |
+| HAS_THREAD                             | 1 << 5  | this message has an associated thread, with the same id as the message            |
+| EPHEMERAL                              | 1 << 6  | this message is only visible to the user who invoked the Interaction              |
+| LOADING                                | 1 << 7  | this message is an Interaction Response and the bot is "thinking"                 |
+| FAILED_TO_MENTION_SOME_ROLES_IN_THREAD | 1 << 8  | this message failed to mention some roles and add their members to the thread     |
+| SUPPRESS_NOTIFICATIONS                 | 1 << 12 | this message will not trigger push and desktop notifications                      |
 
 ###### Example Message
 


### PR DESCRIPTION
# Summary

Hey folks! This is actually my 2022 hackweek project which I got to finish to completion. :)

During a message send request, if you include the new `SUPPRESS_NOTIFICATIONS` flag it will not broadcast any push/desktop notifications but will still increment the relevant mention counters.

The intention is that you can get someone's attention but not feel like you could be distracting them. Like when you DM someone at 5am. I'm sure some bots can leverage this as well to avoid noise or something.

Also this should work for the webhook send request as well. And if you're looking to leverage this as a real user (*gasp* aren't you all just bots), you can write `@silent` as the _very first_ thing in a message.

https://user-images.githubusercontent.com/5456182/217641046-f3cb1f05-5cc2-4f88-92bb-6159215dd241.mov

Also sorry to all the users on Discord named silent who may have some textual conflict now. Forgive me!

# FAQ (for the product not really for this documentation change lol)

## Why is the UX `@silent` instead of a slash command?

Slash command UI is built for interactions with bots. You "basically" cannot mention anyone, or have long-form text, both of which are useful in this interaction scheme. I'm not here to promise anything just pointing it out for this feature.

## When is this rolling out?

Should be available on your next Desktop refresh. Mobile 164 and up should get it I believe?

## What happens if there's a user named "Silent" in the channel?

If you do not select the user in the autocomplete it will come out as a silent message. If you do select the user in the autocomplete it will mention the user instead.

## Is there autocomplete?

No. And it is not planned. Currently, we're considering this like a hidden feature. I think eventually the long-term plan is to put a "proper UI" in place for this instead of it being a text-based flag, which is honestly kinda jank.