### PR TITLE
OAuth2: basic authorization when using refresh token

### DIFF
--- a/docs/topics/OAuth2.md
+++ b/docs/topics/OAuth2.md
@@ -134,7 +134,9 @@ In response, you will receive:
 }
 ```
 
-Having the user's access token allows your application to make certain requests to the API on their behalf, restricted to whatever scopes were requested. `expires_in` is how long, in seconds, until the returned access token expires, allowing you to anticipate the expiration and refresh the token. To refresh, make another `POST` request to the [token URL](#DOCS_TOPICS_OAUTH2/shared-resources-oauth2-urls) with the following parameters:
+Having the user's access token allows your application to make certain requests to the API on their behalf, restricted to whatever scopes were requested. `expires_in` is how long, in seconds, until the returned access token expires, allowing you to anticipate the expiration and refresh the token. 
+
+To refresh, make another `POST` request to the [token URL](#DOCS_TOPICS_OAUTH2/shared-resources-oauth2-urls) with basic authorization where `CLIENT_ID` is username, `CLIENT_SECRET` is password, and the following parameters:
 
 - `grant_type` - must be set to `refresh_token`
 - `refresh_token` - the user's refresh token

--- a/docs/topics/OAuth2.md
+++ b/docs/topics/OAuth2.md
@@ -136,7 +136,7 @@ In response, you will receive:
 
 Having the user's access token allows your application to make certain requests to the API on their behalf, restricted to whatever scopes were requested. `expires_in` is how long, in seconds, until the returned access token expires, allowing you to anticipate the expiration and refresh the token. 
 
-To refresh, make another `POST` request to the [token URL](#DOCS_TOPICS_OAUTH2/shared-resources-oauth2-urls) with basic authorization where `CLIENT_ID` is username, `CLIENT_SECRET` is password, and the following parameters:
+To refresh it, make another `POST` request to the [token URL](#DOCS_TOPICS_OAUTH2/shared-resources-oauth2-urls) with Basic authorization (`CLIENT_ID` as the username and `CLIENT_SECRET` as the password) plus the following parameters:
 
 - `grant_type` - must be set to `refresh_token`
 - `refresh_token` - the user's refresh token

--- a/docs/topics/OAuth2.md
+++ b/docs/topics/OAuth2.md
@@ -136,7 +136,7 @@ In response, you will receive:
 
 Having the user's access token allows your application to make certain requests to the API on their behalf, restricted to whatever scopes were requested. `expires_in` is how long, in seconds, until the returned access token expires, allowing you to anticipate the expiration and refresh the token. 
 
-To refresh it, make another `POST` request to the [token URL](#DOCS_TOPICS_OAUTH2/shared-resources-oauth2-urls) with Basic authorization (`CLIENT_ID` as the username and `CLIENT_SECRET` as the password) plus the following parameters:
+To refresh it, make another `POST` request to the [token URL](#DOCS_TOPICS_OAUTH2/shared-resources-oauth2-urls) with Basic authorization (`client_id` as the username and `client_secret` as the password) plus the following parameters:
 
 - `grant_type` - must be set to `refresh_token`
 - `refresh_token` - the user's refresh token


### PR DESCRIPTION
This pull request adds information about required basic authorization when developer uses `redresh_token` to renew `access_token`.