### PR TITLE
Updating and fixing typo

### DIFF
--- a/docs/activities/Design_Patterns.mdx
+++ b/docs/activities/Design_Patterns.mdx
@@ -111,9 +111,7 @@ Discord is a social platform where users talk to each other. Sharing and invites
 ![Shared Moment from Chess in the Park](activities/chess-victory.png)
 
 #### Activities in Text Channels
-> preview
-> Activities support in text channels is expected later in 2024.
-- The Activity user interace, copy and user flows should not rely on people in voice to explain, organize, clarify, or instruct about how the activity works. 
+- The Activity user interface, copy and user flows should not rely on people in voice to explain, organize, clarify, or instruct about how the activity works. 
 - All controls, CTAs, and instructions should be clear enough that folks (especially first time users) playing in a text channel are able to quickly start using the app without needing to talk on voice to learn about it.
 - Lean on dynamic first-time user experience and "How To Play" instructions, toast messages, Call To Action buttons, etc. but be careful to not over-clutter with copy.
 


### PR DESCRIPTION
Activities are now usable in text channels and there was a typo (interace), in the documentation of design patterns for activities.