### PR TITLE
Fix incorrect link

### DIFF
--- a/docs/interactions/Receiving_and_Responding.mdx
+++ b/docs/interactions/Receiving_and_Responding.mdx
@@ -376,7 +376,7 @@ Interaction tokens are valid for **15 minutes**, meaning you can respond to an i
 
 ## Create Interaction Response % POST /interactions/\{interaction.id#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-object\}/\{interaction.token#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-object\}/callback
 
-Create a response to an Interaction. Body is an [interaction response](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-response-object). Returns `204` unless `with_response` is set to `true` which returns `200` with the body as  [interaction response](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-response-object).
+Create a response to an Interaction. Body is an [interaction response](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-response-object). Returns `204` unless `with_response` is set to `true` which returns `200` with the body as [interaction callback response](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-callback-interaction-callback-response-object).
 
 This endpoint also supports file attachments similar to the webhook endpoints. Refer to [Uploading Files](#DOCS_REFERENCE/uploading-files) for details on uploading files and `multipart/form-data` requests.
 

--- a/docs/interactions/Receiving_and_Responding.mdx
+++ b/docs/interactions/Receiving_and_Responding.mdx
@@ -376,7 +376,7 @@ Interaction tokens are valid for **15 minutes**, meaning you can respond to an i
 
 ## Create Interaction Response % POST /interactions/\{interaction.id#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-object\}/\{interaction.token#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-object\}/callback
 
-Create a response to an Interaction. Body is an [interaction response](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-response-object). Returns `204` unless `with_response` is set to `true` which returns `200` with the body as  [interaction response](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-object).
+Create a response to an Interaction. Body is an [interaction response](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-response-object). Returns `204` unless `with_response` is set to `true` which returns `200` with the body as  [interaction response](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-response-object).
 
 This endpoint also supports file attachments similar to the webhook endpoints. Refer to [Uploading Files](#DOCS_REFERENCE/uploading-files) for details on uploading files and `multipart/form-data` requests.
 


### PR DESCRIPTION
Incorrectly linking to Interaction object instead of interaction callback response object in create interaction response documentation