### PR TITLE
Update GameSDK RelationshipsManager to indicate that OAuth is now required

### DIFF
--- a/docs/game_sdk/Relationships.md
+++ b/docs/game_sdk/Relationships.md
@@ -138,6 +138,9 @@ for (int i = 0; i < relationshipsManager.Count(); i++)
 
 Fires at initialization when Discord has cached a snapshot of the current status of all your relationships. Wait for this to fire before calling `Filter` within its callback.
 
+> warn
+> `OnRefresh` requires the `relationships.read` [OAuth2 scope](https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes). The GameSDK will return 0 relationships if the requested user has not authenticated with that scope.
+
 ###### Parameters
 
 None


### PR DESCRIPTION
Fixes [this issue](https://github.com/discord/discord-api-docs/issues/6446).

The GameSDK Relationships Manager recently received a breaking change to the `OnRefresh` callback. After reaching out to developer support, [it was confirmed](https://github.com/discord/discord-api-docs/issues/6446#issuecomment-1949300938) that this callback now requires the target user to authenticate with OAuth2 and accept the `relationships.read` scope (which requires Discord approval). PR adds a warning above the `OnRefresh` documentation indicating that the scope is now required for the callback to function properly.