### PR TITLE
Undocument deprecated empty string fields

### DIFF
--- a/docs/resources/Application.md
+++ b/docs/resources/Application.md
@@ -23,7 +23,6 @@ sidebar_label: Application
 | terms_of_service_url?              | string                                                                                                                                | URL of the app's Terms of Service                                                                                                                                                                                                          |
 | privacy_policy_url?                | string                                                                                                                                | URL of the app's Privacy Policy                                                                                                                                                                                                            |
 | owner?                             | partial [user](#DOCS_RESOURCES_USER/user-object) object                                                                               | Partial user object for the owner of the app                                                                                                                                                                                               |
-| summary *(deprecated)*             | string                                                                                                                                | **deprecated and will be removed in v11.** An empty string.                                                                                                                                                                                |
 | verify_key                         | string                                                                                                                                | Hex encoded key for verification in interactions and the GameSDK's [GetTicket](https://github.com/discord/discord-api-docs/blob/legacy-gamesdk/docs/game_sdk/Applications.md#getticket)                                                    |
 | team                               | ?[team](#DOCS_TOPICS_TEAMS/data-models-team-object) object                                                                            | If the app belongs to a team, this will be a list of the members of that team                                                                                                                                                              |
 | guild_id?                          | snowflake                                                                                                                             | Guild associated with the app. For example, a developer support server.                                                                                                                                                                    |
@@ -82,7 +81,6 @@ sidebar_label: Application
   },
   "primary_sku_id": "172150183260323840",
   "slug": "test",
-  "summary": "",
   "team": {
     "icon": "dd9b7dcfdf5351b9c3de0fe167bacbe1",
     "id": "531992624043786253",

--- a/docs/resources/Sticker.md
+++ b/docs/resources/Sticker.md
@@ -17,7 +17,6 @@ Represents a sticker that can be sent in messages.
 | name        | string                                          | name of the sticker                                                                   |
 | description | ?string                                         | description of the sticker                                                            |
 | tags\*      | string                                          | autocomplete/suggestion tags for the sticker (max 200 characters)                     |
-| asset?      | string                                          | **Deprecated** previously the sticker asset hash, now an empty string                 |
 | type        | integer                                         | [type of sticker](#DOCS_RESOURCES_STICKER/sticker-object-sticker-types)               |
 | format_type | integer                                         | [type of sticker format](#DOCS_RESOURCES_STICKER/sticker-object-sticker-format-types) |
 | available?  | boolean                                         | whether this guild sticker can be used, may be false due to loss of Server Boosts     |
@@ -54,7 +53,6 @@ Incidentally the client will always use a name generated from an emoji as the va
   "type": 1,
   "format_type": 3,
   "description": "Wumpus waves hello",
-  "asset": "",
   "pack_id": "847199849233514549",
   "sort_value": 12
 }


### PR DESCRIPTION
removes sticker.asset and application.summary from the docs. these are now always empty strings so there is no point in keeping them in the docs, and they are not included in the spec.