### PR TITLE
Add missing me_burst in message example

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -396,6 +396,7 @@ Represents a message sent in a channel within Discord.
          "normal": 1
       },
       "me": false,
+      "me_burst": false,
       "emoji": {
          "id": null,
          "name": "🔥"


### PR DESCRIPTION
This PR add the field `me_burst` in the message example, this was added in crosspost example but not in the normal message where this field exists.