### PR TITLE
Fix links for colyseus project repo 

### DIFF
--- a/docs/activities/Building_An_Activity.mdx
+++ b/docs/activities/Building_An_Activity.mdx
@@ -622,7 +622,7 @@ You can now explore our more extensive [development guides](#DOCS_ACTIVITIES_DEV
 ### Sample projects to try out next
 - Start with a blank slate using our [Discord Activity Starter](https://github.com/discord/embedded-app-sdk-examples/tree/main/discord-activity-starter) project
 - Try out the full range of SDK features in our [Embedded App SDK Playground](https://github.com/discord/embedded-app-sdk-examples/tree/main/sdk-playground)
-- Support multiplayer & state management using our [React Colyseus](https://github.com/colyseus/discord-embedded-app-sdk) project
+- Support multiplayer & state management using [React Colyseus](https://github.com/colyseus/discord-embedded-app-sdk) project
 - Learn more about working with game engines and the [Nested Messages](https://github.com/discord/embedded-app-sdk-examples/tree/main/nested-messages) project
 
 ### Support & Feedback

--- a/docs/activities/Building_An_Activity.mdx
+++ b/docs/activities/Building_An_Activity.mdx
@@ -622,7 +622,7 @@ You can now explore our more extensive [development guides](#DOCS_ACTIVITIES_DEV
 ### Sample projects to try out next
 - Start with a blank slate using our [Discord Activity Starter](https://github.com/discord/embedded-app-sdk-examples/tree/main/discord-activity-starter) project
 - Try out the full range of SDK features in our [Embedded App SDK Playground](https://github.com/discord/embedded-app-sdk-examples/tree/main/sdk-playground)
-- Support multiplayer & state management using [React Colyseus](https://github.com/colyseus/discord-embedded-app-sdk) project
+- Support multiplayer & state management using the [React Colyseus](https://github.com/colyseus/discord-embedded-app-sdk) project
 - Learn more about working with game engines and the [Nested Messages](https://github.com/discord/embedded-app-sdk-examples/tree/main/nested-messages) project
 
 ### Support & Feedback

--- a/docs/activities/Building_An_Activity.mdx
+++ b/docs/activities/Building_An_Activity.mdx
@@ -622,7 +622,7 @@ You can now explore our more extensive [development guides](#DOCS_ACTIVITIES_DEV
 ### Sample projects to try out next
 - Start with a blank slate using our [Discord Activity Starter](https://github.com/discord/embedded-app-sdk-examples/tree/main/discord-activity-starter) project
 - Try out the full range of SDK features in our [Embedded App SDK Playground](https://github.com/discord/embedded-app-sdk-examples/tree/main/sdk-playground)
-- Support multiplayer & state management using our [React Colyseus](https://github.com/discord/embedded-app-sdk-examples/tree/main/react-colyseus) project
+- Support multiplayer & state management using our [React Colyseus](https://github.com/colyseus/discord-embedded-app-sdk) project
 - Learn more about working with game engines and the [Nested Messages](https://github.com/discord/embedded-app-sdk-examples/tree/main/nested-messages) project
 
 ### Support & Feedback

--- a/docs/activities/Overview.mdx
+++ b/docs/activities/Overview.mdx
@@ -44,7 +44,7 @@ We've published some sample apps on [GitHub](https://github.com/discord/embedded
   <Card title="Embedded App SDK Playground" link="https://github.com/discord/embedded-app-sdk-examples/tree/main/sdk-playground">
     This reference example implements the commands and events available to you within the Embedded App SDK.
   </Card>
-  <Card title="Multiplayer + State Management" link="https://github.com/discord/embedded-app-sdk-examples/tree/main/react-colyseus">
+  <Card title="Multiplayer + State Management" link="https://github.com/colyseus/discord-embedded-app-sdk">
     This example uses React Colyseus to demonstrate state management in a multiplayer experience.
   </Card>
   <Card title="Nested Framework App" link="https://github.com/discord/embedded-app-sdk-examples/tree/main/nested-messages">


### PR DESCRIPTION
This project was removed from [embedded-app-sdk-examples](https://github.com/discord/embedded-app-sdk-examples) and now links to externally maintained repo (refer to https://github.com/discord/embedded-app-sdk-examples/pull/9)