### PR TITLE
Update character limit for slash commands

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -92,7 +92,7 @@ Starting in API v8, we've improved error formatting in form error responses. The
         "_errors": [
             {
                 "code": "APPLICATION_COMMAND_TOO_LARGE",
-                "message": "Command exceeds maximum size (4000)"
+                "message": "Command exceeds maximum size (8000)"
             }
         ]
     }

--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -374,7 +374,7 @@ Slash commands—the `CHAT_INPUT` type—are a type of application command. They
 Slash commands can also have groups and subcommands to further organize commands. More on those later.
 
 > warn
-> Slash commands can have a maximum of 4000 characters for combined name, description, and value properties for each command, its options (including subcommands and groups), and choices.  When [localization fields](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/localization) are present, only the longest localization for each field (including the default value) is counted towards the size limit.
+> Slash commands can have a maximum of 8000 characters for combined name, description, and value properties for each command, its options (including subcommands and groups), and choices.  When [localization fields](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/localization) are present, only the longest localization for each field (including the default value) is counted towards the size limit.
 
 
 ###### Example Slash Command


### PR DESCRIPTION
4000 -> 8000
https://github.com/discord/discord-api-docs/issues/6648#issuecomment-1947309509