### PR TITLE
Premium Apps: SKU and Entitlement fields

### DIFF
--- a/docs/monetization/Entitlements.md
+++ b/docs/monetization/Entitlements.md
@@ -10,12 +10,12 @@ Entitlements in Discord represent that a user or guild has access to a premium o
 |----------------|-------------------|---------------------------------------------------------------------------------------------|
 | id             | snowflake         | ID of the entitlement                                                                       |
 | sku_id         | snowflake         | ID of the SKU                                                                               |
-| user_id?       | snowflake         | ID of the user that is granted access to the entitlement's sku                              |
-| guild_id?      | snowflake         | ID of the guild that is granted access to the entitlement's sku                             |
 | application_id | snowflake         | ID of the parent application                                                                |
+| user_id?       | snowflake         | ID of the user that is granted access to the entitlement's sku                              |
 | type           | integer           | [Type of entitlement](#DOCS_MONETIZATION_ENTITLEMENTS/entitlement-object-entitlement-types) |
 | starts_at?     | ISO8601 timestamp | Start date at which the entitlement is valid. Not present when using test entitlements.     |
 | ends_at?       | ISO8601 timestamp | Date at which the entitlement is no longer valid. Not present when using test entitlements. |
+| guild_id?      | snowflake         | ID of the guild that is granted access to the entitlement's sku                             |
 
 ###### Entitlement Example
 

--- a/docs/monetization/Entitlements.md
+++ b/docs/monetization/Entitlements.md
@@ -14,7 +14,6 @@ Entitlements in Discord represent that a user or guild has access to a premium o
 | guild_id?      | snowflake         | ID of the guild that is granted access to the entitlement's sku                             |
 | application_id | snowflake         | ID of the parent application                                                                |
 | type           | integer           | [Type of entitlement](#DOCS_MONETIZATION_ENTITLEMENTS/entitlement-object-entitlement-types) |
-| consumed       | boolean           | Not applicable for App Subscriptions. Subscriptions are not consumed and will be `false`    |
 | starts_at?     | ISO8601 timestamp | Start date at which the entitlement is valid. Not present when using test entitlements.     |
 | ends_at?       | ISO8601 timestamp | Date at which the entitlement is no longer valid. Not present when using test entitlements. |
 

--- a/docs/monetization/Entitlements.md
+++ b/docs/monetization/Entitlements.md
@@ -13,6 +13,7 @@ Entitlements in Discord represent that a user or guild has access to a premium o
 | application_id | snowflake         | ID of the parent application                                                                |
 | user_id?       | snowflake         | ID of the user that is granted access to the entitlement's sku                              |
 | type           | integer           | [Type of entitlement](#DOCS_MONETIZATION_ENTITLEMENTS/entitlement-object-entitlement-types) |
+| deleted        | boolean           | Entitlement was deleted                                                                     |
 | starts_at?     | ISO8601 timestamp | Start date at which the entitlement is valid. Not present when using test entitlements.     |
 | ends_at?       | ISO8601 timestamp | Date at which the entitlement is no longer valid. Not present when using test entitlements. |
 | guild_id?      | snowflake         | ID of the guild that is granted access to the entitlement's sku                             |

--- a/docs/monetization/Entitlements.md
+++ b/docs/monetization/Entitlements.md
@@ -162,7 +162,7 @@ Entitlements are _not_ deleted when they expire.
 
 ### PREMIUM_REQUIRED Interaction Response
 
-If your app has monetization enabled, it will have access to a new [`PREMIUM_REQUIRED` interaction response (`type: 10`)](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-response-object-interaction-callback-type). This can be sent in response to any kind of interaction. It does not allow a `content` field.
+If your app has monetization enabled, it will have access to a new [`PREMIUM_REQUIRED` interaction response (`type: 10`)](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-response-object-interaction-callback-type). This can be sent in response to all interaction types except for `APPLICATION_COMMAND_AUTOCOMPLETE` and `PING`. The response does not allow returning the `content`, `embeds`, or `attachments` fields.
 
 This response will create an ephemeral message shown to the user that ran the interaction, instructing them that whatever they tried to do requires the premium benefits of your app. It also contains an "Upgrade" button to subscribe. The response message is static, but will be automatically updated with the name of your premium SKU.
 

--- a/docs/monetization/Entitlements.md
+++ b/docs/monetization/Entitlements.md
@@ -54,8 +54,8 @@ Returns all entitlements for a given app, active and expired.
 |----------------|-----------------------------------|------------------------------------------------------|
 | user_id?       | snowflake                         | User ID to look up entitlements for                  |
 | sku_ids?       | comma-delimited set of snowflakes | Optional list of SKU IDs to check entitlements for   |
-| before?        | snowflake                         | Retrieve entitlements before this time               |
-| after?         | snowflake                         | Retrieve entitlements after this time                |
+| before?        | snowflake                         | Retrieve entitlements before this entitlement ID     |
+| after?         | snowflake                         | Retrieve entitlements after this entitlement ID      |
 | limit?         | integer                           | Number of entitlements to return, 1-100, default 100 |
 | guild_id?      | snowflake                         | Guild ID to look up entitlements for                 |
 | exclude_ended? | boolean                           | Whether entitlements should be omitted               |

--- a/docs/monetization/SKUs.md
+++ b/docs/monetization/SKUs.md
@@ -53,10 +53,11 @@ For subscriptions, there are two types of access levels you can offer to users:
 
 The `flags` field can be used to differentiate user and server subscriptions with a bitwise `&&` operator.
 
-| Value  | Type               |
-|--------|--------------------|
-| 1 << 7 | GUILD_SUBSCRIPTION |
-| 1 << 8 | USER_SUBSCRIPTION  |
+| Value  | Type               | Description                                                                                                               |
+|--------|--------------------|---------------------------------------------------------------------------------------------------------------------------|
+| 1 << 2 | AVAILABLE          | SKU is available for purchase                                                                                             |
+| 1 << 7 | GUILD_SUBSCRIPTION | Recurring SKU that can be purchased by a user and applied to a single server. Grants access to every user in that server. |
+| 1 << 8 | USER_SUBSCRIPTION  | Recurring SKU purchased by a user for themselves. Grants access to the purchasing user in every server.                   |
 
 ## Customizing Your SKUs
 

--- a/docs/topics/Gateway_Events.md
+++ b/docs/topics/Gateway_Events.md
@@ -550,18 +550,15 @@ Sent when a message is pinned or unpinned in a text channel. This is not sent wh
 
 #### Entitlement Create
 
-Sent when an entitlement is created. The inner payload is a [entitlement](#DOCS_MONETIZATION_ENTITLEMENTS/entitlement-object) object.
+Sent when an entitlement is created. The inner payload is an [entitlement](#DOCS_MONETIZATION_ENTITLEMENTS/entitlement-object) object.
 
 #### Entitlement Update
 
-Sent when an entitlement is renewed for the next billing period. The inner payload is an [entitlement](#DOCS_MONETIZATION_ENTITLEMENTS/entitlement-object) object. The `ends_at` field will have an updated value with the new expiration date.
+Sent when an entitlement is updated. The inner payload is an [entitlement](#DOCS_MONETIZATION_ENTITLEMENTS/entitlement-object) object. 
 
 #### Entitlement Delete
 
-Sent when an entitlement is deleted. The inner payload is a [entitlement](#DOCS_MONETIZATION_ENTITLEMENTS/entitlement-object) object. Entitlements are not deleted when they expire. Entitlement deletions are infrequent and only occur when:
-
--   Discord issues a refund for a subscription
--   Discord removes an entitlement from a user via internal tooling
+Sent when an entitlement is deleted. The inner payload is an [entitlement](#DOCS_MONETIZATION_ENTITLEMENTS/entitlement-object) object. Entitlements are not deleted when they expire.
 
 ### Guilds
 

--- a/docs/topics/Gateway_Events.md
+++ b/docs/topics/Gateway_Events.md
@@ -554,7 +554,7 @@ Sent when an entitlement is created. The inner payload is an [entitlement](#DOCS
 
 #### Entitlement Update
 
-Sent when an entitlement is updated. The inner payload is an [entitlement](#DOCS_MONETIZATION_ENTITLEMENTS/entitlement-object) object. 
+Sent when an entitlement is updated. The inner payload is an [entitlement](#DOCS_MONETIZATION_ENTITLEMENTS/entitlement-object) object. When an entitlement for a subscription is renewed, the `ends_at` field may have an updated value with the new expiration date.
 
 #### Entitlement Delete
 

--- a/docs/topics/Gateway_Events.md
+++ b/docs/topics/Gateway_Events.md
@@ -292,6 +292,9 @@ Receive events are Gateway events encapsulated in an [event payload](#DOCS_TOPIC
 | [Thread List Sync](#DOCS_TOPICS_GATEWAY_EVENTS/thread-list-sync)                                             | Sent when gaining access to a channel, contains all active threads in that channel                                                             |
 | [Thread Member Update](#DOCS_TOPICS_GATEWAY_EVENTS/thread-member-update)                                     | [Thread member](#DOCS_RESOURCES_CHANNEL/thread-member-object) for the current user was updated                                                 |
 | [Thread Members Update](#DOCS_TOPICS_GATEWAY_EVENTS/thread-members-update)                                   | Some user(s) were added to or removed from a thread                                                                                            |
+| [Entitlement Create](#DOCS_TOPICS_GATEWAY_EVENTS/entitlement-create)                                         | Entitlement was created                                                                                                                        |
+| [Entitlement Update](#DOCS_TOPICS_GATEWAY_EVENTS/entitlement-update)                                         | Entitlement was updated or renewed                                                                                                             |
+| [Entitlement Delete](#DOCS_TOPICS_GATEWAY_EVENTS/entitlement-delete)                                         | Entitlement was deleted                                                                                                                        |
 | [Guild Create](#DOCS_TOPICS_GATEWAY_EVENTS/guild-create)                                                     | Lazy-load for unavailable guild, guild became available, or user joined a new guild                                                            |
 | [Guild Update](#DOCS_TOPICS_GATEWAY_EVENTS/guild-update)                                                     | Guild was updated                                                                                                                              |
 | [Guild Delete](#DOCS_TOPICS_GATEWAY_EVENTS/guild-delete)                                                     | Guild became unavailable, or user left/was removed from a guild                                                                                |
@@ -542,6 +545,23 @@ Sent when a message is pinned or unpinned in a text channel. This is not sent wh
 | guild_id?           | snowflake          | ID of the guild                                         |
 | channel_id          | snowflake          | ID of the channel                                       |
 | last_pin_timestamp? | ?ISO8601 timestamp | Time at which the most recent pinned message was pinned |
+
+### Entitlements
+
+#### Entitlement Create
+
+Sent when an entitlement is created. The inner payload is a [entitlement](#DOCS_MONETIZATION_ENTITLEMENTS/entitlement-object) object.
+
+#### Entitlement Update
+
+Sent when an entitlement is renewed for the next billing period. The inner payload is an [entitlement](#DOCS_MONETIZATION_ENTITLEMENTS/entitlement-object) object. The `ends_at` field will have an updated value with the new expiration date.
+
+#### Entitlement Delete
+
+Sent when an entitlement is deleted. The inner payload is a [entitlement](#DOCS_MONETIZATION_ENTITLEMENTS/entitlement-object) object. Entitlements are not deleted when they expire. Entitlement deletions are infrequent and only occur when:
+
+-   Discord issues a refund for a subscription
+-   Discord removes an entitlement from a user via internal tooling
 
 ### Guilds
 


### PR DESCRIPTION
Addressing docs for Entitlements (#6476)

> The subscription_id, promotion_id, deleted, and gift_code_flags fields are undocumented.

- Added `deleted`. 
- `subscription_id`, `promotion_id` and `gift_code_flags` to remain undocumented at this time
- Updated `before` and `after` param descriptions for List Entitlements to be more explicit. Snowflake IDs are time-ordered.

Addressing docs for SKUs (#6468)
> The flags field is mentioned in a bunch of places in the [SKU documentation](https://discord.com/developers/docs/monetization/skus#sku-resource) but it's not documented.
Furthermore, the json includes a bunch more info that aren't present in the object structure documentation.

- Flags was added to documentation in #6452
- Removed `consumed` as it is not usable by devs

For both models:
- The JSON examples **DO** contain fields not included in the table. Fields that can be used by devs **today** are documented in the tables with descriptions. Something we hope to address in the future but for now, rely on the defined fields.