### PR TITLE
Link boolean query param types to reference section

### DIFF
--- a/docs/game_sdk/Store.md
+++ b/docs/game_sdk/Store.md
@@ -379,18 +379,18 @@ Note that parameters with a `?` after the name denote optional fields. Parameter
 
 Gets entitlements for a given user. You can use this on your game backend to check entitlements of an arbitrary user, or perhaps in an administrative panel for your support team.
 
-###### Query Parameters
+###### Query String Params
 
-| name           | type                              | description                                                                                                                    |
-|----------------|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| user_id?       | snowflake                         | the user id to look up entitlements for                                                                                        |
-| sku_ids?       | comma-delimited set of snowflakes | (optional) the list SKU ids to check entitlements for                                                                          |
-| with_payments? | bool                              | returns [limited payment data](#DOCS_GAME_SDK_STORE/httpspecific-data-models-limited-payment-data-object) for each entitlement |
-| before?        | snowflake                         | retrieve entitlements before this time                                                                                         |
-| after?         | snowflake                         | retrieve entitlements after this time                                                                                          |
-| limit?         | int                               | number of entitlements to return, 1-100, default 100                                                                           |
-| guild_id?      | snowflake                         | the guild id to look up entitlements for                                                                                       |
-| exclude_ended? | bool                              | whether or not ended entitlements should be omitted                                                                            |
+| name           | type                                             | description                                                                                                                    |
+|----------------|--------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| user_id?       | snowflake                                        | the user id to look up entitlements for                                                                                        |
+| sku_ids?       | comma-delimited set of snowflakes                | (optional) the list SKU ids to check entitlements for                                                                          |
+| with_payments? | [boolean](#DOCS_REFERENCE/boolean-query-strings) | returns [limited payment data](#DOCS_GAME_SDK_STORE/httpspecific-data-models-limited-payment-data-object) for each entitlement |
+| before?        | snowflake                                        | retrieve entitlements before this time                                                                                         |
+| after?         | snowflake                                        | retrieve entitlements after this time                                                                                          |
+| limit?         | int                                              | number of entitlements to return, 1-100, default 100                                                                           |
+| guild_id?      | snowflake                                        | the guild id to look up entitlements for                                                                                       |
+| exclude_ended? | [boolean](#DOCS_REFERENCE/boolean-query-strings) | whether or not ended entitlements should be omitted                                                                            |
 
 ###### Example
 
@@ -425,11 +425,11 @@ curl https://discord.com/api/v6/applications/461618159171141643/entitlements?use
 
 Fetch an entitlement by its ID. This may be useful in confirming that a user has a given entitlement that another call or the SDK says they do.
 
-###### Query Parameters
+###### Query String Params
 
-| name          | type | description                                                                                                                    |
-|---------------|------|--------------------------------------------------------------------------------------------------------------------------------|
-| with_payment? | bool | returns [limited payment data](#DOCS_GAME_SDK_STORE/httpspecific-data-models-limited-payment-data-object) for each entitlement |
+| name          | type                                             | description                                                                                                                    |
+|---------------|--------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| with_payment? | [boolean](#DOCS_REFERENCE/boolean-query-strings) | returns [limited payment data](#DOCS_GAME_SDK_STORE/httpspecific-data-models-limited-payment-data-object) for each entitlement |
 
 ###### Example
 

--- a/docs/interactions/Application_Commands.md
+++ b/docs/interactions/Application_Commands.md
@@ -1077,9 +1077,9 @@ Fetch all of the global commands for your application. Returns an array of [appl
 
 ###### Query String Params
 
-| Field               | Type    | Description                                                                                                                                                                                                            |
-|---------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| with_localizations? | boolean | Whether to include full localization dictionaries (`name_localizations` and `description_localizations`) in the returned objects, instead of the `name_localized` and `description_localized` fields. Default `false`. |
+| Field               | Type                                             | Description                                                                                                                                                                                                            |
+|---------------------|--------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| with_localizations? | [boolean](#DOCS_REFERENCE/boolean-query-strings) | Whether to include full localization dictionaries (`name_localizations` and `description_localizations`) in the returned objects, instead of the `name_localized` and `description_localized` fields. Default `false`. |
 
 ## Create Global Application Command % POST /applications/{application.id#DOCS_RESOURCES_APPLICATION/application-object}/commands
 
@@ -1152,9 +1152,9 @@ Fetch all of the guild commands for your application for a specific guild. Retur
 
 ###### Query String Params
 
-| Field               | Type    | Description                                                                                                                                                                                                            |
-|---------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| with_localizations? | boolean | Whether to include full localization dictionaries (`name_localizations` and `description_localizations`) in the returned objects, instead of the `name_localized` and `description_localized` fields. Default `false`. |
+| Field               | Type                                             | Description                                                                                                                                                                                                            |
+|---------------------|--------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| with_localizations? | [boolean](#DOCS_REFERENCE/boolean-query-strings) | Whether to include full localization dictionaries (`name_localizations` and `description_localizations`) in the returned objects, instead of the `name_localized` and `description_localized` fields. Default `false`. |
 
 ## Create Guild Application Command % POST /applications/{application.id#DOCS_RESOURCES_APPLICATION/application-object}/guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/commands
 

--- a/docs/monetization/Entitlements.md
+++ b/docs/monetization/Entitlements.md
@@ -56,17 +56,17 @@ Entitlements in Discord represent that a user or guild has access to a premium o
 
 Returns all entitlements for a given app, active and expired.
 
-###### Query Params
+###### Query String Params
 
-| param          | type                              | description                                          |
-|----------------|-----------------------------------|------------------------------------------------------|
-| user_id?       | snowflake                         | User ID to look up entitlements for                  |
-| sku_ids?       | comma-delimited set of snowflakes | Optional list of SKU IDs to check entitlements for   |
-| before?        | snowflake                         | Retrieve entitlements before this entitlement ID     |
-| after?         | snowflake                         | Retrieve entitlements after this entitlement ID      |
-| limit?         | integer                           | Number of entitlements to return, 1-100, default 100 |
-| guild_id?      | snowflake                         | Guild ID to look up entitlements for                 |
-| exclude_ended? | boolean                           | Whether or not ended entitlements should be omitted  |
+| param          | type                                             | description                                          |
+|----------------|--------------------------------------------------|------------------------------------------------------|
+| user_id?       | snowflake                                        | User ID to look up entitlements for                  |
+| sku_ids?       | comma-delimited set of snowflakes                | Optional list of SKU IDs to check entitlements for   |
+| before?        | snowflake                                        | Retrieve entitlements before this entitlement ID     |
+| after?         | snowflake                                        | Retrieve entitlements after this entitlement ID      |
+| limit?         | integer                                          | Number of entitlements to return, 1-100, default 100 |
+| guild_id?      | snowflake                                        | Guild ID to look up entitlements for                 |
+| exclude_ended? | [boolean](#DOCS_REFERENCE/boolean-query-strings) | Whether or not ended entitlements should be omitted  |
 
 ```json
 [

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -1408,9 +1408,9 @@ When `with_member` is set to `true`, the thread member object will include a `me
 
 ###### Query String Params
 
-| Field        | Type    | Description                                                                                                 |
-|--------------|---------|-------------------------------------------------------------------------------------------------------------|
-| with_member? | boolean | Whether to include a [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object for the thread member |
+| Field        | Type                                             | Description                                                                                                 |
+|--------------|--------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
+| with_member? | [boolean](#DOCS_REFERENCE/boolean-query-strings) | Whether to include a [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object for the thread member |
 
 ## List Thread Members % GET /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/thread-members
 
@@ -1426,11 +1426,11 @@ When `with_member` is set to `true`, the results will be paginated and each thre
 
 ###### Query String Params
 
-| Field        | Type      | Description                                                                                                  |
-|--------------|-----------|--------------------------------------------------------------------------------------------------------------|
-| with_member? | boolean   | Whether to include a [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object for each thread member |
-| after?       | snowflake | Get thread members after this user ID                                                                        |
-| limit?       | integer   | Max number of thread members to return (1-100). Defaults to 100.                                             |
+| Field        | Type                                             | Description                                                                                                  |
+|--------------|--------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| with_member? | [boolean](#DOCS_REFERENCE/boolean-query-strings) | Whether to include a [guild member](#DOCS_RESOURCES_GUILD/guild-member-object) object for each thread member |
+| after?       | snowflake                                        | Get thread members after this user ID                                                                        |
+| limit?       | integer                                          | Max number of thread members to return (1-100). Defaults to 100.                                             |
 
 ## List Public Archived Threads % GET /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/threads/archived/public
 

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -720,9 +720,9 @@ Returns the [guild](#DOCS_RESOURCES_GUILD/guild-object) object for the given id.
 
 ###### Query String Params
 
-| Field        | Type    | Description                                                                   | Required | Default |
-|--------------|---------|-------------------------------------------------------------------------------|----------|---------|
-| with_counts? | boolean | when `true`, will return approximate member and presence counts for the guild | false    | false   |
+| Field        | Type                                             | Description                                                                   | Required | Default |
+|--------------|--------------------------------------------------|-------------------------------------------------------------------------------|----------|---------|
+| with_counts? | [boolean](#DOCS_REFERENCE/boolean-query-strings) | when `true`, will return approximate member and presence counts for the guild | false    | false   |
 
 ###### Example Response
 

--- a/docs/resources/Guild_Scheduled_Event.md
+++ b/docs/resources/Guild_Scheduled_Event.md
@@ -108,9 +108,9 @@ Returns a list of [guild scheduled event](#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/
 
 ###### Query String Params
 
-| Field            | Type    | Description                                      |
-|------------------|---------|--------------------------------------------------|
-| with_user_count? | boolean | include number of users subscribed to each event |
+| Field            | Type                                             | Description                                      |
+|------------------|--------------------------------------------------|--------------------------------------------------|
+| with_user_count? | [boolean](#DOCS_REFERENCE/boolean-query-strings) | include number of users subscribed to each event |
 
 ## Create Guild Scheduled Event % POST /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/scheduled-events
 
@@ -146,9 +146,9 @@ Get a guild scheduled event. Returns a [guild scheduled event](#DOCS_RESOURCES_G
 
 ###### Query String Params
 
-| Field            | Type    | Description                                      |
-|------------------|---------|--------------------------------------------------|
-| with_user_count? | boolean | include number of users subscribed to this event |
+| Field            | Type                                             | Description                                      |
+|------------------|--------------------------------------------------|--------------------------------------------------|
+| with_user_count? | [boolean](#DOCS_REFERENCE/boolean-query-strings) | include number of users subscribed to this event |
 
 ## Modify Guild Scheduled Event % PATCH /guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/scheduled-events/{guild_scheduled_event.id#DOCS_RESOURCES_GUILD_SCHEDULED_EVENT/guild-scheduled-event-object}
 
@@ -194,12 +194,12 @@ Get a list of guild scheduled event users subscribed to a guild scheduled event.
 
 ###### Query String Params
 
-| Field        | Type      | Description                                   | Default |
-|--------------|-----------|-----------------------------------------------|---------|
-| limit?       | number    | number of users to return (up to maximum 100) | 100     |
-| with_member? | boolean   | include guild member data if it exists        | false   |
-| before? *    | snowflake | consider only users before given user id      | null    |
-| after? *     | snowflake | consider only users after given user id       | null    |
+| Field        | Type                                             | Description                                   | Default |
+|--------------|--------------------------------------------------|-----------------------------------------------|---------|
+| limit?       | number                                           | number of users to return (up to maximum 100) | 100     |
+| with_member? | [boolean](#DOCS_REFERENCE/boolean-query-strings) | include guild member data if it exists        | false   |
+| before? *    | snowflake                                        | consider only users before given user id      | null    |
+| after? *     | snowflake                                        | consider only users after given user id       | null    |
 
 \* Provide a user id to `before` and `after` for pagination. Users will always be returned in ascending order by `user_id`. If both `before` and `after` are provided, only `before` is respected. Fetching users in-between `before` and `after` is not supported.
 

--- a/docs/resources/Invite.md
+++ b/docs/resources/Invite.md
@@ -136,11 +136,11 @@ Returns an [invite](#DOCS_RESOURCES_INVITE/invite-object) object for the given c
 
 ###### Query String Params
 
-| Field                     | Type      | Description                                                 |
-|---------------------------|-----------|-------------------------------------------------------------|
-| with_counts?              | boolean   | whether the invite should contain approximate member counts |
-| with_expiration?          | boolean   | whether the invite should contain the expiration date       |
-| guild_scheduled_event_id? | snowflake | the guild scheduled event to include with the invite        |
+| Field                     | Type                                             | Description                                                 |
+|---------------------------|--------------------------------------------------|-------------------------------------------------------------|
+| with_counts?              | [boolean](#DOCS_REFERENCE/boolean-query-strings) | whether the invite should contain approximate member counts |
+| with_expiration?          | [boolean](#DOCS_REFERENCE/boolean-query-strings) | whether the invite should contain the expiration date       |
+| guild_scheduled_event_id? | snowflake                                        | the guild scheduled event to include with the invite        |
 
 ## Delete Invite % DELETE /invites/{invite.code#DOCS_RESOURCES_INVITE/invite-object}
 

--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -204,12 +204,12 @@ Returns a list of partial [guild](#DOCS_RESOURCES_GUILD/guild-object) objects th
 
 ###### Query String Params
 
-| Field       | Type      | Description                                                | Required | Default |
-|-------------|-----------|------------------------------------------------------------|----------|---------|
-| before      | snowflake | get guilds before this guild ID                            | false    | absent  |
-| after       | snowflake | get guilds after this guild ID                             | false    | absent  |
-| limit       | integer   | max number of guilds to return (1-200)                     | false    | 200     |
-| with_counts | boolean   | include approximate member and presence counts in response | false    | false   |
+| Field       | Type                                             | Description                                                | Required | Default |
+|-------------|--------------------------------------------------|------------------------------------------------------------|----------|---------|
+| before      | snowflake                                        | get guilds before this guild ID                            | false    | absent  |
+| after       | snowflake                                        | get guilds after this guild ID                             | false    | absent  |
+| limit       | integer                                          | max number of guilds to return (1-200)                     | false    | 200     |
+| with_counts | [boolean](#DOCS_REFERENCE/boolean-query-strings) | include approximate member and presence counts in response | false    | false   |
 
 ## Get Current User Guild Member % GET /users/@me/guilds/{guild.id#DOCS_RESOURCES_GUILD/guild-object}/member
 

--- a/docs/resources/Webhook.md
+++ b/docs/resources/Webhook.md
@@ -181,10 +181,10 @@ Refer to [Uploading Files](#DOCS_REFERENCE/uploading-files) for details on attac
 
 ###### Query String Params
 
-| Field     | Type      | Description                                                                                                                                                                                  | Required |
-|-----------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
-| wait      | boolean   | waits for server confirmation of message send before response, and returns the created message body (defaults to `false`; when `false` a message that is not saved does not return an error) | false    |
-| thread_id | snowflake | Send a message to the specified thread within a webhook's channel. The thread will automatically be unarchived.                                                                              | false    |
+| Field     | Type                                             | Description                                                                                                                                                                                  | Required |
+|-----------|--------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| wait      | [boolean](#DOCS_REFERENCE/boolean-query-strings) | waits for server confirmation of message send before response, and returns the created message body (defaults to `false`; when `false` a message that is not saved does not return an error) | false    |
+| thread_id | snowflake                                        | Send a message to the specified thread within a webhook's channel. The thread will automatically be unarchived.                                                                              | false    |
 
 ###### JSON/Form Params
 
@@ -219,10 +219,10 @@ Refer to [Slack's documentation](https://api.slack.com/incoming-webhooks) for mo
 
 ###### Query String Params
 
-| Field     | Type      | Description                                                                                                                                           | Required |
-|-----------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
-| thread_id | snowflake | id of the thread to send the message in                                                                                                               | false    |
-| wait      | boolean   | waits for server confirmation of message send before response (defaults to `true`; when `false` a message that is not saved does not return an error) | false    |
+| Field     | Type                                             | Description                                                                                                                                           | Required |
+|-----------|--------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| thread_id | snowflake                                        | id of the thread to send the message in                                                                                                               | false    |
+| wait      | [boolean](#DOCS_REFERENCE/boolean-query-strings) | waits for server confirmation of message send before response (defaults to `true`; when `false` a message that is not saved does not return an error) | false    |
 
 ## Execute GitHub-Compatible Webhook % POST /webhooks/{webhook.id#DOCS_RESOURCES_WEBHOOK/webhook-object}/{webhook.token#DOCS_RESOURCES_WEBHOOK/webhook-object}/github
 
@@ -230,10 +230,10 @@ Refer to [Slack's documentation](https://api.slack.com/incoming-webhooks) for mo
 
 ###### Query String Params
 
-| Field     | Type      | Description                                                                                                                                           | Required |
-|-----------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
-| thread_id | snowflake | id of the thread to send the message in                                                                                                               | false    |
-| wait      | boolean   | waits for server confirmation of message send before response (defaults to `true`; when `false` a message that is not saved does not return an error) | false    |
+| Field     | Type                                             | Description                                                                                                                                           | Required |
+|-----------|--------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| thread_id | snowflake                                        | id of the thread to send the message in                                                                                                               | false    |
+| wait      | [boolean](#DOCS_REFERENCE/boolean-query-strings) | waits for server confirmation of message send before response (defaults to `true`; when `false` a message that is not saved does not return an error) | false    |
 
 ## Get Webhook Message % GET /webhooks/{webhook.id#DOCS_RESOURCES_WEBHOOK/webhook-object}/{webhook.token#DOCS_RESOURCES_WEBHOOK/webhook-object}/messages/{message.id#DOCS_RESOURCES_CHANNEL/message-object}
 


### PR DESCRIPTION
The reference page specifies the supported formats for boolean query params, but people don't see it. This PR adds links to the reference section in the query param tables so it will be visible when needed.