### PR TITLE
Fix bounds issue with integer field in application command

### DIFF
--- a/docs/interactions/application-commands.mdx
+++ b/docs/interactions/application-commands.mdx
@@ -84,7 +84,7 @@ Application commands are native ways to interact with apps in the Discord client
 | SUB_COMMAND       | 1     |                                                                |
 | SUB_COMMAND_GROUP | 2     |                                                                |
 | STRING            | 3     |                                                                |
-| INTEGER           | 4     | Any integer between -2^53 and 2^53                             |
+| INTEGER           | 4     | Any integer between -2^53+1 and 2^53-1                         |
 | BOOLEAN           | 5     |                                                                |
 | USER              | 6     |                                                                |
 | CHANNEL           | 7     | Includes all channel types + categories                        |


### PR DESCRIPTION
The bound for integers [here](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type) was incorrectly specified as -2^53 to 2^53, ignoring the representation for integers in JS with minimum (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_SAFE_INTEGER) and maximum (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER)