### PR TITLE
use explicit sidebar labels

### DIFF
--- a/docs/Intro.mdx
+++ b/docs/Intro.mdx
@@ -1,5 +1,6 @@
 ---
 showTOC: false
+sidebar_label: Intro
 ---
 
 ![Welcome to the Discord Developer Platform](docs-header.svg)

--- a/docs/activities/Building_An_Activity.mdx
+++ b/docs/activities/Building_An_Activity.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_label: Building an Activity
+---
+
 # Building Your First Activity in Discord
 
 > preview

--- a/docs/activities/Design_Patterns.mdx
+++ b/docs/activities/Design_Patterns.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_label: Design Patterns
+---
+
 # Activity Design Patterns
 
 > preview

--- a/docs/activities/Development_Guides.mdx
+++ b/docs/activities/Development_Guides.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_label: Development Guides
+---
+
 # Activity Development Guides
 
 > preview

--- a/docs/activities/Overview.mdx
+++ b/docs/activities/Overview.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_label: Overview
+---
+
 # Discord Activities
 
 > preview

--- a/docs/best_practices/Crafting_your_App_Directory_Product_Page.md
+++ b/docs/best_practices/Crafting_your_App_Directory_Product_Page.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Crafting your App Directory Product Page
+---
+
 # Best Practices for App Directory Product Pages
 
 So you’ve made an app on Discord and are ready to opt in to discovery on the App Directory! Or maybe you have already listed your app but aren’t seeing as much traction to it as you’d like? Whatever stage you’re at, this guide has some tips and tricks from your friendly Discord Staff members to help boost performance of your App Directory Product Page.

--- a/docs/developer_tools/Embedded_App_SDK.mdx
+++ b/docs/developer_tools/Embedded_App_SDK.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_label: Embedded App SDK
+---
+
 # Embedded App SDK Reference
 
 > preview

--- a/docs/interactions/Overview.mdx
+++ b/docs/interactions/Overview.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_label: Overview
+---
+
 # Overview of Interactions
 
 Interactive features like commands and message components allows users to invoke an app natively within Discord. When a user engages with one of your app's interactive features, your app will receive an [interaction](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-object).

--- a/docs/interactions/Receiving_and_Responding.mdx
+++ b/docs/interactions/Receiving_and_Responding.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_label: Receiving and Responding
+---
+
 # Interactions
 
 An **[Interaction](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-object)** is the message that your application receives when a user uses an application command or a message component.

--- a/docs/monetization/Overview.md
+++ b/docs/monetization/Overview.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Overview
+---
+
 # Monetizing Your Discord App
 
 Premium Apps is a set of monetization features for apps on Discord that allows developers to:

--- a/docs/monetization/SKUs.md
+++ b/docs/monetization/SKUs.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: SKUs
+---
+
 # SKU Resource
 
 SKUs (stock-keeping units) in Discord represent premium offerings that can be made available to your application's users or guilds.

--- a/docs/policies_and_agreements/Developer_Policy.md
+++ b/docs/policies_and_agreements/Developer_Policy.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Developer Policy
+---
+
 # Discord Developer Policy
 
 > info

--- a/docs/policies_and_agreements/Developer_Terms_of_Service.md
+++ b/docs/policies_and_agreements/Developer_Terms_of_Service.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Developer Terms of Service
+---
+
 # Discord Developer Terms of Service
 
 > info

--- a/docs/quick_start/Getting_Started.mdx
+++ b/docs/quick_start/Getting_Started.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_label: Getting Started
+---
+
 # Building your first Discord app
 
 [Discord apps](#DOCS_QUICK_START_OVERVIEW_OF_APPS) let you customize and extend Discord using a collection of APIs and interactive features. This guide will walk you through building your first Discord app using JavaScript and by the end you'll have an app that uses slash commands, sends messages, and responds to component interactions.

--- a/docs/quick_start/Overview_of_Apps.mdx
+++ b/docs/quick_start/Overview_of_Apps.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_label: Overview of Apps
+---
+
 # Overview of Discord Apps
 
 ![Overview of Apps](overview-of-apps-banner.png)

--- a/docs/resources/Application.md
+++ b/docs/resources/Application.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Application
+---
+
 # Application Resource
 
 [Applications](#DOCS_QUICK_START_OVERVIEW_OF_APPS) (or "apps") are containers for developer platform features, and can be installed to Discord servers and/or user accounts. 

--- a/docs/resources/Audit_Log.md
+++ b/docs/resources/Audit_Log.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Audit Log
+---
+
 # Audit Logs Resource
 
 ## Audit Logs

--- a/docs/resources/Channel.md
+++ b/docs/resources/Channel.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Channel
+---
+
 # Channels Resource
 
 ### Channel Object

--- a/docs/resources/Emoji.md
+++ b/docs/resources/Emoji.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Emoji
+---
+
 # Emoji Resource
 
 > warn

--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Guild
+---
+
 # Guild Resource
 
 Guilds in Discord represent an isolated collection of users and channels, and are often referred to as "servers" in the UI.

--- a/docs/resources/Guild_Template.md
+++ b/docs/resources/Guild_Template.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Guild Template
+---
+
 # Guild Template Resource
 
 ### Guild Template Object

--- a/docs/resources/Invite.md
+++ b/docs/resources/Invite.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Invite
+---
+
 # Invite Resource
 
 ### Invite Object

--- a/docs/resources/Message.md
+++ b/docs/resources/Message.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Message
+---
+
 # Messages Resource
 
 ### Message Object

--- a/docs/resources/Poll.md
+++ b/docs/resources/Poll.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Poll
+---
+
 # Poll Resource
 
 A poll is... well... a poll! It holds information about a poll!

--- a/docs/resources/Stage_Instance.md
+++ b/docs/resources/Stage_Instance.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Stage Instance
+---
+
 # Stage Instance Resource
 
 A _Stage Instance_ holds information about a live stage.

--- a/docs/resources/Sticker.md
+++ b/docs/resources/Sticker.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Sticker
+---
+
 # Sticker Resource
 
 ### Sticker Object

--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: User
+---
+
 # Users Resource
 
 Users in Discord are generally considered the base entity. Users can spawn across the entire platform, be members of

--- a/docs/resources/Voice.md
+++ b/docs/resources/Voice.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Voice
+---
+
 # Voice Resource
 
 ### Voice State Object

--- a/docs/resources/Webhook.md
+++ b/docs/resources/Webhook.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Webhook
+---
+
 # Webhook Resource
 
 Webhooks are a low-effort way to post messages to channels in Discord. They do not require a bot user or authentication to use.

--- a/docs/rich_presence/Best_Practices.md
+++ b/docs/rich_presence/Best_Practices.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Best Practices
+---
+
 # Best Practices for Rich Presence
 
 Rich Presence lets you display actionable data in a Discord user's profile about what they're up to in your game or app. This guide is intended to show some best practices on how to make that data the best it can be.

--- a/docs/rich_presence/Overview.mdx
+++ b/docs/rich_presence/Overview.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_label: Overview
+---
+
 # Overview of Rich Presence
 
 ![Examples of Rich Presence data on Discord user profiles](rich-presence-examples.png)

--- a/docs/rich_presence/Using_with_the_Embedded_App_SDK.mdx
+++ b/docs/rich_presence/Using_with_the_Embedded_App_SDK.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_label: Using with the Embedded App SDK
+---
+
 # Using Rich Presence with the Embedded App SDK
 
 When developing an [Activity](#DOCS_ACTIVITIES_OVERVIEW), the [Embedded App SDK](#DOCS_DEVELOPER_TOOLS_EMBEDDED_APP_SDK) makes it easy to integrate Rich Presence to display details about what a user is up to inside of your game or social experience.

--- a/docs/rich_presence/Using_with_the_Game_SDK.mdx
+++ b/docs/rich_presence/Using_with_the_Game_SDK.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_label: Using with the Game SDK
+---
+
 # Using Rich Presence with the Game SDK
 
 The [Game SDK](#DOCS_DEVELOPER_TOOLS_GAME_SDK) helps you build 3rd party games and integrate them with Discord. One of its specialties is making it easy to bring your game's data to Discord using [Rich Presence](#DOCS_RICH_PRESENCE_OVERVIEW), which this guide will cover.

--- a/docs/tutorials/Hosting_on_Cloudflare_Workers.md
+++ b/docs/tutorials/Hosting_on_Cloudflare_Workers.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Hosting on Cloudflare Workers
+---
+
 # Hosting a Reddit API Discord app on Cloudflare Workers
 
 When building Discord apps, your app can receive common events from the client as [webhooks](#DOCS_RESOURCES_WEBHOOK) when users interact with your app through interactions like [application commands](#DOCS_INTERACTIONS_APPLICATION_COMMANDS) or [message components](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS).

--- a/docs/tutorials/Upgrading_to_Application_Commands.md
+++ b/docs/tutorials/Upgrading_to_Application_Commands.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Upgrading to Application Commands
+---
+
 # Upgrading Apps to Use Application Commands
 
 As [message content has become a privileged intent](https://support-dev.discord.com/hc/en-us/articles/4404772028055-Message-Content-Privileged-Intent-FAQ) for verified apps, [application commands](#DOCS_INTERACTIONS_APPLICATION_COMMANDS) are the primary way Discord users interact with apps. The three types of commands (slash commands, user commands, and message commands) act as entry points into apps, and can be registered globally or for a subset of guilds.


### PR DESCRIPTION
Today the label we use on the sidebar is entirely determined by the filename of the doc.  I'd like to separate these so we have a little more control over naming, and aren't dependent upon casing in the filename in git. 

The implementation in discord_developers looks in order:
- explicit sidebar_label in frontmatter
- explicit title in frontmatter
- title parsed from H1