### PR TITLE
Add message flag for forwarded messages

### DIFF
--- a/docs/resources/Message.md
+++ b/docs/resources/Message.md
@@ -143,7 +143,7 @@ Represents a message sent in a channel within Discord.
 | FAILED_TO_MENTION_SOME_ROLES_IN_THREAD | `1 << 8`  | this message failed to mention some roles and add their members to the thread     |
 | SUPPRESS_NOTIFICATIONS                 | `1 << 12` | this message will not trigger push and desktop notifications                      |
 | IS_VOICE_MESSAGE                       | `1 << 13` | this message is a voice message                                                   |
-| HAS_SNAPSHOT                           | `1 << 14` | this message is a forwarded message                                               |
+| HAS_SNAPSHOT                           | `1 << 14` | this message has a snapshot (via Message Forwarding)                              |
 
 ###### Example Message
 

--- a/docs/resources/Message.md
+++ b/docs/resources/Message.md
@@ -143,6 +143,7 @@ Represents a message sent in a channel within Discord.
 | FAILED_TO_MENTION_SOME_ROLES_IN_THREAD | `1 << 8`  | this message failed to mention some roles and add their members to the thread     |
 | SUPPRESS_NOTIFICATIONS                 | `1 << 12` | this message will not trigger push and desktop notifications                      |
 | IS_VOICE_MESSAGE                       | `1 << 13` | this message is a voice message                                                   |
+| IS_FORWARDED_MESSAGE                   | `1 << 14` | this message is a forwarded message                                               |
 
 ###### Example Message
 

--- a/docs/resources/Message.md
+++ b/docs/resources/Message.md
@@ -143,7 +143,7 @@ Represents a message sent in a channel within Discord.
 | FAILED_TO_MENTION_SOME_ROLES_IN_THREAD | `1 << 8`  | this message failed to mention some roles and add their members to the thread     |
 | SUPPRESS_NOTIFICATIONS                 | `1 << 12` | this message will not trigger push and desktop notifications                      |
 | IS_VOICE_MESSAGE                       | `1 << 13` | this message is a voice message                                                   |
-| IS_FORWARDED_MESSAGE                   | `1 << 14` | this message is a forwarded message                                               |
+| HAS_SNAPSHOT                           | `1 << 14` | this message is a forwarded message                                               |
 
 ###### Example Message
 


### PR DESCRIPTION
The documentation is missing the flag `1 << 14` for forwarded messages / messages having a snapshot.