### PR TITLE
Document applied_tags on Execute Webhook

### DIFF
--- a/docs/resources/Webhook.md
+++ b/docs/resources/Webhook.md
@@ -174,7 +174,7 @@ Refer to [Uploading Files](#DOCS_REFERENCE/uploading-files) for details on attac
 > Note that when sending a message, you must provide a value for at **least one of** `content`, `embeds`, `components`, or `file`.
 
 > info
-> If the webhook channel is a forum channel, you must provide either `thread_id` in the query string params, or `thread_name` in the JSON/form params. If `thread_id` is provided, the message will send in that thread. If `thread_name` is provided, a thread with that name will be created in the forum channel.
+> If the webhook channel is a forum or media channel, you must provide either `thread_id` in the query string params, or `thread_name` in the JSON/form params. If `thread_id` is provided, the message will send in that thread. If `thread_name` is provided, a thread with that name will be created in the channel.
 
 > warn
 > Discord may strip certain characters from message content, like invalid unicode characters or characters which cause unexpected message formatting. If you are passing user-generated strings into message content, consider sanitizing the data to prevent unexpected behavior and using `allowed_mentions` to prevent unexpected mentions.
@@ -201,7 +201,8 @@ Refer to [Uploading Files](#DOCS_REFERENCE/uploading-files) for details on attac
 | payload_json \*\* | string                                                                               | JSON encoded body of non-file params                                                                                                                                        | `multipart/form-data` only   |
 | attachments \*\*  | array of partial [attachment](#DOCS_RESOURCES_CHANNEL/attachment-object) objects     | attachment objects with filename and description                                                                                                                            | false                        |
 | flags             | integer                                                                              | [message flags](#DOCS_RESOURCES_CHANNEL/message-object-message-flags) combined as a [bitfield](https://en.wikipedia.org/wiki/Bit_field) (only `SUPPRESS_EMBEDS` can be set) | false                        |
-| thread_name       | string                                                                               | name of thread to create (requires the webhook channel to be a forum channel)                                                                                               | false                        |
+| thread_name       | string                                                                               | name of thread to create (requires the webhook channel to be a forum or media channel)                                                                                      | false                        |
+| applied_tags      | array of snowflakes                                                                  | array of tag ids to apply to the thread (requires the webhook channel to be a forum or media channel)                                                                       | false                        |
 
 \* Requires an application-owned webhook.
 


### PR DESCRIPTION
turns out I asked for this back in July and it was added, but it was never announced or documented
