### PR TITLE
Added `Spanish, LATAM` to `Reference.md`

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -472,6 +472,7 @@ For example:
 | en-GB  | English, UK           | English, UK         |
 | en-US  | English, US           | English, US         |
 | es-ES  | Spanish               | Español             |
+| es-419 | Spanish               | Español, LATAM      |
 | fr     | French                | Français            |
 | hr     | Croatian              | Hrvatski            |
 | it     | Italian               | Italiano            |

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -472,7 +472,7 @@ For example:
 | en-GB  | English, UK           | English, UK         |
 | en-US  | English, US           | English, US         |
 | es-ES  | Spanish               | Español             |
-| es-419 | Spanish               | Español, LATAM      |
+| es-419 | Spanish, LATAM        | Español, LATAM      |
 | fr     | French                | Français            |
 | hr     | Croatian              | Hrvatski            |
 | it     | Italian               | Italiano            |


### PR DESCRIPTION
# Description

This pull request addresses the recent addition of a new language option for Spanish speakers in Discord, referred to internally as es-419. The proposed change adds documentation for this language option. For visual reference, check the Discord UI screenshot provided in the pull request.

![image](https://github.com/discord/discord-api-docs/assets/4616452/f5168ffd-01f2-486f-8c1f-42dab2bfdda7)

# ChangeLog

- Added the new language field to `Reference.md`

# Unresolved Questions

- For consistency, should we use the full name Spanish, LATAM or opt for the shorter Spanish, LA in this context?