### PR TITLE
Fix example JSON error response

### DIFF
--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -324,7 +324,7 @@ Along with the HTTP error code, our API can also return more detailed error code
 
 ```json
 {
-  "message": "Invalid authentication token",
+  "message": "Invalid authentication token provided",
   "code": 50014
 }
 ```


### PR DESCRIPTION
50014 is "Invalid authentication token provided". currently the example shows "Invalid authentication token". this commit corrects this.