### PR TITLE
clarify GET archived thread `before` query param

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -1378,10 +1378,10 @@ Returns archived threads in the channel that are public. When called on a `GUILD
 
 ###### Query String Params
 
-| Field   | Type              | Description                                  |
-| ------- | ----------------- | -------------------------------------------- |
-| before? | ISO8601 timestamp | returns threads before this timestamp        |
-| limit?  | integer           | optional maximum number of threads to return |
+| Field   | Type              | Description                                    |
+| ------- | ----------------- | ---------------------------------------------- |
+| before? | ISO8601 timestamp | returns threads archived before this timestamp |
+| limit?  | integer           | optional maximum number of threads to return   |
 
 ###### Response Body
 
@@ -1397,10 +1397,10 @@ Returns archived threads in the channel that are of [type](#DOCS_RESOURCES_CHANN
 
 ###### Query String Params
 
-| Field   | Type              | Description                                  |
-| ------- | ----------------- | -------------------------------------------- |
-| before? | ISO8601 timestamp | returns threads before this timestamp        |
-| limit?  | integer           | optional maximum number of threads to return |
+| Field   | Type              | Description                                    |
+| ------- | ----------------- | ---------------------------------------------- |
+| before? | ISO8601 timestamp | returns threads archived before this timestamp |
+| limit?  | integer           | optional maximum number of threads to return   |
 
 ###### Response Body
 


### PR DESCRIPTION
I was initially confused on if the `before` query param was with regards to the creation or archival time of the thread so thought this would be a worthwhile tweak.