### PR TITLE
fix: do not translate blocks

### DIFF
--- a/docs/ja/Getting_Started.mdx
+++ b/docs/ja/Getting_Started.mdx
@@ -61,7 +61,7 @@ BotトークンはAPIリクエストの認証に使われ、Botユーザーの�
 
 トークンをコピーし、安全な場所（パスワードマネージャーなど）に保管しておきましょう。
 
-> 警告
+> warn
 > トークンは再生成しない限り2度と見ることはできませんので、必ず安全な場所に保管してください。
 
 ### スコープとBot権限を追加する
@@ -77,7 +77,7 @@ BotトークンはAPIリクエストの認証に使われ、Botユーザーの�
 
 左側のサイドバーで**OAuth2**をクリックし、続いて**URLジェネレータ（URL generator）**を選択します。
 
-> 情報
+> info
 > URLジェネレータは、あなたがアプリ用に選択したスコープと権限に基づいてインストール用リンクを生成します。このリンクで自分のサーバーにアプリをインストールできるほか、他の人と共有してインストールしてもらうこともできます。
 
 今のところは2つのスコープを追加してみましょう：
@@ -92,7 +92,7 @@ BotトークンはAPIリクエストの認証に使われ、Botユーザーの�
 
 ![URLジェネレータのスクリーンショット](url-generator.png)
 
-> 情報
+> info
 > アプリ開発にあたっては、他の人がアクティブに利用していないサーバーでビルドおよびテストを行ってください。自分のサーバーがまだない方は、[無料で作成できます](https://support.discord.com/hc/en-us/articles/204849977-How-do-I-create-a-server-)。
 
 上記よりURLをコピーし、ブラウザにペーストしてください。インストールのステップを踏む際は、アプリの開発とテストをできるサーバーに間違いなくインストールしていることを確かめてください。
@@ -113,7 +113,7 @@ BotトークンはAPIリクエストの認証に使われ、Botユーザーの�
 
 このガイドでは、ブラウザでクローンと開発ができるGlitchを使用しています。ローカルでアプリの開発をしたい場合は、[README](https://github.com/discord/discord-example-app#running-app-locally)にngrokの使い方が掲載されています。
 
-> 情報
+> info
 > Glitchは開発とテストには最適ですが、[技術的な制限があるため](https://help.glitch.com/hc/en-us/articles/16287495313293-Technical-Restrictions)、プロダクションアプリについては他のホスティング・プロバイダをご検討ください。
 
 まず**[Glitchプロジェクトをリミックス（またはクローン）しましょう🎏](https://glitch.com/edit/#!/import/git?url=https://github.com/discord/discord-example-app.git)**
@@ -162,7 +162,7 @@ BotトークンはAPIリクエストの認証に使われ、Botユーザーの�
 
 ### スラッシュコマンドをインストールする
 
-> 情報
+> info
 > アプリはスラッシュコマンドをインストールするにあたり、[`node-fetch`](https://github.com/node-fetch/node-fetch)を利用しています。インストールの実装は、`DiscordRequest()`関数内の`utils.js`で確認できます。
 
 プロジェクトには`register`スクリプトが含まれています。これを用いて、`commands.js`の最下部で定義されている`ALL_COMMANDS`のコマンドをインストールできます。これはHTTP APIの[`PUT /applications/<APP_ID>/commands`](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/bulk-overwrite-global-application-commands)エンドポイントを呼び出すことで、コマンドをグローバルコマンドとしてインストールします。
@@ -196,7 +196,7 @@ Discordでは、アプリがスラッシュコマンド・リクエスト（お�
 
 Glitchプロジェクトでは、デフォルトで公開URLが見られるようになっています。右上隅の**共有（Share）**ボタンをクリックしてプロジェクトのURLをコピーし、続いてモーダルの下部近くにある「ライブ中のサイト（Live Site）」プロジェクトリンクをコピーしてください。
 
-> 情報
+> info
 > ローカルで開発をしている場合は、ローカルの環境にリクエストをトンネリングする手順を[Github README](https://github.com/discord/discord-example-app#running-app-locally)で確認できます。
 
 リンクがコピーできたら、[開発者ポータル](https://discord.com/developers/applications)からアプリの設定を開きます。
@@ -233,7 +233,7 @@ if (name === 'test') {
 
 上記のコードは、起点となったチャンネルにおけるメッセージとのインタラクションに応答しています。可能な応答タイプ（モーダルで応答するなど）は[ドキュメント](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-response-object-interaction-callback-type)でご確認いただけます。
 
-> 情報
+> info
 > `InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE`は[`discord-interactions`からエクスポートされた](https://github.com/discord/discord-interactions-js/blob/main/src/index.ts#L33)定数です
 
 サーバーに移動し、アプリの`/test`スラッシュコマンドが機能することを確かめましょう。トリガーすると、アプリは「hello world」という言葉のあとにランダムな絵文字を含むメッセージを送信するはずです。
@@ -252,7 +252,7 @@ if (name === 'test') {
 
 コマンドオプションとその構造については[ドキュメント](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-object-application-command-option-structure)をご覧ください。
 
-> 情報
+> info
 > このガイドでは`game.js`にはあまり深入りしませんが、コマンドやコマンド内のオプションを変えるなど、いろいろといじってみましょう。
 
 <Collapsible title="コマンド・インタラクションをハンドリングする" description="challengeコマンドをハンドリングし、ボタンを含むメッセージで応答するためのコード" icon="code" open>
@@ -296,7 +296,7 @@ if (name === 'challenge' && id) {
 ```
 
 
-> 情報
+> info
 > コードをペーストする場所が分からない場合は、Glitchプロジェクトの`examples/app.js`でコード全体を見るか、[Github](https://github.com/discord/discord-example-app/blob/main/app.js)でルート`app.js`を見てみましょう。
 
 上記のコードは、次のような動きをしています：
@@ -304,7 +304,7 @@ if (name === 'challenge' && id) {
 2. インタラクションIDを使用して、`activeGames`オブジェクトに新しいゲームを追加します。アクティブなゲームは`userId`と`objectName`を記録します。
 3. チャンネルに、`accept_button_<SOME_ID>`の`custom_id`を伴う、ボタンのついたメッセージを送り返します。
 
-> 警告
+> warn
 > サンプルコードではオブジェクトをメモリ内ストレージとして使用していますが、プロダクションアプリではデータベースを使用してください。
 
 [メッセージ・コンポーネント](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/what-is-a-component)を伴うメッセージを送るとき、個々のペイロードは`components`アレイにアペンドされます。実行可能なコンポーネント（ボタンなど）は、コードサンプルで確認できる[アクション行](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/action-rows)の中にある必要があります。

--- a/docs/nl/Getting_Started.mdx
+++ b/docs/nl/Getting_Started.mdx
@@ -304,7 +304,7 @@ De bovenstaande code doet een aantal dingen:
 2. Hij voegt een nieuw spel toe aan het object `activeGames` met behulp van de interactie-ID. Het actieve spel registreert de `userId` en `objectName`.
 3. Hij stuurt een bericht met daarin een knop met een `custom_id` van `accept_button_<SOME_ID>` naar het kanaal terug.
 
-> waarschuwing
+> warn
 > De voorbeeldcode gebruikt een object als opslag in het geheugen, maar voor productie-apps moet je een database gebruiken.
 
 Bij het sturen van een bericht met [berichtonderdelen](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/what-is-a-component) worden de individuele payloads aan een `components`-lijst toegevoegd. Onderdelen waar acties mee worden uitgevoerd (zoals knoppen) moeten deel uitmaken van een [actierij](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/action-rows), die je in het codevoorbeeld ziet staan.

--- a/docs/pl/Getting_Started.mdx
+++ b/docs/pl/Getting_Started.mdx
@@ -31,7 +31,7 @@ Poniżej przedstawiono szczegółowy zarys przepływu użytkowników:
 
 ## Krok 1: Tworzenie aplikacji
 
-Najpierw musisz stworzyć aplikację w portalu deweloperów, jeśli jeszcze jej nie masz:
+Najpierw musisz stworzyć aplikację w portalu deweloperów, jeśli jeszcze tego nie zrobiłeś:
 
 <Button href="https://discord.com/developers/applications?new_application=true" color="brand">Stwórz aplikację</Button>
 
@@ -61,7 +61,7 @@ Tokeny bota służą do uwierzytelniania żądań API i zawierają uprawnienia u
 
 Skopiuj token i zapisz go w bezpiecznym miejscu (np. menedżerze haseł).
 
-> ostrzeżenie
+> warn
 > Nie będzie można wyświetlić tokena ponownie, chyba że wygenerujesz go od nowa, więc przechowaj token w bezpiecznym miejscu.
 
 ### Dodawanie zakresów i uprawnień bota
@@ -77,7 +77,7 @@ Podczas tworzenia aplikacji zakresy i uprawnienia określają, co Twoja aplikacj
 
 Kliknij **OAuth2** na lewym pasku bocznym, a następnie wybierz **Generator adresu URL**.
 
-> informacje
+> info
 > Generator adresu URL tworzy łącze instalacyjne na podstawie zakresów i uprawnień wybranych dla aplikacji. Możesz użyć łącza do instalacji aplikacji na swoim serwerze lub udostępnić je innym, aby mogli zainstalować aplikację.
 
 Na razie dodaj dwa zakresy:
@@ -92,10 +92,10 @@ Po dodaniu zakresów powinien zostać wyświetlony adres URL, który możesz sko
 
 ![Zrzut ekranu generatora adresu URL](url-generator.png)
 
-> informacje
-> Podczas pracy nad aplikacjami należy budować i testować je na serwerze, który nie jest aktywnie używany przez innych. Jeśli nie masz jeszcze własnego serwera, możesz [utworzyć go za darmo](https://support.discord.com/hc/en-us/articles/204849977-How-do-I-create-a-server-).
+> info
+> Podczas pracy nad aplikacjami należy budować i testować je na serwerze, który nie jest aktywnie używany przez innych. Jeśli nie masz jeszcze własnego serwera, możesz [utworzyć go za darmo](https://support.discord.com/hc/pl/articles/204849977-Jak-stworzy%C4%87-serwer-).
 
-Skopiuj powyższy adres URL i wklej go w swojej przeglądarce. Zostanie wyświetlony interfejs instalacji, w którym należy upewnić się, że instalujesz aplikację na serwerze, na którym możesz rozwijać ją i testować.
+Skopiuj powyższy adres URL i wklej go w swojej przeglądarce. Zostanie wyświetlony interfejs instalacji, w którym należy upewnić się, że instalujesz aplikację na serwerze, na którym możesz ją rozwijać i testować.
 
 Po zainstalowaniu aplikacji przejdź do serwera, aby zobaczyć, czy została do niego dodana ✨
 
@@ -113,8 +113,8 @@ Aby uprościć nieco pracę, aplikacja wykorzystuje bibliotekę [discord-interac
 
 W tym przewodniku używamy narzędzia Glitch, które pozwala sklonować aplikację i pracować nad nią w przeglądarce. Jeśli wolisz pracować nad aplikacją lokalnie, zobacz instrukcje dotyczące używania narzędzia ngrok [w README](https://github.com/discord/discord-example-app#running-app-locally).
 
-> informacje
-> Choć rozwiązanie Glitch znakomicie nadaje się do pracy nad aplikacją i jej testowania, [ma ograniczenia techniczne,](https://help.glitch.com/kb/article/17-technical-restrictions/) więc należy rozważyć użycie innych dostawców usług hostingowych do publicznej wersji aplikacji.
+> info
+> Choć rozwiązanie Glitch znakomicie nadaje się do pracy nad aplikacją i jej testowania, [ma ograniczenia techniczne](https://help.glitch.com/kb/article/17-technical-restrictions/), więc należy rozważyć użycie innych dostawców usług hostingowych do publicznej wersji aplikacji.
 
 Aby zacząć, **[edytuj (lub sklonuj) projekt Glitch 🎏](https://glitch.com/edit/#!/import/git?url=https://github.com/discord/discord-example-app.git)**.
 
@@ -124,7 +124,7 @@ Po edytowaniu projektu zostanie otwarty nowy projekt Glitch.
 ![Przegląd projektu Glitch](glitch-project.png)
 
 - **Nazwa projektu** to unikalna nazwa produktu widoczna w lewym górnym rogu
-- **`.env`** to plik, w którym są przechowywane wszystkie Twoje dane uwierzytelniające do aplikacji
+- **`.env`** to plik, w którym są przechowywane Twoje wszystkie dane uwierzytelniające do aplikacji
 - **Dzienniki** zawierają dane wyjściowe projektu – pomagają one w ustaleniu, czy aplikacja działa; znajdziesz tu również informacje o wszelkich błędach występujących w aplikacji
 - Przycisk **Udostępnij** w prawym górnym rogu pozwala uzyskać aktywny adres URL projektu, który będzie potrzebny do skonfigurowania interaktywności w dalszej części przewodnika
 </Collapsible>
@@ -162,7 +162,7 @@ Po skonfigurowaniu danych uwierzytelniających czas zainstalować i wdrożyć po
 
 ### Instalacja poleceń z ukośnikiem
 
-> informacje
+> info
 > Aplikacja wykorzystuje moduł [`node-fetch`](https://github.com/node-fetch/node-fetch) do instalacji poleceń z ukośnikiem. Kod odpowiedzialny za instalację znajduje się w pliku `utils.js`, w funkcji `DiscordRequest()`.
 
 Projekt zawiera skrypt `register`, którego możesz użyć do instalacji poleceń w elemencie `ALL_COMMANDS`, który jest zdefiniowany na końcu pliku `commands.js`. Instaluje on polecenia jako globalne polecenia, wywołując punkt końcowy [`PUT /applications/<APP_ID>/commands`](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/bulk-overwrite-global-application-commands) API HTTP.
@@ -196,7 +196,7 @@ Aby umożliwić aplikacji otrzymywanie żądań w postaci poleceń z ukośnikiem
 
 Projekty Glitch mają publiczny adres URL, który jest domyślnie ujawniony. Skopuj go, klikając przycisk **Udostępnij** w prawym górnym rogu, a następnie skopiuj łącze projektu „Aktywna witryna” blisko dolnej części okna.
 
-> informacje
+> info
 > Jeśli pracujesz nad aplikacją lokalnie, zobacz instrukcje dotyczące przekazywania żądań do lokalnego środowiska [w README na GitHubie](https://github.com/discord/discord-example-app#running-app-locally).
 
 Po skopiowaniu łącza przejdź do ustawień aplikacji z poziomu [portalu deweloperów](https://discord.com/developers/applications).
@@ -233,7 +233,7 @@ if (name === 'test') {
 
 Powyższy kod reaguje na interakcję z wiadomością na kanale, z którego pochodzi. Możesz zobaczyć wszystkie dostępne typy reakcji, takie jak reagowanie oknem, [w dokumentacji](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-response-object-interaction-callback-type).
 
-> informacje
+> info
 > `InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE` jest stałą [eksportowaną z pliku pakietu `discord-interactions`](https://github.com/discord/discord-interactions-js/blob/main/src/index.ts#L33)
 
 Przejdź do swojego serwera i upewnij się, że polecenie z ukośnikiem `/test` działa. Gdy je aktywujesz, aplikacja powinna wysłać wiadomość z tekstem „hello world” i losowym emoji.
@@ -252,7 +252,7 @@ Polecenie `/challenge`, zwane `CHALLENGE_COMMAND` w pliku `commands.js`, ma szer
 
 Więcej o opcjach poleceń i ich strukturze przeczytasz [w dokumentacji](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-object-application-command-option-structure).
 
-> informacje
+> info
 > Choć w tym przewodniku nie zagłębimy się w plik `game.js`, możesz poeksperymentować z nim, zmieniając polecenia lub ich opcje.
 
 <Collapsible title="Obsługa interakcji poprzez polecenia" description="Kod odpowiadający za obsługę polecenia „challenge” i reagowanie wiadomością z przyciskiem" icon="code" open>
@@ -296,7 +296,7 @@ if (name === 'challenge' && id) {
 ```
 
 
-> informacje
+> info
 > Jeśli nie wiesz, gdzie wkleić kod, możesz zobaczyć pełen kod w pliku `examples/app.js` w projekcie Glitch lub w nadrzędnym pliku `app.js` [na GitFHubie](https://github.com/discord/discord-example-app/blob/main/app.js).
 
 Powyższy kod wykonuje szereg czynności:
@@ -304,7 +304,7 @@ Powyższy kod wykonuje szereg czynności:
 2. Dodaje nową grę do obiektu `activeGames` przy pomocy ID interakcji. Aktywna gra zapisuje elementy `userId` i `objectName`.
 3. Wysyła na kanał wiadomość z przyciskiem z wartością `accept_button_<SOME_ID>` w polu `custom_id`.
 
-> ostrzeżenie
+> warn
 > Przykładowy kod wykorzystuje obiekt przechowywany w pamięci, ale na potrzeby publicznej wersji aplikacji zaleca się użycie bazy danych.
 
 Przy wysyłaniu [elementów wiadomości](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/what-is-a-component) indywidualne payloady są dodawane do tablicy `components`. Interaktywne elementy (takie jak przyciski) muszą znajdować się w [rzędzie czynności](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/action-rows), który jest widoczny w przykładowym kodzie.

--- a/docs/tr/Getting_Started.mdx
+++ b/docs/tr/Getting_Started.mdx
@@ -61,7 +61,7 @@ Bot token'ları, API isteklerini yetkilendirmek için kullanılır ve bot kullan
 
 Şimdi token'ı kopyala ve onu örneğin parola yöneticisi gibi güvenli bir yerde sakla.
 
-> uyarı
+> warn
 > Token'ını yeniden oluşturmadığın sürece tekrar görüntüleyemezsin, bu nedenle güvenli bir yerde sakladığından emin ol.
 
 ### Bot izinlerini ve kapsamlarını ekleme
@@ -77,7 +77,7 @@ Kapsamlar ve izinler, bir uygulama oluştururken uygulamanın Discord sunucular�
 
 Sol kenar çubuğunda **OAuth2**'ye tıkla, ardından **URL oluşturucuyu** seç.
 
-> bilgi
+> info
 > URL oluşturucu, uygulaman için seçtiğin kapsamlara ve izinlere göre bir yükleme bağlantısı oluşturur. Bağlantıyı, uygulamayı kendi sunucuna yüklemek için kullanabilir veya yükleyebilmeleri için başkalarıyla paylaşabilirsin.
 
 Şimdilik iki kapsam ekleyelim:
@@ -92,7 +92,7 @@ Kapsamları ekledikten sonra uygulamanı yüklemek için kopyalayabileceğin bir
 
 ![URL oluşturucu ekran görüntüsü](url-generator.png)
 
-> bilgi
+> info
 > Uygulama geliştirirken uygulamanı başkaları tarafından aktif olarak kullanılmayan bir sunucuda oluşturmalı ve test etmelisin. Hâlihazırda kendi sunucun yoksa [ücretsiz bir tane oluşturabilirsin](https://support.discord.com/hc/articles/204849977-How-do-I-create-a-server-).
 
 URL'yi yukarıdan kopyala ve tarayıcına yapıştır. Kurulum süreci sana rehberlik edecektir; bu süreçte uygulamanı geliştirebileceğin ve test edebileceğin bir sunucuya yüklediğinden emin olmalısın.
@@ -113,7 +113,7 @@ Uygulama, geliştirmeyi daha basit hâle getirmek için tipler ve yardımcı fon
 
 Bu rehber, tarayıcında klonlama ve geliştirme yapmanı sağlayan Glitch'i kullanır. Uygulamanı yerel olarak geliştirmeyi tercih edersen, [README](https://github.com/discord/discord-example-app#running-app-locally) dosyasından ngrok kullanımıyla ilgili talimatlara ulaşabilirsin.
 
-> bilgi
+> info
 > Glitch, geliştirme ve test için harika olsa da [teknik kısıtlamalara sahiptir](https://help.glitch.com/hc/en-us/articles/16287495313293-Technical-Restrictions/), bu nedenle bitmiş uygulamalar için diğer barındırma sağlayıcıları düşünmekte fayda vardır.
 
 Başlamak için **[Glitch projesini 🎏 remiksle (veya klonla)](https://glitch.com/edit/#!/import/git?url=https://github.com/discord/discord-example-app.git)**.
@@ -162,7 +162,7 @@ Kimlik bilgilerin yapılandırıldıktan sonra eğik çizgi komutlarını yükle
 
 ### Eğik çizgi komutlarını yükleme
 
-> bilgi
+> info
 > Eğik çizgi komutlarını yüklemek için uygulama [`node-fetch`](https://github.com/node-fetch/node-fetch) kullanır. Yükleme implementasyonunu `utils.js`'de `DiscordRequest()` fonksiyonu içinde görebilirsin.
 
 Proje, `commands.js` dosyasının altında tanımlanan `ALL_COMMANDS` içerisindeki komutları yüklemek için kullanabileceğin bir `register` komut dosyası içerir. HTTP API'sinin [`PUT /applications/<APP_ID>/commands`](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/bulk-overwrite-global-application-commands) uç noktasını çağırarak komutları global komutlar olarak yükler.
@@ -196,7 +196,7 @@ Uygulamanın eğik çizgi komut isteklerini (ve diğer etkileşimleri) almasın�
 
 Glitch projeleri varsayılan olarak herkese açık bir URL'ye sahiptir. Sağ üst köşedeki **Paylaş** butonuna tıklayarak projenin URL'sini kopyala, ardından minik pencerenin alt kısmındaki "Canlı site" proje bağlantısını kopyala.
 
-> bilgi
+> info
 > Yerel olarak geliştirme yapıyorsan, [GitHub README'de](https://github.com/discord/discord-example-app#running-app-locally) istekleri yerel ortamına tünellemek için talimatlara ulaşabilirsin.
 
 Bağlantı kopyalandıktan sonra [geliştirici portalından](https://discord.com/developers/applications) uygulamanın ayarlarına git.
@@ -233,7 +233,7 @@ if (name === 'test') {
 
 Yukarıdaki kod, gelen etkileşime meydana geldiği kanaldaki bir mesajla yanıt veriyor. Modal ile yanıt vermek gibi mevcut tüm yanıt türlerini [dokümantasyonda](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-response-object-interaction-callback-type) bulabilirsin.
 
-> bilgi
+> info
 > `InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE`, [`discord-interactions`'dan dışa aktarılmış](https://github.com/discord/discord-interactions-js/blob/main/src/index.ts#L33) bir sabittir.
 
 Sunucuna git ve uygulamanın `/test` eğik çizgi komutunun çalıştığından emin ol. Bunu tetiklediğinde, uygulaman "hello world" kelimelerini takip eden rastgele bir emoji içeren bir mesaj göndermelidir.
@@ -252,7 +252,7 @@ Taş-kâğıt-makas tarzı oyunumuz `/challenge` komutuyla başlatılacaktır. K
 
 Komut seçenekleri ve bunların yapısı hakkında daha fazla bilgiyi [dokümantasyonlardan](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/application-command-object-application-command-option-structure) edinebilirsin.
 
-> bilgi
+> info
 > Bu rehber `game.js` dosyasına fazla değinmeyecek olsa da sen onu kurcalayabilir, komutları veya komutlardaki seçenekleri çekinmeden değiştirebilirsin.
 
 <Collapsible title="Komut etkileşiminin işlenmesi" description="Meydan okuma komutunun işlenmesi ve bir buton içeren bir mesajla yanıt verilmesi için kod" icon="code" open>
@@ -296,7 +296,7 @@ if (name === 'challenge' && id) {
 ```
 
 
-> bilgi
+> info
 > Kodu nereye yapıştıracağından emin değilsen, kodun tamamını Glitch projesindeki `examples/app.js` dosyasında veya [GitHub'daki](https://github.com/discord/discord-example-app/blob/main/app.js) kök `app.js` dosyasında bulabilirsin.
 
 Yukarıdaki kod birkaç şey yapıyor:
@@ -304,7 +304,7 @@ Yukarıdaki kod birkaç şey yapıyor:
 2. Etkileşim kimliğini kullanarak `activeGames` nesnesine yeni bir oyun ekler. Etkin oyun `userId` ve `objectName`'i kaydeder.
 3. Kanala, `custom_id`'si `accept_button_<SOME_ID>` olan bir buton ile bir mesaj gönderir.
 
-> uyarı
+> warn
 > Örnek kod, bellek içi depolama alanı olarak bir nesne kullanır ancak bitmiş uygulamalar için bir veri tabanı kullanman gerekir.
 
 [Mesaj bileşenleriyle](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/what-is-a-component) bir mesaj gönderirken, tekil payload'lar bir `components` dizisine eklenir. Eyleme geçirilebilir bileşenlerin (butonlar gibi) kod örneğinde görebileceğin bir [eylem satırının](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/action-rows) içinde olması gereklidir.


### PR DESCRIPTION
Blocks doesnt display the outlines when info or warn is translated fixes it in ALL LANGUAGES

And fixes some gramar in polish

<details>
<summary>Example</summary>

English:

![image](https://github.com/turkwr/discord-api-docs/assets/76836550/eda8767b-c06a-4d4b-9deb-0996b78ec864)


Polish: 

![image](https://github.com/turkwr/discord-api-docs/assets/76836550/ab5d0092-261b-43c9-ad48-51425037ceca)


</details>