### PR TITLE
[embedded-app-sdk] add information on captureLog level parameter

### DIFF
--- a/docs/developer_tools/Embedded_App_SDK.md
+++ b/docs/developer_tools/Embedded_App_SDK.md
@@ -249,14 +249,12 @@ No scopes required
 #### Level Parameter
 
 `captureLog` requires a `level` parameter which matches the javascript [console](https://developer.mozilla.org/en-US/docs/Web/API/console) log levels.
-
-| Level   | Effect                                      |
-|---------|---------------------------------------------|
-| `debug` | logs the message with the debug log level   |
-| `log`   | logs the message                            |
-| `info`  | logs the message with the info log level    |
-| `warn`  | logs the message with the warning log level |
-| `error` | logs the message with the error log level   |
+The supported values for `level` are:
+- `debug`
+- `log`
+- `info`
+- `warn`
+- `error`
 
 #### Usage
 

--- a/docs/developer_tools/Embedded_App_SDK.md
+++ b/docs/developer_tools/Embedded_App_SDK.md
@@ -246,6 +246,18 @@ Forward logs to your own logger.
 
 No scopes required
 
+#### Level Parameter
+
+`captureLog` requires a `level` parameter which matches the javascript [console](https://developer.mozilla.org/en-US/docs/Web/API/console) log levels.
+
+| Level   | Effect                                      |
+|---------|---------------------------------------------|
+| `debug` | logs the message with the debug log level   |
+| `log`   | logs the message                            |
+| `info`  | logs the message with the info log level    |
+| `warn`  | logs the message with the warning log level |
+| `error` | logs the message with the error log level   |
+
 #### Usage
 
 ```js


### PR DESCRIPTION
had a partner ask about the valid options for `level`, figured it would be good to document 