### PR TITLE
[voice] clarify session re-use on guild channel change

### DIFF
--- a/docs/topics/Voice_Connections.mdx
+++ b/docs/topics/Voice_Connections.mdx
@@ -58,6 +58,8 @@ If our request succeeded, the gateway will respond with _two_ events—a [Voice 
 
 With this information, we can move on to establishing a voice WebSocket connection.
 
+When sending a voice state update to change channels within the same guild, it is possible to receive a VOICE_SERVER_UPDATE with the same `endpoint` as the previous VOICE_SERVER_UPDATE. The `token` will be changed and you cannot re-use the previous session during a channel change, even if the endpoint remains the same.
+
 > info
 > Bot users respect the voice channel's user limit, if set. When the voice channel is full, you will not receive
 > the Voice State Update or Voice Server Update events in response to your own Voice State Update. Having `MANAGE_CHANNELS`


### PR DESCRIPTION
This has been a growing expectation of various Discord systems, and will likely be solidified this week with the token being re-generated on channel change. It is also a strict requirement of an upcoming voice protocol change.