### PR TITLE
Add Bluesky & Mastodon to services table

### DIFF
--- a/docs/resources/User.md
+++ b/docs/resources/User.md
@@ -138,6 +138,7 @@ The connection object that the user has attached.
 | amazon-music    | Amazon Music        |
 | battlenet       | Battle.net          |
 | bungie          | Bungie.net          |
+| bluesky         | Bluesky             |
 | domain          | Domain              |
 | ebay            | eBay                |
 | epicgames       | Epic Games          |
@@ -145,6 +146,7 @@ The connection object that the user has attached.
 | github          | GitHub              |
 | instagram       | Instagram           |
 | leagueoflegends | League of Legends   |
+| mastodon        | Mastodon            |
 | paypal          | PayPal              |
 | playstation     | PlayStation Network |
 | reddit          | Reddit              |


### PR DESCRIPTION
Not sure if Mastodon should be added here as it is not publicly available unlike Bluesky which is out on canary at least but there are people who have their Mastodon accounts on their profile so it's something developers can encounter