### PR TITLE
Fix lowercase "intro" title.

### DIFF
--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -1,6 +1,7 @@
 ---
 showTOC: false
 sidebar_label: Intro
+title: Intro
 ---
 
 <Hero title="Build Where the World Plays" subheading="Create social games, experiences, and integrations for millions of users on Discord" />


### PR DESCRIPTION
Workaround is to provide an explicit "ttile: Intro" top level config on the page.