### PR TITLE
fix: Make description of `exclude_ended` field more specific

### DIFF
--- a/docs/monetization/Entitlements.md
+++ b/docs/monetization/Entitlements.md
@@ -58,7 +58,7 @@ Returns all entitlements for a given app, active and expired.
 | after?         | snowflake                         | Retrieve entitlements after this entitlement ID      |
 | limit?         | integer                           | Number of entitlements to return, 1-100, default 100 |
 | guild_id?      | snowflake                         | Guild ID to look up entitlements for                 |
-| exclude_ended? | boolean                           | Whether entitlements should be omitted               |
+| exclude_ended? | boolean                           | Whether expired entitlements should be omitted       |
 
 ```json
 [


### PR DESCRIPTION
Describe wich entitlements will be omitted (the expired ones)