### PR TITLE
Update markdown table CI to Node 20

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Node v18
+      - name: Install Node v20
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
fixes
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'discord-api-docs@1.1.1',
npm WARN EBADENGINE   required: { node: '>= 20.11.0' },
npm WARN EBADENGINE   current: { node: 'v18.20.2', npm: '10.5.0' }
npm WARN EBADENGINE }
```


