### PR TITLE
docs: document connection type domain

### DIFF
--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -118,9 +118,9 @@ The connection object that the user has attached.
 |-----------------|---------------------|
 | battlenet       | Battle.net          |
 | bungie          | Bungie.net          |
+| domain          | Domain              |
 | ebay            | eBay                |
 | epicgames       | Epic Games          |
-| domain          | Domain              |
 | facebook        | Facebook            |
 | github          | GitHub              |
 | instagram       | Instagram           |

--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -120,6 +120,7 @@ The connection object that the user has attached.
 | bungie          | Bungie.net          |
 | ebay            | eBay                |
 | epicgames       | Epic Games          |
+| domain          | Domain              |
 | facebook        | Facebook            |
 | github          | GitHub              |
 | instagram       | Instagram           |


### PR DESCRIPTION
Added the connection type `domain` based on the api response and the clients ui name.

```json
{
    "type":"domain",
    "id":"pycord.dev",
    "name":"pycord.dev",
    "verified":true
}
```
![client ui](https://github.com/discord/discord-api-docs/assets/14029133/458ace91-ba9b-4d48-a699-188c4e7830a8)

