### PR TITLE
Add clarification around URL mappings and file targets.

### DIFF
--- a/docs/activities/Development_Guides.mdx
+++ b/docs/activities/Development_Guides.mdx
@@ -220,6 +220,7 @@ To add or modify your application's URL mappings, click on `Activities -> URL Ma
   | PREFIX                | TARGET                   |
   |-----------------------|--------------------------|
   | `/google/{subdomain}` | `{subdomain}.google.com` |
+- Targets must point to a directory; setting a target to a file (e.g. `example.com/index.html`) is unsupported and may lead to unexpected behavior.
 - Because of how URL globbing works, if you have multiple prefix urls with the same initial path, you must place the shortest of the prefix paths last in order for each url mapping to be reachable. For example, if you have `/foo` and `/foo/bar`, you must place the url `/foo/bar` before `/foo` or else the mapping for `/foo/bar` will never be reached.
 
 | ✅ DO                                                 | ❌ DON'T                                                    |


### PR DESCRIPTION
We received #7223 reporting issues with URL mappings set to a file failing to resolve due to the activity proxy adding a trailing slash to the resolved URL.

After discussion, we don't consider this a supported use case, and have added a note indicating that this may lead to unexpected behavior.

Resolves #7223