### PR TITLE
Remove integration_types from Application Object Example

### DIFF
--- a/docs/resources/Application.md
+++ b/docs/resources/Application.md
@@ -48,7 +48,6 @@
   "guild_id": "290926798626357260",
   "icon": null,
   "id": "172150183260323840",
-  "integration_types": [0, 1],
   "integration_types_config": {
     "0": {
       "oauth2_install_params": {


### PR DESCRIPTION
Currently the example for Application Object use a field removed time ago.