### PR TITLE
Remove Javacord library

### DIFF
--- a/docs/developer_tools/Community_Resources.mdx
+++ b/docs/developer_tools/Community_Resources.mdx
@@ -20,7 +20,6 @@ Discord does not maintain official SDKs.  The following table is an inexhaustive
 | [discljord](https://github.com/discljord/discljord)           | Clojure    |
 | [DiscordGo](https://github.com/bwmarrin/discordgo)            | Go         |
 | [Discord4J](https://github.com/Discord4J/Discord4J)           | Java       |
-| [Javacord](https://github.com/Javacord/Javacord)              | Java       |
 | [JDA](https://github.com/DV8FromTheWorld/JDA)                 | Java       |
 | [discord.js](https://github.com/discordjs/discord.js)         | JavaScript |
 | [Eris](https://github.com/abalabahaha/eris)                   | JavaScript |


### PR DESCRIPTION
Javacord has officially ceased development and we do no longer recommend new users to use it.

![image](https://github.com/user-attachments/assets/35c78dca-0fb6-46ea-a31b-b50b9fec83f7)
