### PR TITLE
Move Pin/Unpin Message docs to the Message section

### DIFF
--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -487,23 +487,6 @@ Generally bots should **not** use this route. However, if a bot is responding to
 
 Returns all pinned messages in the channel as an array of [message](#DOCS_RESOURCES_MESSAGE/message-object) objects.
 
-## Pin Message % PUT /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/pins/{message.id#DOCS_RESOURCES_MESSAGE/message-object}
-
-Pin a message in a channel. Requires the `MANAGE_MESSAGES` permission. Returns a 204 empty response on success. Fires a [Channel Pins Update](#DOCS_TOPICS_GATEWAY_EVENTS/channel-pins-update) Gateway event.
-
-> warn
-> The max pinned messages is 50.
-
-> info
-> This endpoint supports the `X-Audit-Log-Reason` header.
-
-## Unpin Message % DELETE /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/pins/{message.id#DOCS_RESOURCES_MESSAGE/message-object}
-
-Unpin a message in a channel. Requires the `MANAGE_MESSAGES` permission. Returns a 204 empty response on success. Fires a [Channel Pins Update](#DOCS_TOPICS_GATEWAY_EVENTS/channel-pins-update) Gateway event.
-
-> info
-> This endpoint supports the `X-Audit-Log-Reason` header.
-
 ## Group DM Add Recipient % PUT /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/recipients/{user.id#DOCS_RESOURCES_USER/user-object}
 
 Adds a recipient to a Group DM using their access token.

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -483,10 +483,6 @@ Post a typing indicator for the specified channel, which expires after 10 second
 
 Generally bots should **not** use this route. However, if a bot is responding to a command and expects the computation to take a few seconds, this endpoint may be called to let the user know that the bot is processing their message.
 
-## Get Pinned Messages % GET /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/pins
-
-Returns all pinned messages in the channel as an array of [message](#DOCS_RESOURCES_MESSAGE/message-object) objects.
-
 ## Group DM Add Recipient % PUT /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/recipients/{user.id#DOCS_RESOURCES_USER/user-object}
 
 Adds a recipient to a Group DM using their access token.

--- a/docs/resources/Message.md
+++ b/docs/resources/Message.md
@@ -855,3 +855,21 @@ Any message IDs given that do not exist or are invalid will count towards the mi
 | Field    | Type                | Description                               |
 |----------|---------------------|-------------------------------------------|
 | messages | array of snowflakes | an array of message ids to delete (2-100) |
+
+## Pin Message % PUT /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/pins/{message.id#DOCS_RESOURCES_MESSAGE/message-object}
+
+Pin a message in a channel. Requires the `MANAGE_MESSAGES` permission. Returns a 204 empty response on success. Fires a [Channel Pins Update](#DOCS_TOPICS_GATEWAY_EVENTS/channel-pins-update) Gateway event.
+
+> warn
+> A channel can have up to 50 pinned messages.
+
+> info
+> This endpoint supports the `X-Audit-Log-Reason` header.
+
+## Unpin Message % DELETE /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/pins/{message.id#DOCS_RESOURCES_MESSAGE/message-object}
+
+Unpin a message in a channel. Requires the `MANAGE_MESSAGES` permission. Returns a 204 empty response on success. Fires a [Channel Pins Update](#DOCS_TOPICS_GATEWAY_EVENTS/channel-pins-update) Gateway event.
+
+> info
+> This endpoint supports the `X-Audit-Log-Reason` header.
+

--- a/docs/resources/Message.md
+++ b/docs/resources/Message.md
@@ -873,3 +873,6 @@ Unpin a message in a channel. Requires the `MANAGE_MESSAGES` permission. Returns
 > info
 > This endpoint supports the `X-Audit-Log-Reason` header.
 
+## Get Pinned Messages % GET /channels/{channel.id#DOCS_RESOURCES_CHANNEL/channel-object}/pins
+
+Returns all pinned messages in the channel as an array of [message](#DOCS_RESOURCES_MESSAGE/message-object) objects.


### PR DESCRIPTION
I think it makes sense to have pins-related docs in the messages section