### PR TITLE
note that deferred callback can only have ephemeral as flag

### DIFF
--- a/docs/interactions/Receiving_and_Responding.mdx
+++ b/docs/interactions/Receiving_and_Responding.mdx
@@ -250,7 +250,7 @@ Not all message fields are currently supported.
 | attachments? \*\* | array of partial [attachment](#DOCS_RESOURCES_MESSAGE/attachment-object) objects | Attachment objects with filename and description                                                                                                                                                                       |
 | poll?             | [poll](#DOCS_RESOURCES_POLL/poll-create-request-object) request object           | Details about the poll                                                                                                                                                                                                 |
 
-\* If you create a callback with the [type](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-response-object-interaction-callback-type) `DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE` you can only set `EPHEMERAL` as flag.
+\* If you create a callback with the [type](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-response-object-interaction-callback-type) `DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE` the only valid [message flag](#DOCS_RESOURCES_MESSAGE/message-object-message-flags) you may use is `EPHEMERAL`.
 
 \*\* See [Uploading Files](#DOCS_REFERENCE/uploading-files) for details.
 

--- a/docs/interactions/Receiving_and_Responding.mdx
+++ b/docs/interactions/Receiving_and_Responding.mdx
@@ -245,12 +245,14 @@ Not all message fields are currently supported.
 | content?          | string                                                                           | Message content                                                                                                                                                                                                        |
 | embeds?           | array of [embeds](#DOCS_RESOURCES_MESSAGE/embed-object)                          | Supports up to 10 embeds                                                                                                                                                                                               |
 | allowed_mentions? | [allowed mentions](#DOCS_RESOURCES_MESSAGE/allowed-mentions-object)              | [Allowed mentions](#DOCS_RESOURCES_MESSAGE/allowed-mentions-object) object                                                                                                                                             |
-| flags?            | integer                                                                          | [Message flags](#DOCS_RESOURCES_MESSAGE/message-object-message-flags) combined as a [bitfield](https://en.wikipedia.org/wiki/Bit_field) (only `SUPPRESS_EMBEDS`, `EPHEMERAL`, and `SUPPRESS_NOTIFICATIONS` can be set) |
+| flags? \*         | integer                                                                          | [Message flags](#DOCS_RESOURCES_MESSAGE/message-object-message-flags) combined as a [bitfield](https://en.wikipedia.org/wiki/Bit_field) (only `SUPPRESS_EMBEDS`, `EPHEMERAL`, and `SUPPRESS_NOTIFICATIONS` can be set) |
 | components?       | array of [components](#DOCS_INTERACTIONS_MESSAGE_COMPONENTS/)                    | Message components                                                                                                                                                                                                     |
-| attachments? \*   | array of partial [attachment](#DOCS_RESOURCES_MESSAGE/attachment-object) objects | Attachment objects with filename and description                                                                                                                                                                       |
+| attachments? \*\* | array of partial [attachment](#DOCS_RESOURCES_MESSAGE/attachment-object) objects | Attachment objects with filename and description                                                                                                                                                                       |
 | poll?             | [poll](#DOCS_RESOURCES_POLL/poll-create-request-object) request object           | Details about the poll                                                                                                                                                                                                 |
 
-\* See [Uploading Files](#DOCS_REFERENCE/uploading-files) for details.
+\* If you create a callback with the [type](#DOCS_INTERACTIONS_RECEIVING_AND_RESPONDING/interaction-response-object-interaction-callback-type) `DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE` you can only set `EPHEMERAL` as flag.
+
+\*\* See [Uploading Files](#DOCS_REFERENCE/uploading-files) for details.
 
 ###### Autocomplete
 


### PR DESCRIPTION
I believe this is not noted anywhere.

Trying to set the suppress notification flag and the ephemeral flags while deferring ends up being filtered to just the ephemeral flag.

Tested with:
```cs
[SlashCommand("test", "Testing")]
public static async Task TestAsync(InteractionContext ctx)
{
        var builder = new DiscordInteractionResponseBuilder().AsEphemeral().AsSilentMessage().SuppressEmbeds().WithV2Components();
        var response = await ctx.CreateResponseAsync(InteractionResponseType.DeferredChannelMessageWithSource, builder);
        await ctx.EditResponseAsync($"Send the following flags: {response.SendFlags}\nReceived the following flags from the callback response: {response.Message?.Flags}");
}
```
![image](https://github.com/user-attachments/assets/27fd5e14-f8b4-485f-a0c4-b1276446812b)