### PR TITLE
change "lurkable" to "Discoverable" on get guild preview route

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -784,7 +784,7 @@ Returns the [guild](#DOCS_RESOURCES_GUILD/guild-object) object for the given id.
 ## Get Guild Preview % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/preview
 
 Returns the [guild preview](#DOCS_RESOURCES_GUILD/guild-preview-object) object for the given id. 
-If the user is not in the guild, then the guild must be have the "DISCOVERABLE" [feature](#DOCS_RESOURCES_GUILD/guild-object-guild-features).
+If the user is not in the guild, then the guild must have the "DISCOVERABLE" [feature](#DOCS_RESOURCES_GUILD/guild-object-guild-features).
 
 ## Modify Guild % PATCH /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}
 

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -783,7 +783,8 @@ Returns the [guild](#DOCS_RESOURCES_GUILD/guild-object) object for the given id.
 
 ## Get Guild Preview % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/preview
 
-Returns the [guild preview](#DOCS_RESOURCES_GUILD/guild-preview-object) object for the given id. If the user is not in the guild, then the guild must be lurkable.
+Returns the [guild preview](#DOCS_RESOURCES_GUILD/guild-preview-object) object for the given id. If the user is not in the guild, 
+then the guild must be have the "DISCOVERABLE" [feature](#DOCS_RESOURCES_GUILD/guild-object-guild-features).
 
 ## Modify Guild % PATCH /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}
 

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -784,7 +784,7 @@ Returns the [guild](#DOCS_RESOURCES_GUILD/guild-object) object for the given id.
 ## Get Guild Preview % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/preview
 
 Returns the [guild preview](#DOCS_RESOURCES_GUILD/guild-preview-object) object for the given id. 
-If the user is not in the guild, then the guild must have the "DISCOVERABLE" [feature](#DOCS_RESOURCES_GUILD/guild-object-guild-features).
+If the user is not in the guild, then the guild must be [discoverable](#DOCS_RESOURCES_GUILD/guild-object-guild-features).
 
 ## Modify Guild % PATCH /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}
 

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -783,8 +783,8 @@ Returns the [guild](#DOCS_RESOURCES_GUILD/guild-object) object for the given id.
 
 ## Get Guild Preview % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/preview
 
-Returns the [guild preview](#DOCS_RESOURCES_GUILD/guild-preview-object) object for the given id. If the user is not in the guild, 
-then the guild must be have the "DISCOVERABLE" [feature](#DOCS_RESOURCES_GUILD/guild-object-guild-features).
+Returns the [guild preview](#DOCS_RESOURCES_GUILD/guild-preview-object) object for the given id. 
+If the user is not in the guild, then the guild must be have the "DISCOVERABLE" [feature](#DOCS_RESOURCES_GUILD/guild-object-guild-features).
 
 ## Modify Guild % PATCH /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}
 


### PR DESCRIPTION
This changes the word `lurkable` to `Discoverable` on the Get [Guild Preview route](https://discord.com/developers/docs/resources/guild#get-guild-preview).