### PR TITLE
Updated link to Twemoji

### DIFF
--- a/docs/Reference.mdx
+++ b/docs/Reference.mdx
@@ -271,7 +271,7 @@ Discord utilizes a subset of markdown for rendering message content on its clien
 | Unix Timestamp (Styled) | `<t:TIMESTAMP:STYLE>` | `<t:1618953630:d>`              |
 | Guild Navigation        | `<id:TYPE>`           | `<id:customize>`                |
 
-Using the markdown for either users, roles, or channels will usually mention the target(s) accordingly, but this can be suppressed using the `allowed_mentions` parameter when creating a message. Standard emoji are currently rendered using [Twemoji](https://twemoji.twitter.com/) for Desktop/Android and Apple's native emoji on iOS.
+Using the markdown for either users, roles, or channels will usually mention the target(s) accordingly, but this can be suppressed using the `allowed_mentions` parameter when creating a message. Standard emoji are currently rendered using [Twemoji](https://github.com/twitter/twemoji) for Desktop/Android and Apple's native emoji on iOS.
 
 Timestamps are expressed in seconds and display the given timestamp in the user's timezone and locale.
 


### PR DESCRIPTION
The previous link is no longer valid, and there is no replacement available on x.com. Therefore, I have updated the reference to point to the GitHub repository.