### PR TITLE
Add "Block member interactions" to Action Types

### DIFF
--- a/docs/resources/Auto_Moderation.md
+++ b/docs/resources/Auto_Moderation.md
@@ -173,6 +173,7 @@ An action which will execute whenever a rule is triggered.
 | BLOCK_MESSAGE      | 1     | blocks a member's message and prevents it from being posted. A custom explanation can be specified and shown to members whenever their message is blocked. |
 | SEND_ALERT_MESSAGE | 2     | logs user content to a specified channel                                                                                                                   |
 | TIMEOUT            | 3     | timeout user for a specified duration *                                                                                                                    |
+| BLOCK_INTERACTIONS | 4     | prevents a member from using channels and interactions                                                                                                     |
 
 \* A `TIMEOUT` action can only be set up for `KEYWORD` and `MENTION_SPAM` rules. The `MODERATE_MEMBERS` permission is required to use the `TIMEOUT` action type.
 

--- a/docs/resources/Auto_Moderation.md
+++ b/docs/resources/Auto_Moderation.md
@@ -173,7 +173,7 @@ An action which will execute whenever a rule is triggered.
 | BLOCK_MESSAGE      | 1     | blocks a member's message and prevents it from being posted. A custom explanation can be specified and shown to members whenever their message is blocked. |
 | SEND_ALERT_MESSAGE | 2     | logs user content to a specified channel                                                                                                                   |
 | TIMEOUT            | 3     | timeout user for a specified duration *                                                                                                                    |
-| BLOCK_INTERACTIONS | 4     | prevents a member from using channels and interactions                                                                                                     |
+| QUARANTINE_USER    | 4     | prevents a member from using channels and interactions                                                                                                     |
 
 \* A `TIMEOUT` action can only be set up for `KEYWORD` and `MENTION_SPAM` rules. The `MODERATE_MEMBERS` permission is required to use the `TIMEOUT` action type.
 


### PR DESCRIPTION
"Block member interactions" is a new AutoMod Action Type related to the Member Profile Moderation feature.