### PR TITLE
Update User.md

### DIFF
--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -199,11 +199,12 @@ Returns a list of partial [guild](#DOCS_RESOURCES_GUILD/guild-object) objects th
 
 ###### Query String Params
 
-| Field  | Type      | Description                            | Required | Default |
-| ------ | --------- | -------------------------------------- | -------- | ------- |
-| before | snowflake | get guilds before this guild ID        | false    | absent  |
-| after  | snowflake | get guilds after this guild ID         | false    | absent  |
-| limit  | integer   | max number of guilds to return (1-200) | false    | 200     |
+| Field        | Type      | Description                                                                    | Required | Default |
+|--------------|-----------|--------------------------------------------------------------------------------|----------|---------|
+| before       | snowflake | get guilds before this guild ID                                                | false    | absent  |
+| after        | snowflake | get guilds after this guild ID                                                 | false    | absent  |
+| limit        | integer   | max number of guilds to return (1-200)                                         | false    | 200     |
+| with_counts? | boolean   | when `true`, will return approximate member and presence counts for each guild | false    | false   |
 
 ## Get Current User Guild Member % GET /users/@me/guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/member
 


### PR DESCRIPTION
Document the `with_counts` query string param for the Get Current User Guilds endpoint for returning the approx. member and presence counts in each guild. The image below is using the endpoint with a Bearer token:
![image](https://user-images.githubusercontent.com/46201432/228753299-3d593832-db5b-4032-be1d-c63cf66fdc5c.png)
