### PR TITLE
Fix typo in example code of Getting Started

### DIFF
--- a/docs/Getting_Started.mdx
+++ b/docs/Getting_Started.mdx
@@ -394,7 +394,6 @@ const componentId = data.custom_id;
       await res.send({
         type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
         data: {
-          // Fetches a random emoji to send from a helper function
           content: 'What is your object of choice?',
           // Indicates it'll be an ephemeral message
           flags: InteractionResponseFlags.EPHEMERAL,


### PR DESCRIPTION
- Issues
    - No issue has been created
- Changes proposed in this pull request
    - Deleted a line of comment that didn't match the content of the code. I was confused while I was reading this part of document.
        - https://github.com/discord/discord-api-docs/blob/main/docs/Getting_Started.mdx#L397
    - I think it's left over after being copied and pasted from the test command. 
        - https://github.com/discord/discord-example-app/blob/main/app.js#L50

I'll also create a pull request to [discord-example-app](https://github.com/cabbage63/discord-example-app) repository.
