### PR TITLE
Components v2 Example Flags

### DIFF
--- a/docs/components/using-message-components.mdx
+++ b/docs/components/using-message-components.mdx
@@ -30,7 +30,7 @@ All content must be sent as components instead of using the standard message for
 
 ```json
 {
-  "flags": "32768",
+  "flags": 32768,
   "components": [
     {
       "type": 10,
@@ -46,7 +46,7 @@ To send a message with multiple components, you can include multiple component o
 
 ```json
 {
-  "flags": "32768",
+  "flags": 32768,
   "components": [
     {
       "type": 10,
@@ -68,7 +68,7 @@ For example, you can create a message with an Action Row component that contains
 
 ```json
 {
-  "flags": "32768",
+  "flags": 32768,
   "components": [
     {
       "type": 10,


### PR DESCRIPTION
In the Using Message Components examples the `flags` field was of string type when it should be integer type. Fixed.