### PR TITLE
Fixing typo in interactions overview

### DIFF
--- a/docs/interactions/Overview.mdx
+++ b/docs/interactions/Overview.mdx
@@ -45,7 +45,7 @@ A list of all message components and details on sending and receiving component 
 
 ### Modals
 
-**[Modals](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-response-object-modal)** are single-user pop-up interfaces that allow apps to collect form-like data. Modals can only be opened in response to a user invoking on of your app's commands or message components.
+**[Modals](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-response-object-modal)** are single-user pop-up interfaces that allow apps to collect form-like data. Modals can only be opened in response to a user invoking one of your app's commands or message components.
 
 ![Modals in the Discord client](overview-modals.png)
 


### PR DESCRIPTION
Fixing a typo
`invoking **on** of your app's` -> `invoking **one** of your app's`