### PR TITLE
Make allowed mentions fields optional

### DIFF
--- a/docs/resources/Message.md
+++ b/docs/resources/Message.md
@@ -631,12 +631,12 @@ The allowed mention field allows for more granular control over mentions without
 
 ###### Allowed Mentions Structure
 
-| Field        | Type                           | Description                                                                                                                           |
-|--------------|--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| parse        | array of allowed mention types | An array of [allowed mention types](#DOCS_RESOURCES_MESSAGE/allowed-mentions-object-allowed-mention-types) to parse from the content. |
-| roles        | list of snowflakes             | Array of role_ids to mention (Max size of 100)                                                                                        |
-| users        | list of snowflakes             | Array of user_ids to mention (Max size of 100)                                                                                        |
-| replied_user | boolean                        | For replies, whether to mention the author of the message being replied to (default false)                                            |
+| Field         | Type                           | Description                                                                                                                           |
+|---------------|--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| parse?        | array of allowed mention types | An array of [allowed mention types](#DOCS_RESOURCES_MESSAGE/allowed-mentions-object-allowed-mention-types) to parse from the content. |
+| roles?        | list of snowflakes             | Array of role_ids to mention (Max size of 100)                                                                                        |
+| users?        | list of snowflakes             | Array of user_ids to mention (Max size of 100)                                                                                        |
+| replied_user? | boolean                        | For replies, whether to mention the author of the message being replied to (default false)                                            |
 
 ###### Allowed Mentions Reference
 


### PR DESCRIPTION
Marks fields in the allowed mentions structure optional, as they are represented in the examples given below. RE: #7420 