### PR TITLE
Fix sample snippet incorrectly checking webhook type

### DIFF
--- a/docs/events/Webhook_Events.mdx
+++ b/docs/events/Webhook_Events.mdx
@@ -51,7 +51,7 @@ To properly acknowledge a `PING` payload, return a `204` response with no body:
 ```py
 @app.route('/', methods=['POST'])
 def my_command():
-    if request.json["type"] == 'PING':
+    if request.json["type"] == 0:
         return Response(status=204)
 ```
 </Collapsible> 


### PR DESCRIPTION
Put this in the thread in the announcement on ddevs but been a day or so and still present (granted, probably due to weekend). The snippet compares the payload type to the string `'PING'` when it should be the int `0`