### PR TITLE
Document global_name as optional

### DIFF
--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -29,7 +29,7 @@ There are other rules and restrictions not shared here for the sake of spam and 
 | id                 | snowflake | the user's id                                                                                        | identify              |
 | username           | string    | the user's username, not unique across the platform                                                  | identify              |
 | discriminator      | string    | the user's Discord-tag                                                                               | identify              |
-| global_name        | ?string   | the user's display name, if it is set. For bots, this is the application name                        | identify              |
+| global_name?       | ?string   | the user's display name, if it is set. For bots, this is the application name                        | identify              |
 | avatar             | ?string   | the user's [avatar hash](#DOCS_REFERENCE/image-formatting)                                           | identify              |
 | bot?               | boolean   | whether the user belongs to an OAuth2 application                                                    | identify              |
 | system?            | boolean   | whether the user is an Official Discord System user (part of the urgent message system)              | identify              |


### PR DESCRIPTION
`global_name` is optional (namely in the case of bots and webhooks)

`GET /users/@me` returns the following:
```json
{
  "id": "1055294262184509460",
  "username": "Kobalt",
  "avatar": "b9f018710c05cbaf6e9175a56e140e35",
  "discriminator": "3822",
  "public_flags": 524288,
  "flags": 524288,
  "bot": true,
  "bio": "",
  "locale": "en-US",
  "mfa_enabled": true,
  "premium_type": 0,
  "linked_users": [],
  "verified": true
}
```