### PR TITLE
Add Domain to connection services in User

### DIFF
--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -117,6 +117,7 @@ The connection object that the user has attached.
 | Value           | Name                |
 |-----------------|---------------------|
 | battlenet       | Battle.net          |
+| domain          | Domain              |
 | ebay            | eBay                |
 | epicgames       | Epic Games          |
 | facebook        | Facebook            |


### PR DESCRIPTION
Adds the Domain service to the list of connection services in the User section, as they are returned by the API