### PR TITLE
make message_author_id optional

### DIFF
--- a/docs/topics/Gateway_Events.md
+++ b/docs/topics/Gateway_Events.md
@@ -906,15 +906,15 @@ Sent when a user adds a reaction to a message.
 
 ###### Message Reaction Add Event Fields
 
-| Field             | Type                                                         | Description                                                                                |
-| ----------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
-| user_id           | snowflake                                                    | ID of the user                                                                             |
-| channel_id        | snowflake                                                    | ID of the channel                                                                          |
-| message_id        | snowflake                                                    | ID of the message                                                                          |
-| guild_id?         | snowflake                                                    | ID of the guild                                                                            |
-| member?           | [member](#DOCS_RESOURCES_GUILD/guild-member-object) object   | Member who reacted if this happened in a guild                                             |
-| emoji             | a partial [emoji](#DOCS_RESOURCES_EMOJI/emoji-object) object | Emoji used to react - [example](#DOCS_RESOURCES_EMOJI/emoji-object-standard-emoji-example) |
-| message_author_id | snowflake                                                    | ID of the user who authored the message which was reacted to                                 |
+| Field              | Type                                                         | Description                                                                                |
+| ------------------ | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| user_id            | snowflake                                                    | ID of the user                                                                             |
+| channel_id         | snowflake                                                    | ID of the channel                                                                          |
+| message_id         | snowflake                                                    | ID of the message                                                                          |
+| guild_id?          | snowflake                                                    | ID of the guild                                                                            |
+| member?            | [member](#DOCS_RESOURCES_GUILD/guild-member-object) object   | Member who reacted if this happened in a guild                                             |
+| emoji              | a partial [emoji](#DOCS_RESOURCES_EMOJI/emoji-object) object | Emoji used to react - [example](#DOCS_RESOURCES_EMOJI/emoji-object-standard-emoji-example) |
+| message_author_id? | snowflake                                                    | ID of the user who authored the message which was reacted to                               |
 
 #### Message Reaction Remove
 


### PR DESCRIPTION
Made a mistake in merging #6102 without making `message_author_id` optional