### PR TITLE
[gateway] Clarify Reconnect opcode, Document zstd-stream

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -103,7 +103,7 @@ When connecting to the URL, it's a good idea to explicitly pass the API version 
 |-----------|---------|-----------------------------------------------------------------------------------------------------|------------------------------------------------------------|
 | v         | integer | [API Version](#DOCS_REFERENCE/api-versioning) to use                                                | [API version](#DOCS_REFERENCE/api-versioning-api-versions) |
 | encoding  | string  | The [encoding](#DOCS_TOPICS_GATEWAY/encoding-and-compression) of received gateway packets           | `json` or `etf`                                            |
-| compress? | string  | The optional [transport compression](#DOCS_TOPICS_GATEWAY/transport-compression) of gateway packets | `zlib-stream`                                              |
+| compress? | string  | The optional [transport compression](#DOCS_TOPICS_GATEWAY/transport-compression) of gateway packets | `zlib-stream` or `zstd-stream`                             |
 
 #### Hello Event
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -509,7 +509,7 @@ See [erlpack](https://github.com/discord/erlpack) for an ETF implementation exam
 
 ### Transport Compression
 
-Transport compression enables optional compression for all packets when Discord is sending events over the connection. The only currently-available transport compression options are `zlib-stream` and `zstd-stream`.
+Transport compression enables optional compression for all packets when Discord is sending events over the connection. The currently-available transport compression options are `zlib-stream` and `zstd-stream`.
 
 #### zlib-stream
 

--- a/docs/topics/Gateway_Events.md
+++ b/docs/topics/Gateway_Events.md
@@ -387,7 +387,7 @@ The resumed event is dispatched when a client has sent a [resume payload](#DOCS_
 
 #### Reconnect
 
-The reconnect event is dispatched when a client should reconnect to the gateway (and resume their existing session, if they have one). This event usually occurs during deploys to migrate sessions gracefully off old hosts.
+The reconnect event is dispatched when a client should reconnect to the gateway (and resume their existing session, if they have one). This can occur at any point in the gateway connection lifecycle. A few seconds after this event is dispatched, the connection may be closed by the server. This may even happen before/in place of receiving a [Hello](#DOCTS_TOPICS_GATEWAY_EVENTS/hello).
 
 ###### Example Gateway Reconnect
 

--- a/docs/topics/Gateway_Events.md
+++ b/docs/topics/Gateway_Events.md
@@ -387,7 +387,7 @@ The resumed event is dispatched when a client has sent a [resume payload](#DOCS_
 
 #### Reconnect
 
-The reconnect event is dispatched when a client should reconnect to the gateway (and resume their existing session, if they have one). This can occur at any point in the gateway connection lifecycle. A few seconds after this event is dispatched, the connection may be closed by the server. This may even happen before/in place of receiving a [Hello](#DOCTS_TOPICS_GATEWAY_EVENTS/hello).
+The reconnect event is dispatched when a client should reconnect to the gateway (and resume their existing session, if they have one). This can occur at any point in the gateway connection lifecycle. A few seconds after this event is dispatched, the connection may be closed by the server. This may even happen before/in place of receiving a [Hello](#DOCS_TOPICS_GATEWAY_EVENTS/hello).
 
 ###### Example Gateway Reconnect
 

--- a/docs/topics/Gateway_Events.md
+++ b/docs/topics/Gateway_Events.md
@@ -387,7 +387,7 @@ The resumed event is dispatched when a client has sent a [resume payload](#DOCS_
 
 #### Reconnect
 
-The reconnect event is dispatched when a client should reconnect to the gateway (and resume their existing session, if they have one). This can occur at any point in the gateway connection lifecycle. A few seconds after this event is dispatched, the connection may be closed by the server. This may even happen before/in place of receiving a [Hello](#DOCS_TOPICS_GATEWAY_EVENTS/hello).
+The reconnect event is dispatched when a client should reconnect to the gateway (and resume their existing session, if they have one). This can occur at any point in the gateway connection lifecycle, even before/in place of receiving a [Hello](#DOCS_TOPICS_GATEWAY_EVENTS/hello) event. A few seconds after the reconnect event is dispatched, the connection may be closed by the server.
 
 ###### Example Gateway Reconnect
 


### PR DESCRIPTION
This clarifies that Reconnect can come at any time, even before hello. Also, document the resurrected zstd-stream gateway compression option.