### PR TITLE
Add GET /webhook/<webhook_id> permission info

### DIFF
--- a/docs/resources/Webhook.md
+++ b/docs/resources/Webhook.md
@@ -134,6 +134,9 @@ Returns a list of guild [webhook](#DOCS_RESOURCES_WEBHOOK/webhook-object) object
 
 Returns the new [webhook](#DOCS_RESOURCES_WEBHOOK/webhook-object) object for the given id.
 
+This request requires the `MANAGE_WEBHOOKS` permission unless the application making the request owns the
+webhook. [(see: webhook.application_id)](#DOCS_RESOURCES_WEBHOOK/webhook-object)
+
 ## Get Webhook with Token % GET /webhooks/{webhook.id#DOCS_RESOURCES_WEBHOOK/webhook-object}/{webhook.token#DOCS_RESOURCES_WEBHOOK/webhook-object}
 
 Same as above, except this call does not require authentication and returns no user in the webhook object.


### PR DESCRIPTION
This endpoint has historically always required MANAGE_WEBHOOKS. We have just recently relaxed this requirement.