### PR TITLE
[Issues templates] Fix the label used for Developer Site Bug Reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/developer-site-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/developer-site-bug-report.yml
@@ -1,6 +1,6 @@
 name: Developer Site Bug Report
 description: A bug has been found with Discord's Developer site or documentation.
-labels: ["bug"]
+labels: ["developer portal"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
The Developer Site Bug Reports issue template uses the "bug" label, instead of the more specific "developer portal" label.

I believe this might have been an oversight when migrating the issues templates or smth.