### PR TITLE
Document voice messages.

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -519,7 +519,7 @@ Voice messages are messages with the `IS_VOICE_MESSAGE` flag. They have the foll
 
 - They cannot be edited.
 - Only a single audio attachment is allowed. No content, stickers, etc...
-- The attachment has additional fields: `duration_secs` and `waveform`.
+- The [attachment](#DOCS_RESOURCES_CHANNEL/attachment-object) has additional fields: `duration_secs` and `waveform`.
 
 As of 2023-04-14, clients upload a 1 channel, 48000 Hz, 32kbps Opus stream in an OGG container.
 This is an implementation detail and may change without warning or documentation.
@@ -753,7 +753,7 @@ Embeds are deduplicated by URL.  If a message contains multiple embeds with the 
 | height?        | ?integer  | height of file (if image)                                                               |
 | width?         | ?integer  | width of file (if image)                                                                |
 | ephemeral? \*  | boolean   | whether this attachment is ephemeral                                                    |
-| duration_secs? | integer   | the duration of the audio file (currently for voice messages)                           |
+| duration_secs? | float     | the duration of the audio file (currently for voice messages)                           |
 | waveform?      | string    | base64 encoded bytearray representing a sampled waveform (currently for voice messages) |
 
 \* Ephemeral attachments will automatically be removed after a set period of time. Ephemeral attachments on messages are guaranteed to be available as long as the message itself exists.

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -376,6 +376,7 @@ Represents a message sent in a channel within Discord.
 | LOADING                                | 1 << 7  | this message is an Interaction Response and the bot is "thinking"                 |
 | FAILED_TO_MENTION_SOME_ROLES_IN_THREAD | 1 << 8  | this message failed to mention some roles and add their members to the thread     |
 | SUPPRESS_NOTIFICATIONS                 | 1 << 12 | this message will not trigger push and desktop notifications                      |
+| IS_VOICE_MESSAGE                       | 1 << 13 | this message is a voice message                                                   |
 
 ###### Example Message
 
@@ -511,6 +512,17 @@ There are multiple message types that have a message_reference object.  Since me
 - These are the first message in public threads created from messages. They point back to the message in the parent channel from which the thread was started. (type 21)
 - These messages have `message_id`, `channel_id`, and `guild_id`.
 - These messages will never have content, embeds, or attachments, mainly just the `message_reference` and `referenced_message` fields.
+
+#### Voice Messages
+
+Voice messages are messages with the `IS_VOICE_MESSAGE` flag. They have the following properties.
+
+- They cannot be edited.
+- Only a single audio attachment is allowed. No content, stickers, etc...
+- The attachment has additional fields: `duration_secs` and `waveform`.
+
+As of 2023-04-14, clients upload a 1 channel, 48000 Hz, 32kbps Opus stream in an OGG container.
+This is an implementation detail and may change without warning or documentation.
 
 ### Followed Channel Object
 
@@ -729,18 +741,20 @@ Embeds are deduplicated by URL.  If a message contains multiple embeds with the 
 > info
 > For the `attachments` array in Message Create/Edit requests, only the `id` is required.
 
-| Field         | Type      | Description                                                             |
-| ------------- | --------- | ----------------------------------------------------------------------- |
-| id            | snowflake | attachment id                                                           |
-| filename      | string    | name of file attached                                                   |
-| description?  | string    | description for the file (max 1024 characters)                          |
-| content_type? | string    | the attachment's [media type](https://en.wikipedia.org/wiki/Media_type) |
-| size          | integer   | size of file in bytes                                                   |
-| url           | string    | source url of file                                                      |
-| proxy_url     | string    | a proxied url of file                                                   |
-| height?       | ?integer  | height of file (if image)                                               |
-| width?        | ?integer  | width of file (if image)                                                |
-| ephemeral? \* | boolean   | whether this attachment is ephemeral                                    |
+| Field          | Type      | Description                                                                             |
+| -------------- | --------- | --------------------------------------------------------------------------------------- |
+| id             | snowflake | attachment id                                                                           |
+| filename       | string    | name of file attached                                                                   |
+| description?   | string    | description for the file (max 1024 characters)                                          |
+| content_type?  | string    | the attachment's [media type](https://en.wikipedia.org/wiki/Media_type)                 |
+| size           | integer   | size of file in bytes                                                                   |
+| url            | string    | source url of file                                                                      |
+| proxy_url      | string    | a proxied url of file                                                                   |
+| height?        | ?integer  | height of file (if image)                                                               |
+| width?         | ?integer  | width of file (if image)                                                                |
+| ephemeral? \*  | boolean   | whether this attachment is ephemeral                                                    |
+| duration_secs? | integer   | the duration of the audio file (currently for voice messages)                           |
+| waveform?      | string    | base64 encoded bytearray representing a sampled waveform (currently for voice messages) |
 
 \* Ephemeral attachments will automatically be removed after a set period of time. Ephemeral attachments on messages are guaranteed to be available as long as the message itself exists.
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -521,8 +521,11 @@ Voice messages are messages with the `IS_VOICE_MESSAGE` flag. They have the foll
 - Only a single audio attachment is allowed. No content, stickers, etc...
 - The [attachment](#DOCS_RESOURCES_CHANNEL/attachment-object) has additional fields: `duration_secs` and `waveform`.
 
+The `waveform` is intended to be a preview of the entire voice message, with 1 byte per datapoint encoded in base64. Clients sample the recording at most
+once per 100 milliseconds, but will downsample so that no more than 256 datapoints are in the waveform.
+
 As of 2023-04-14, clients upload a 1 channel, 48000 Hz, 32kbps Opus stream in an OGG container.
-This is an implementation detail and may change without warning or documentation.
+The encoding, and the waveform details, are an implementation detail and may change without warning or documentation.
 
 ### Followed Channel Object
 

--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -271,6 +271,11 @@ Along with the HTTP error code, our API can also return more detailed error code
 | 50145  | Cannot convert between premium emoji and normal emoji                                                                         |
 | 50146  | Uploaded file not found.                                                                                                      |
 | 50163  | Cannot delete guild subscription integration                                                                                  |
+| 50159  | Voice messages do not support additional content.                                                                             |
+| 50160  | Voice messages must have a single audio attachment.                                                                           |
+| 50161  | Voice messages must have supporting metadata.                                                                                 |
+| 50162  | Voice messages cannot be edited.                                                                                              |
+| 50173  | You cannot send voice messages in this channel.                                                                               |
 | 50600  | You do not have permission to send this sticker.                                                                              |
 | 60003  | Two factor is required for this operation                                                                                     |
 | 80004  | No users with DiscordTag exist                                                                                                |

--- a/docs/topics/Permissions.md
+++ b/docs/topics/Permissions.md
@@ -75,6 +75,7 @@ Below is a table of all current permissions, their integer values in hexadecimal
 | MODERATE_MEMBERS \*\*                  | `0x0000010000000000` `(1 << 40)` | Allows for timing out users to prevent them from sending or reacting to messages in chat and threads, and from speaking in voice and stage channels |              |
 | VIEW_CREATOR_MONETIZATION_ANALYTICS \* | `0x0000020000000000` `(1 << 41)` | Allows for viewing role subscription insights                                                                                                       |              |
 | USE_SOUNDBOARD                         | `0x0000040000000000` `(1 << 42)` | Allows for using soundboard in a voice channel                                                                                                      | V            |
+| SEND_VOICE_MESSAGES                    | `0x0000400000000000` `(1 << 46)` | Allows sending voice messages                                                                                                                       | T, V, S      |
 
 **\* These permissions require the owner account to use [two-factor authentication](#DOCS_TOPICS_OAUTH2/twofactor-authentication-requirement) when used on a guild that has server-wide 2FA enabled.**
 


### PR DESCRIPTION
# Summary

Voice messages has hit a form of general availability so it's time to bust out the API docs.

One thing to note is that even though voice messages are implemented as attachments, they do not require the Attach Files permission. The gating is purely on the Send Voice Message permission.

Bots are currently not able to send voice messages, mainly as a short-term implementation detail. This will change... eventually.

I wanted to document some implementation details about voice messages, but I'm not sure where to in the docs. So I just put there where I thought makes sense lol.

Also not sure if there's additional places that I should change 🤔 