### PR TITLE
Fix markdown link in Voice Connections topic

### DIFF
--- a/docs/topics/Voice_Connections.mdx
+++ b/docs/topics/Voice_Connections.mdx
@@ -322,7 +322,7 @@ When any DAVE protocol is enabled for a call, the full contents of OPUS frames s
 
 #### ULEB128 Encoding
 
-Some fields in the protocol frame payload use (ULEB128 encoding)[https://en.wikipedia.org/wiki/LEB128#Unsigned_LEB128]. This is a variable-length code compression to represent arbitrarily large unsigned integers in a small number of bytes.
+Some fields in the protocol frame payload use [ULEB128 encoding](https://en.wikipedia.org/wiki/LEB128#Unsigned_LEB128). This is a variable-length code compression to represent arbitrarily large unsigned integers in a small number of bytes.
 
 #### Payload Format
 


### PR DESCRIPTION
Fixed the ULEB128 encoding link to properly link to the Wikipedia page.