### PR TITLE
Update channel create message request size limit

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -990,7 +990,7 @@ Files must be attached using a `multipart/form-data` body as described in [Uploa
 - When sending a message with `tts` (text-to-speech) set to `true`, the current user must have the `SEND_TTS_MESSAGES` permission.
 - When creating a message as a reply to another message, the current user must have the `READ_MESSAGE_HISTORY` permission.
     - The referenced message must exist and cannot be a system message.
-- The maximum request size when sending a message is **8MiB**
+- The maximum request size when sending a message is **25 MiB**
 - For the embed object, you can set every field except `type` (it will be `rich` regardless of if you try to set it), `provider`, `video`, and any `height`, `width`, or `proxy_url` values for images.
 
 ###### JSON/Form Params

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -1265,7 +1265,7 @@ Creates a new thread in a forum channel, and sends a message within the created 
 - The type of the created thread is `PUBLIC_THREAD`.
 - See [message formatting](#DOCS_REFERENCE/message-formatting) for more information on how to properly format messages.
 - The current user must have the `SEND_MESSAGES` permission (`CREATE_PUBLIC_THREADS` is ignored).
-- The maximum request size when sending a message is **8MiB**.
+- The maximum request size when sending a message is **25 MiB**.
 - For the embed object, you can set every field except `type` (it will be `rich` regardless of if you try to set it), `provider`, `video`, and any `height`, `width`, or `proxy_url` values for images.
 - Examples for file uploads are available in [Uploading Files](#DOCS_REFERENCE/uploading-files).
 - Files must be attached using a `multipart/form-data` body as described in [Uploading Files](#DOCS_REFERENCE/uploading-files).


### PR DESCRIPTION
The default request limit was recently bumped to `25 MiB` and information about this change was only updated in one place (https://github.com/discord/discord-api-docs/pull/6078) which might confuse some people trying to figure out the exact limit.

I've updated the second place where the request size limit is mentioned.