### PR TITLE
Top-level components are not necessarily action rows

### DIFF
--- a/docs/interactions/Message_Components.md
+++ b/docs/interactions/Message_Components.md
@@ -8,8 +8,6 @@ There are several different types of components; this documentation will outline
 
 Components are a field on the [message object](#DOCS_RESOURCES_MESSAGE/message-object), so you can use them whether you're sending messages or responding to a [slash command](#DOCS_INTERACTIONS_APPLICATION_COMMANDS/) or other interaction.
 
-The top-level `components` field is an array of [Action Row](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/action-rows) components.
-
 ### Component Object
 
 ###### Component Types


### PR DESCRIPTION
looks like people were writing code that assumes that top-level components are always action rows, but that is not the case. unfortunately we were saying this in the docs, so removing that