### PR TITLE
Document default file upload limit

### DIFF
--- a/docs/Reference.mdx
+++ b/docs/Reference.mdx
@@ -397,7 +397,7 @@ https://cdn.discordapp.com/attachments/1012345678900020080/1234567891233211234/m
 ## Uploading Files
 
 > info
-> A file upload size limit applies to *all* files in a request (rather than each individual file). While the limit depends on the [**Boost Tier**](https://support.discord.com/hc/en-us/articles/360028038352-Server-Boosting-FAQ-#h_419c3bd5-addd-4989-b7cf-c7957ef92583) of a guild, it is `25 MiB` by default.
+> A file upload size limit applies to *all* files in a request (rather than each individual file). While the limit depends on the [**Boost Tier**](https://support.discord.com/hc/en-us/articles/360028038352-Server-Boosting-FAQ-#h_419c3bd5-addd-4989-b7cf-c7957ef92583) of a guild, it is `10 MiB` by default.
 
 Some endpoints support file attachments, indicated by the `files[n]` parameter. To add file(s), the standard `application/json` body must be replaced by a `multipart/form-data` body. The JSON message body can optionally be provided using the `payload_json` parameter.
 

--- a/docs/change_log/2024-12-17-updated-file-upload-limit.md
+++ b/docs/change_log/2024-12-17-updated-file-upload-limit.md
@@ -1,0 +1,17 @@
+---
+title: "Default File Upload Limit Change"
+date: "2024-12-16"
+breaking: true
+topics:
+- "HTTP API"
+- "Interactions"
+---
+
+On January 16, 2025, the default file upload limit will change from 25 MiB to 10 MiB.
+
+While this limit is already active for users and bot users, it hasn't yet been applied to webhooks.
+
+- This change will take effect on January 16, 2025.
+- The 10 MiB limit will apply to both webhooks and interaction responses.
+
+For more information, check out [our documentation on file uploads](#DOCS_REFERENCE/uploading-files).


### PR DESCRIPTION
Updates default file upload limit to 10 MiB + change log.

> On January 16, 2025, the default file upload limit will change from 25 MiB to 10 MiB.
> While this limit is already active for users and bot users, it hasn't yet been applied to webhooks.
> - This change will take effect on January 16, 2025.
> - The 10 MiB limit will apply to both webhooks and interaction responses.