### PR TITLE
Mark optional params for Modify Guild Channel Positions (#6147)

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -888,12 +888,12 @@ This endpoint takes a JSON array of parameters in the following format:
 
 ###### JSON Params
 
-| Field            | Type       | Description                                                                      |
-| ---------------- | ---------- | -------------------------------------------------------------------------------- |
-| id               | snowflake  | channel id                                                                       |
-| position         | ?integer   | sorting position of the channel                                                  |
-| lock_permissions | ?boolean   | syncs the permission overwrites with the new parent, if moving to a new category |
-| parent_id        | ?snowflake | the new parent ID for the channel that is moved                                  |
+| Field             | Type       | Description                                                                      |
+| ----------------- | ---------- | -------------------------------------------------------------------------------- |
+| id                | snowflake  | channel id                                                                       |
+| position?         | ?integer   | sorting position of the channel                                                  |
+| lock_permissions? | ?boolean   | syncs the permission overwrites with the new parent, if moving to a new category |
+| parent_id?        | ?snowflake | the new parent ID for the channel that is moved                                  |
 
 ## List Active Guild Threads % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/threads/active
 


### PR DESCRIPTION
Clarifies what parameters are optional for [Modify Guild Channel Positions](https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions).

- `position`
- `lock_permissions`
- `parent_id`