### PR TITLE
`openExternalLink` returns a `{ opened:  boolean | null }` result

### DIFF
--- a/docs/developer_tools/Embedded_App_SDK.mdx
+++ b/docs/developer_tools/Embedded_App_SDK.mdx
@@ -1337,7 +1337,8 @@ No scopes required
 
 #### OpenExternalLinkResponse
 
-> **Note:** `{ opened: null }` is returned on older Discord clients that do not report the result of the open link action.
+> warn
+> `{ opened: null }` is returned on Discord clients before December 2024 that do not report the open link result.
 
 | Property | Type            |
 |----------|-----------------|

--- a/docs/developer_tools/Embedded_App_SDK.mdx
+++ b/docs/developer_tools/Embedded_App_SDK.mdx
@@ -524,7 +524,7 @@ No scopes required
 #### Signature
 
 <Monospace>
-openExternalLink(args: [OpenExternalLinkRequest](#DOCS_DEVELOPER_TOOLS_EMBEDDED_APP_SDK/openexternallinkrequest)): Promise\<void\>
+openExternalLink(args: [OpenExternalLinkRequest](#DOCS_DEVELOPER_TOOLS_EMBEDDED_APP_SDK/openexternallinkrequest)): Promise\<[OpenExternalLinkResponse](#DOCS_DEVELOPER_TOOLS_EMBEDDED_APP_SDK/openexternallinkresponse)\>
 </Monospace>
 
 #### Usage
@@ -1334,6 +1334,12 @@ No scopes required
 | Property | Type   |
 |----------|--------|
 | url      | string |
+
+#### OpenExternalLinkResponse
+
+| Property | Type    |
+|----------|---------|
+| opened   | boolean |
 
 #### OpenInviteDialogRequest
 

--- a/docs/developer_tools/Embedded_App_SDK.mdx
+++ b/docs/developer_tools/Embedded_App_SDK.mdx
@@ -1337,9 +1337,11 @@ No scopes required
 
 #### OpenExternalLinkResponse
 
-| Property | Type    |
-|----------|---------|
-| opened   | boolean |
+> **Note:** `{ opened: null }` is returned on older Discord clients that do not report the result of the open link action.
+
+| Property | Type            |
+|----------|-----------------|
+| opened   | boolean \| null |
 
 #### OpenInviteDialogRequest
 


### PR DESCRIPTION
Edit the return type for `openExternalLink`. With this change the result of `openExternalLink` will be an object containing a boolean value `opened`. 

If `opened` is true, then the link was opened by the user
If `opened` is false, then the link was not opened by the user

The lifetime of the promise is also changed. Previously the promise completed after opening the "Leaving Discord" dialog, but with this change the promise completes after the user selects an action in the dialog (visit the site, or go back). If the dialog does not appear because the site visit is automatically approved, then the promise returns `{ opened: true }` following the link opening.