### PR TITLE
update emoji gateway event information

### DIFF
--- a/docs/resources/Emoji.md
+++ b/docs/resources/Emoji.md
@@ -57,7 +57,7 @@ Emojis cannot be converted between normal and premium after creation.
 ###### Custom Emoji Examples
 
 >info
->In `MESSAGE_REACTION_ADD` gateway events `animated` will be returned for animated emoji.
+>In `MESSAGE_REACTION_ADD`, `MESSAGE_REACTION_REMOVE` and `MESSAGE_REACTION_REMOVE_EMOJI` gateway events `animated` will be returned for animated emoji.
 
 >info
 >In `MESSAGE_REACTION_ADD` and `MESSAGE_REACTION_REMOVE` gateway events `name` may be `null` when custom emoji data is not available (for example, if it was deleted from the guild).


### PR DESCRIPTION
The gateway events `MESSAGE_REACTION_REMOVE` and `MESSAGE_REACTION_REMOVE_EMOJI` have the field `emoji`.`animated` now when the reaction emoji was animated.

Ref: https://discord.com/channels/613425648685547541/801247546151403531/1104171572375326782
