### PR TITLE
build: move to ESM and update chalk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"@types/node": "^20.6.2",
 				"@typescript-eslint/eslint-plugin": "^6.7.0",
 				"@typescript-eslint/parser": "^6.7.0",
-				"chalk": "^4.1.2",
+				"chalk": "^5.3.0",
 				"eslint": "^8.49.0",
 				"eslint-config-prettier": "^9.0.0",
 				"eslint-plugin-prettier": "^5.0.0",
@@ -560,16 +560,12 @@
 			}
 		},
 		"node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
 			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
@@ -839,6 +835,22 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
 		"node_modules/espree": {
@@ -2576,14 +2588,10 @@
 			"dev": true
 		},
 		"chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			}
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+			"dev": true
 		},
 		"color-convert": {
 			"version": "2.0.1",
@@ -2727,6 +2735,18 @@
 				"optionator": "^0.9.3",
 				"strip-ansi": "^6.0.1",
 				"text-table": "^0.2.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				}
 			}
 		},
 		"eslint-config-prettier": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "1.1.1",
 	"description": "Documentation for using Discord's API",
 	"main": "index.js",
+	"type": "module",
 	"directories": {
 		"doc": "docs"
 	},
@@ -29,7 +30,7 @@
 		"@types/node": "^20.6.2",
 		"@typescript-eslint/eslint-plugin": "^6.7.0",
 		"@typescript-eslint/parser": "^6.7.0",
-		"chalk": "^4.1.2",
+		"chalk": "^5.3.0",
 		"eslint": "^8.49.0",
 		"eslint-config-prettier": "^9.0.0",
 		"eslint-plugin-prettier": "^5.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,12 @@
 {
 	"compilerOptions": {
-		"target": "ES2021",
-		"lib": ["ESNext"],
-		"skipLibCheck": true,
+		"target": "ES2022",
 		"strict": true,
-		"alwaysStrict": true,
-		"forceConsistentCasingInFileNames": true,
 		"esModuleInterop": true,
-		"module": "commonjs",
-		"moduleResolution": "node",
-		"isolatedModules": true,
 		"rootDir": "./",
+		"module": "ES2022",
+		"moduleResolution": "Node",
 		"outDir": "./dist"
 	},
 	"include": ["**/*.ts"],
-	"exclude": ["node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,7 @@
 		"strict": true,
 		"esModuleInterop": true,
 		"rootDir": "./",
-		"module": "ES2022",
-		"moduleResolution": "Node",
+		"module": "NodeNext",
 		"outDir": "./dist"
 	},
 	"include": ["**/*.ts"],


### PR DESCRIPTION
https://github.com/discord/discord-api-docs/pull/6417 is failing because it looks like the latest version of chalk requires ESM.  I updated this to be an ESM package, cleaned up some unneccessary tsconfig, and validated the import into the dev portal still works.  It seems to be ok?