### PR TITLE
document error code 50178

### DIFF
--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -271,6 +271,7 @@ Along with the HTTP error code, our API can also return more detailed error code
 | 50145  | Cannot convert between premium emoji and normal emoji                                                                         |
 | 50146  | Uploaded file not found.                                                                                                      |
 | 50163  | Cannot delete guild subscription integration                                                                                  |
+| 50178  | The user account must first be verified                                                                                       |
 | 50600  | You do not have permission to send this sticker.                                                                              |
 | 60003  | Two factor is required for this operation                                                                                     |
 | 80004  | No users with DiscordTag exist                                                                                                |


### PR DESCRIPTION
This error is returned if you [add guild member](https://discord.com/developers/docs/resources/guild#add-guild-member) with an account that is verification locked.