### PR TITLE
Document attachment flags

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -764,9 +764,9 @@ Embeds are deduplicated by URL.  If a message contains multiple embeds with the 
 
 ###### Attachment Flags
 
-| Flag                                   | Value   | Description                                                                       |
-| -------------------------------------- | ------  | --------------------------------------------------------------------------------- |
-| REMIX                                  | 1 << 2  | this attachment has been edited using the remix feature on mobile                 |
+| Flag     | Value  | Description                                                       |
+| -------- | ------ | ----------------------------------------------------------------- |
+| IS_REMIX | 1 << 2 | this attachment has been edited using the remix feature on mobile |
 
 ### Channel Mention Object
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -758,7 +758,7 @@ Embeds are deduplicated by URL.  If a message contains multiple embeds with the 
 | ephemeral? \*  | boolean   | whether this attachment is ephemeral                                                    |
 | duration_secs? | float     | the duration of the audio file (currently for voice messages)                           |
 | waveform?      | string    | base64 encoded bytearray representing a sampled waveform (currently for voice messages) |
-| flags?         | integer   | [arrachment flags](#DOCS_RESOURCES_CHANNEL/attachment-object-attachment-flags) combined as a [bitfield](https://en.wikipedia.org/wiki/Bit_field) |
+| flags?         | integer   | [attachment flags](#DOCS_RESOURCES_CHANNEL/attachment-object-attachment-flags) combined as a [bitfield](https://en.wikipedia.org/wiki/Bit_field) |
 
 \* Ephemeral attachments will automatically be removed after a set period of time. Ephemeral attachments on messages are guaranteed to be available as long as the message itself exists.
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -758,8 +758,15 @@ Embeds are deduplicated by URL.  If a message contains multiple embeds with the 
 | ephemeral? \*  | boolean   | whether this attachment is ephemeral                                                    |
 | duration_secs? | float     | the duration of the audio file (currently for voice messages)                           |
 | waveform?      | string    | base64 encoded bytearray representing a sampled waveform (currently for voice messages) |
+| flags?         | integer   | [arrachment flags](#DOCS_RESOURCES_CHANNEL/attachment-object-attachment-flags) combined as a [bitfield](https://en.wikipedia.org/wiki/Bit_field) |
 
 \* Ephemeral attachments will automatically be removed after a set period of time. Ephemeral attachments on messages are guaranteed to be available as long as the message itself exists.
+
+###### Attachment Flags
+
+| Flag                                   | Value   | Description                                                                       |
+| -------------------------------------- | ------  | --------------------------------------------------------------------------------- |
+| REMIX                                  | 1 << 2  | this attachment has been edited using the remix feature on mobile                 |
 
 ### Channel Mention Object
 


### PR DESCRIPTION
Documents the new attachment flags field and the flag `1 << 2` for the remix feature. I am not aware of any other flags on attachments.