### PR TITLE
Update User Agent link to point to latest RFC

### DIFF
--- a/docs/Reference.mdx
+++ b/docs/Reference.mdx
@@ -222,7 +222,7 @@ Clients should operate on events and results from the API in as much of an idemp
 
 ### User Agent
 
-Clients using the HTTP API must provide a valid [User Agent](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.43) which specifies information about the client library and version in the following format:
+Clients using the HTTP API must provide a valid [User Agent](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.5) which specifies information about the client library and version in the following format:
 
 ###### User Agent Example
 


### PR DESCRIPTION
Closes #6950 by updating the User Agent link to point to the URL the current target page recommends as newer.