### PR TITLE
Editing a Published SKU docs behavior fix

### DIFF
--- a/docs/monetization/Managing_SKUs.mdx
+++ b/docs/monetization/Managing_SKUs.mdx
@@ -128,7 +128,7 @@ Deleting a SKU has the following effects:
 ---
 
 ## Editing a Published SKU
-If you wish to change a SKU that is published, you can do so at any time by first unpublishing the currently published one. When you unpublish a SKU, it is no longer available for sale, but users who have already subscribed will remain subscribed. You must continue to make the premium offering available to them until the end of their subscription.
+If you wish to change a SKU that is published, you can do so at any time by first unpublishing the currently published one. When you unpublish a SKU, it is no longer available for sale and users who have already subscribed will not renew at the end of their billing period. You must continue to make the premium offering available to them until the end of their subscription.
 
 ### Changing a Subscription SKU Price
 


### PR DESCRIPTION
Update docs to match Dev Portal warning re: unpublishing a published SKU.  The dev portal has the correct behavior.

![CleanShot 2024-09-16 at 13 59 28@2x](https://github.com/user-attachments/assets/4e3b5b15-a879-437f-921d-f6585910b533)
