### PR TITLE
Clarify that user object is partial for /oauth2/@me

### DIFF
--- a/docs/topics/OAuth2.md
+++ b/docs/topics/OAuth2.md
@@ -424,7 +424,7 @@ Returns info about the current authorization. Requires authentication with a bea
 | application | partial [application](#DOCS_RESOURCES_APPLICATION/application-object) object | the current application                                                           |
 | scopes      | array of strings                                                             | the scopes the user has authorized the application for                            |
 | expires     | ISO8601 timestamp                                                            | when the access token expires                                                     |
-| user?       | [user](#DOCS_RESOURCES_USER/user-object) object                              | the user who has authorized, if the user has authorized with the `identify` scope |
+| user?       | partial [user](#DOCS_RESOURCES_USER/user-object) object                      | the user who has authorized, if the user has authorized with the `identify` scope |
 
 ###### Example Authorization Information
 


### PR DESCRIPTION
If you decide to fetch `/oauth2/@me` with an access_token instead of `/users/@me`, you will NOT get the `email` field, the `locale` field, the `mfa_enabled`, `verified` and maybe other fields as well.

This pull request aims to clarify that the user object is partial. Since that is only said for the application object right now.

Also, for other app developers reading, I see you can get the `scope` field from `/oauth2/token`, so I just changed back to using `/users/@me` when I noticed all the missing fields from `/oauth2/@me`

![image](https://github.com/discord/discord-api-docs/assets/83034852/720a0a6d-b72e-4f70-b198-0f782dfdc8d2)
