### PR TITLE
Add super-reactions to gateway events

### DIFF
--- a/docs/topics/Gateway_Events.md
+++ b/docs/topics/Gateway_Events.md
@@ -915,6 +915,8 @@ Sent when a user adds a reaction to a message.
 | member?            | [member](#DOCS_RESOURCES_GUILD/guild-member-object) object   | Member who reacted if this happened in a guild                                             |
 | emoji              | a partial [emoji](#DOCS_RESOURCES_EMOJI/emoji-object) object | Emoji used to react - [example](#DOCS_RESOURCES_EMOJI/emoji-object-standard-emoji-example) |
 | message_author_id? | snowflake                                                    | ID of the user who authored the message which was reacted to                               |
+| burst              | boolean                                                      | true if this is a super-reaction                                                           |
+| burst_colors?      | array of strings                                             | Colors used for super-reaction animation in "#rrggbb" format                               |
 
 #### Message Reaction Remove
 
@@ -929,6 +931,7 @@ Sent when a user removes a reaction from a message.
 | message_id | snowflake                                                    | ID of the message                                                                          |
 | guild_id?  | snowflake                                                    | ID of the guild                                                                            |
 | emoji      | a partial [emoji](#DOCS_RESOURCES_EMOJI/emoji-object) object | Emoji used to react - [example](#DOCS_RESOURCES_EMOJI/emoji-object-standard-emoji-example) |
+| burst      | boolean                                                      | true if this was a super-reaction                                                          |
 
 #### Message Reaction Remove All
 


### PR DESCRIPTION
Adds super-reactions related event members missing from #6056 
Was originally a PR to #6056 in https://github.com/Mateo-tem/discord-api-docs/pull/1, but #6056 was just recently merged before the author of #6056 merged my PR.

I have observed these super-reaction related members in the MESSAGE_REACTION_ADD and MESSAGE_REACTION_REMOVE events as demonstrated below:

<details>
<summary>Add and Remove Screenshots</summary>

![Screenshot_20230714_133238](https://github.com/Mateo-tem/discord-api-docs/assets/5211576/b9689dc4-f2d7-4190-be64-e81c59e7c98b)


![Screenshot_20230714_133004-1](https://github.com/Mateo-tem/discord-api-docs/assets/5211576/85edc0aa-9a03-417a-8fad-5e35301b776b)

</details>

`burst_colors` was left out of MESSAGE_REACTION_REMOVE because my findings show it is always empty even if it was a super-reaction

I have also observed similar members in the MESSAGE_REACTION_REMOVE_EMOJI event, but they don't seem to work the same way so they were omitted.

<details>
<summary>Add and Remove All Emoji Screenshots</summary>

![Screenshot_20230714_134227-1](https://github.com/Mateo-tem/discord-api-docs/assets/5211576/3bfc7449-3f41-452f-9faf-8983b0ab26c1)

![Screenshot_20230714_135019](https://github.com/Mateo-tem/discord-api-docs/assets/5211576/0e692dfa-a6b2-4536-b800-4374a77c239f)

</details>