### PR TITLE
Document bulk ban endpoint

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -1082,6 +1082,32 @@ Remove the ban for a user. Requires the `BAN_MEMBERS` permissions. Returns a 204
 > info
 > This endpoint supports the `X-Audit-Log-Reason` header.
 
+## Bulk Guild Ban % POST /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/bulk-ban
+
+Ban up to 200 users from a guild, and optionally delete previous messages sent by the banned users. Requires `BAN_MEMBERS` permission. Returns 200 response on success, including a field `banned_users` with the IDs of the banned users and `failed_users` with all that were not be banned. The list of `failed_users` will also include all users that were already banned.
+
+> info
+> This endpoint supports the `X-Audit-Log-Reason` header.
+
+###### JSON Params
+
+| Field                   | Type                | Description                                                             | Default |
+|-------------------------|---------------------|-------------------------------------------------------------------------|---------|
+| user_ids                | array of snowflakes | list of user ids to ban (max 200)                                       |         |
+| delete_message_seconds? | integer             | number of seconds to delete messages for, between 0 and 604800 (7 days) | 0       |
+
+###### Bulk Ban Response
+
+On success, this endpoint returns a 200 success response with the following body.
+
+| Field         | Type                | Description                                     |
+|---------------|---------------------|-------------------------------------------------|
+| banned_users? | array of snowflakes | list of user ids, that were successfully banned |
+| failed_users? | array of snowflakes | list of user ids, that were not banned          |
+
+> info
+> If none of the users could be banned, an error response code `500000: Failed to ban users` is returned instead.
+
 ## Get Guild Roles % GET /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/roles
 
 Returns a list of [role](#DOCS_TOPICS_PERMISSIONS/role-object) objects for the guild.

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -1100,10 +1100,10 @@ Ban up to 200 users from a guild, and optionally delete previous messages sent b
 
 On success, this endpoint returns a 200 success response with the following body.
 
-| Field         | Type                | Description                                     |
-|---------------|---------------------|-------------------------------------------------|
-| banned_users? | array of snowflakes | list of user ids, that were successfully banned |
-| failed_users? | array of snowflakes | list of user ids, that were not banned          |
+| Field        | Type                | Description                                     |
+|--------------|---------------------|-------------------------------------------------|
+| banned_users | array of snowflakes | list of user ids, that were successfully banned |
+| failed_users | array of snowflakes | list of user ids, that were not banned          |
 
 > info
 > If none of the users could be banned, an error response code `500000: Failed to ban users` is returned instead.

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -1084,7 +1084,7 @@ Remove the ban for a user. Requires the `BAN_MEMBERS` permissions. Returns a 204
 
 ## Bulk Guild Ban % POST /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/bulk-ban
 
-Ban up to 200 users from a guild, and optionally delete previous messages sent by the banned users. Requires both the `BAN_MEMBERS` and `MANAGE_GUILD` permissions. Returns 200 response on success, including a field `banned_users` with the IDs of the banned users and `failed_users` with all that were not be banned. The list of `failed_users` will also include all users that were already banned.
+Ban up to 200 users from a guild, and optionally delete previous messages sent by the banned users. Requires both the `BAN_MEMBERS` and `MANAGE_GUILD` permissions. Returns a 200 response on success, including the fields `banned_users` with the IDs of the banned users and `failed_users` with IDs that could not be banned or were already banned.
 
 > info
 > This endpoint supports the `X-Audit-Log-Reason` header.

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -1084,7 +1084,7 @@ Remove the ban for a user. Requires the `BAN_MEMBERS` permissions. Returns a 204
 
 ## Bulk Guild Ban % POST /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/bulk-ban
 
-Ban up to 200 users from a guild, and optionally delete previous messages sent by the banned users. Requires `BAN_MEMBERS` permission. Returns 200 response on success, including a field `banned_users` with the IDs of the banned users and `failed_users` with all that were not be banned. The list of `failed_users` will also include all users that were already banned.
+Ban up to 200 users from a guild, and optionally delete previous messages sent by the banned users. Requires both the `BAN_MEMBERS` and `MANAGE_GUILD` permissions. Returns 200 response on success, including a field `banned_users` with the IDs of the banned users and `failed_users` with all that were not be banned. The list of `failed_users` will also include all users that were already banned.
 
 > info
 > This endpoint supports the `X-Audit-Log-Reason` header.

--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -311,6 +311,7 @@ Along with the HTTP error code, our API can also return more detailed error code
 | 240000 | Message blocked by harmful links filter                                                                                       |
 | 350000 | Cannot enable onboarding, requirements are not met                                                                            |
 | 350001 | Cannot update onboarding while below requirements                                                                             |
+| 500000 | Failed to ban users                                                                                                           |
 
 ###### Example JSON Error Response
 


### PR DESCRIPTION
This endpoint has some interesting pitfalls when a user is not banned.

- If a user was already banned, they are in the "failed_users" array
- If you don't have permissions to ban a user, they also appear in failed users
- If all users "failed" you get an error response instead
- The endpoint filters out the self user (does not show up in either array)