### PR TITLE
Fix Embedded App SDK doc for `setOrientationLockState()`

### DIFF
--- a/docs/developer_tools/Embedded_App_SDK.md
+++ b/docs/developer_tools/Embedded_App_SDK.md
@@ -499,9 +499,9 @@ No scopes required
 
 ```js
 await discordSdk.commands.setOrientationLockState({ 
-  lock_state: 'landscape', 
-  picture_in_picture_lock_state: 'landscape', 
-  grid_lock_state: 'unlocked'
+  lock_state: 3, // landscape
+  picture_in_picture_lock_state: 3, // landscape
+  grid_lock_state: 1 // unlocked
 });
 ```
 

--- a/docs/developer_tools/Embedded_App_SDK.md
+++ b/docs/developer_tools/Embedded_App_SDK.md
@@ -493,7 +493,7 @@ Locks the application to specific orientations in each of the supported layout m
 
 #### Required Scopes
 
-- guilds.members.read
+No scopes required
 
 #### Usage
 


### PR DESCRIPTION
Seems like this command doesn't actually need the `guilds.members.read` scope, and the values in the usage doesn't use strings.