### PR TITLE
Add X-Audit-Log-Reason to Follow Announcement Channel endpoint

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -1231,6 +1231,9 @@ Delete a channel permission overwrite for a user or role in a channel. Only usab
 
 Follow an Announcement Channel to send messages to a target channel. Requires the `MANAGE_WEBHOOKS` permission in the target channel. Returns a [followed channel](#DOCS_RESOURCES_CHANNEL/followed-channel-object) object. Fires a [Webhooks Update](#DOCS_TOPICS_GATEWAY_EVENTS/webhooks-update) Gateway event for the target channel.
 
+> info
+> This endpoint supports the `X-Audit-Log-Reason` header.
+
 ###### JSON Params
 
 | Field              | Type      | Description          |


### PR DESCRIPTION
The Follow Announcement Channel endpoint, like the Create Webhook endpoint that it essentially is, supports the `X-Audit-Log-Reason` header; this is not currently documented.