### PR TITLE
Fix: Optional parameters

### DIFF
--- a/docs/resources/Application.md
+++ b/docs/resources/Application.md
@@ -110,7 +110,7 @@ Returns the [application](#DOCS_RESOURCES_APPLICATION/application-object) object
 Edit properties of the app associated with the requesting bot user. Only properties that are passed will be updated. Returns the updated [application](#DOCS_RESOURCES_APPLICATION/application-object) object on success. 
 
 > info 
-> All parameters to this endpoint are optional
+> All parameters to this endpoint are optional.
 
 ###### JSON Params
 

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -928,7 +928,10 @@ Get a channel by ID. Returns a [channel](#DOCS_RESOURCES_CHANNEL/channel-object)
 
 ## Modify Channel % PATCH /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}
 
-Update a channel's settings. Returns a [channel](#DOCS_RESOURCES_CHANNEL/channel-object) on success, and a 400 BAD REQUEST on invalid parameters. All JSON parameters are optional.
+Update a channel's settings. Returns a [channel](#DOCS_RESOURCES_CHANNEL/channel-object) on success, and a 400 BAD REQUEST on invalid parameters.
+
+> info
+> All parameters to this endpoint are optional.
 
 > info
 > This endpoint supports the `X-Audit-Log-Reason` header.
@@ -1203,7 +1206,10 @@ Returns a list of [invite](#DOCS_RESOURCES_INVITE/invite-object) objects (with [
 
 ## Create Channel Invite % POST /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/invites
 
-Create a new [invite](#DOCS_RESOURCES_INVITE/invite-object) object for the channel. Only usable for guild channels. Requires the `CREATE_INSTANT_INVITE` permission. All JSON parameters for this route are optional, however the request body is not. If you are not sending any fields, you still have to send an empty JSON object (`{}`). Returns an [invite](#DOCS_RESOURCES_INVITE/invite-object) object. Fires an [Invite Create](#DOCS_TOPICS_GATEWAY_EVENTS/invite-create) Gateway event.
+Create a new [invite](#DOCS_RESOURCES_INVITE/invite-object) object for the channel. Only usable for guild channels. Requires the `CREATE_INSTANT_INVITE` permission. If you are not sending any fields, you still have to send an empty JSON object (`{}`). Returns an [invite](#DOCS_RESOURCES_INVITE/invite-object) object. Fires an [Invite Create](#DOCS_TOPICS_GATEWAY_EVENTS/invite-create) Gateway event.
+
+> info
+> All parameters to this endpoint are optional.
 
 > info
 > This endpoint supports the `X-Audit-Log-Reason` header.

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -942,8 +942,8 @@ Returns a list of [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) obje
 
 | Field  | Type    | Description                                                | Default |
 |------- |---------|------------------------------------------------------------|---------|
-| query? | string  | Query string to match username(s) and nickname(s) against. |         |
-| limit  | integer | max number of members to return (1-1000)                   | 1       |
+| query  | string  | Query string to match username(s) and nickname(s) against. |         |
+| limit? | integer | max number of members to return (1-1000)                   | 1       |
 
 ## Add Guild Member % PUT /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/members/{user.id#DOCS_RESOURCES_USER/user-object}
 

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -805,7 +805,7 @@ If the user is not in the guild, then the guild must be [discoverable](#DOCS_RES
 Modify a guild's settings. Requires the `MANAGE_GUILD` permission. Returns the updated [guild](#DOCS_RESOURCES_GUILD/guild-object) object on success. Fires a [Guild Update](#DOCS_TOPICS_GATEWAY_EVENTS/guild-update) Gateway event.
 
 > info
-> All parameters to this endpoint are optional
+> All parameters to this endpoint are optional.
 
 > info
 > This endpoint supports the `X-Audit-Log-Reason` header.
@@ -852,7 +852,7 @@ Returns a list of guild [channel](#DOCS_RESOURCES_CHANNEL/channel-object) object
 Create a new [channel](#DOCS_RESOURCES_CHANNEL/channel-object) object for the guild. Requires the `MANAGE_CHANNELS` permission. If setting permission overwrites, only permissions your bot has in the guild can be allowed/denied. Setting `MANAGE_ROLES` permission in channels is only possible for guild administrators. Returns the new [channel](#DOCS_RESOURCES_CHANNEL/channel-object) object on success. Fires a [Channel Create](#DOCS_TOPICS_GATEWAY_EVENTS/channel-create) Gateway event.
 
 > info
-> All parameters to this endpoint are optional and nullable excluding `name`
+> All parameters to this endpoint are optional and nullable excluding `name`.
 
 > info
 > This endpoint supports the `X-Audit-Log-Reason` header.
@@ -925,7 +925,7 @@ Returns a list of [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) obje
 > This endpoint is restricted according to whether the `GUILD_MEMBERS` [Privileged Intent](#DOCS_TOPICS_GATEWAY/privileged-intents) is enabled for your application.
 
 > info
-> All parameters to this endpoint are optional
+> All parameters to this endpoint are optional.
 
 ###### Query String Params
 
@@ -938,15 +938,12 @@ Returns a list of [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) obje
 
 Returns a list of [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) objects whose username or nickname starts with a provided string.
 
-> info
-> All parameters to this endpoint except for `query` are optional
-
 ###### Query String Params
 
-| Field | Type    | Description                                                | Default |
-|-------|---------|------------------------------------------------------------|---------|
-| query | string  | Query string to match username(s) and nickname(s) against. |         |
-| limit | integer | max number of members to return (1-1000)                   | 1       |
+| Field  | Type    | Description                                                | Default |
+|------- |---------|------------------------------------------------------------|---------|
+| query? | string  | Query string to match username(s) and nickname(s) against. |         |
+| limit  | integer | max number of members to return (1-1000)                   | 1       |
 
 ## Add Guild Member % PUT /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/members/{user.id#DOCS_RESOURCES_USER/user-object}
 
@@ -1088,7 +1085,10 @@ Returns a list of [role](#DOCS_TOPICS_PERMISSIONS/role-object) objects for the g
 
 ## Create Guild Role % POST /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/roles
 
-Create a new [role](#DOCS_TOPICS_PERMISSIONS/role-object) for the guild. Requires the `MANAGE_ROLES` permission. Returns the new [role](#DOCS_TOPICS_PERMISSIONS/role-object) object on success. Fires a [Guild Role Create](#DOCS_TOPICS_GATEWAY_EVENTS/guild-role-create) Gateway event. All JSON params are optional.
+Create a new [role](#DOCS_TOPICS_PERMISSIONS/role-object) for the guild. Requires the `MANAGE_ROLES` permission. Returns the new [role](#DOCS_TOPICS_PERMISSIONS/role-object) object on success. Fires a [Guild Role Create](#DOCS_TOPICS_GATEWAY_EVENTS/guild-role-create) Gateway event.
+
+> info
+> All parameters to this endpoint are optional.
 
 > info
 > This endpoint supports the `X-Audit-Log-Reason` header.
@@ -1276,7 +1276,7 @@ Returns the [Welcome Screen](#DOCS_RESOURCES_GUILD/welcome-screen-object) object
 Modify the guild's [Welcome Screen](#DOCS_RESOURCES_GUILD/welcome-screen-object). Requires the `MANAGE_GUILD` permission. Returns the updated [Welcome Screen](#DOCS_RESOURCES_GUILD/welcome-screen-object) object. May fire a [Guild Update](#DOCS_TOPICS_GATEWAY_EVENTS/guild-update) Gateway event.
 
 > info
-> All parameters to this endpoint are optional and nullable
+> All parameters to this endpoint are optional and nullable.
 
 > info
 > This endpoint supports the `X-Audit-Log-Reason` header.

--- a/docs/resources/Webhook.md
+++ b/docs/resources/Webhook.md
@@ -138,7 +138,7 @@ Same as above, except this call does not require authentication and returns no u
 Modify a webhook. Requires the `MANAGE_WEBHOOKS` permission. Returns the updated [webhook](#DOCS_RESOURCES_WEBHOOK/webhook-object) object on success. Fires a [Webhooks Update](#DOCS_TOPICS_GATEWAY_EVENTS/webhooks-update) Gateway event.
 
 > info
-> All parameters to this endpoint are optional
+> All parameters to this endpoint are optional.
 
 > info
 > This endpoint supports the `X-Audit-Log-Reason` header.


### PR DESCRIPTION
# Fix: Optional parameters
- Removed text "All JSON parameters are optional" and added info "All parameters for this endpoint are optional."
- Added `.` at the end of the infos
- Removed the "All parameters for this endpoint are optional." info where is useless