### PR TITLE
Added YDE to API Types

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -103,3 +103,4 @@ If you're working on a project that interacts with our API, you might find an AP
 | ---------------------------------------------------------------------- | ---------- |
 | [dasgo](https://github.com/switchupcb/dasgo)                           | Go         |
 | [discord-api-types](https://github.com/discordjs/discord-api-types)    | JavaScript |
+| [yde](https://github.com/YDWK/YDE)                                     | Kotlin     |


### PR DESCRIPTION
YDE contains most of if not all of the discord entitles which are used in [ydwk](https://github.com/YDWK/YDWK) and these discord entities try as much as possible to adhere to the way discord has some but have some minor changes here and there such as with some minor changes to name or where some variables are located in some files but these changes do not make it significantly different.