### PR TITLE
Document AutoMod incident action message types

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -349,10 +349,10 @@ Represents a message sent in a channel within Discord.
 | STAGE_SPEAKER                                | 29    | true      |
 | STAGE_TOPIC                                  | 31    | true      |
 | GUILD_APPLICATION_PREMIUM_SUBSCRIPTION       | 32    | true      |
-| GUILD_INCIDENT_ALERT_MODE_ENABLED            | 36    | false     |
-| GUILD_INCIDENT_ALERT_MODE_DISABLED           | 37    | false     |
-| GUILD_INCIDENT_REPORT_RAID                   | 38    | false     |
-| GUILD_INCIDENT_REPORT_FALSE_ALARM            | 39    | false     |
+| GUILD_INCIDENT_ALERT_MODE_ENABLED            | 36    | true      |
+| GUILD_INCIDENT_ALERT_MODE_DISABLED           | 37    | true      |
+| GUILD_INCIDENT_REPORT_RAID                   | 38    | true      |
+| GUILD_INCIDENT_REPORT_FALSE_ALARM            | 39    | true      |
 
 \* Can only be deleted by members with `MANAGE_MESSAGES` permission
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -348,7 +348,11 @@ Represents a message sent in a channel within Discord.
 | STAGE_END                                    | 28    | true      |
 | STAGE_SPEAKER                                | 29    | true      |
 | STAGE_TOPIC                                  | 31    | true      |
-| GUILD_APPLICATION_PREMIUM_SUBSCRIPTION       | 32    | false     |
+| GUILD_APPLICATION_PREMIUM_SUBSCRIPTION       | 32    | true      |
+| GUILD_INCIDENT_ALERT_MODE_ENABLED            | 36    | false     |
+| GUILD_INCIDENT_ALERT_MODE_DISABLED           | 37    | false     |
+| GUILD_INCIDENT_REPORT_RAID                   | 38    | false     |
+| GUILD_INCIDENT_REPORT_FALSE_ALARM            | 39    | false     |
 
 \* Can only be deleted by members with `MANAGE_MESSAGES` permission
 


### PR DESCRIPTION
incident actions fully released months ago, and the [support article](https://support.discord.com/hc/en-us/articles/17439993574167-Activity-Alerts-Security-Actions) says "This feature is available to all servers!"

also, `GUILD_APPLICATION_PREMIUM_SUBSCRIPTION` was marked as undeletable, but it is deletable so I fixed that

I didn't document types 33-35 and 40-44, because either they are dead/unreleased or I don't know the status of the feature