### PR TITLE
Update twemoji repo link

### DIFF
--- a/docs/Reference.mdx
+++ b/docs/Reference.mdx
@@ -271,7 +271,7 @@ Discord utilizes a subset of markdown for rendering message content on its clien
 | Unix Timestamp (Styled) | `<t:TIMESTAMP:STYLE>` | `<t:1618953630:d>`              |
 | Guild Navigation        | `<id:TYPE>`           | `<id:customize>`                |
 
-Using the markdown for either users, roles, or channels will usually mention the target(s) accordingly, but this can be suppressed using the `allowed_mentions` parameter when creating a message. Standard emoji are currently rendered using [Twemoji](https://github.com/twitter/twemoji) for Desktop/Android and Apple's native emoji on iOS.
+Using the markdown for either users, roles, or channels will usually mention the target(s) accordingly, but this can be suppressed using the `allowed_mentions` parameter when creating a message. Standard emoji are currently rendered using [Twemoji](https://github.com/jdecked/twemoji) for Desktop/Android and Apple's native emoji on iOS.
 
 Timestamps are expressed in seconds and display the given timestamp in the user's timezone and locale.
 


### PR DESCRIPTION
#7361 linked this to twitter/twemoji, but that repo is outdated and Discord now uses the maintained fork jdecked/twemoji.