### PR TITLE
Fix bug causing incorrect rendering of HTTP methods for resource docs

### DIFF
--- a/docs/events/gateway.mdx
+++ b/docs/events/gateway.mdx
@@ -698,7 +698,7 @@ The [Get Gateway Bot endpoint](/docs/events/gateway#get-gateway-bot) will always
 The session start limit for these bots will also be increased from 1000 to `max(2000, (guild_count / 1000) * 5)` per day. You also receive an increased `max_concurrency`, the number of [shards you can concurrently start](/docs/events/gateway#session-start-limit-object).
 
 ## Get Gateway
-<Route type="GET">/gateway</Route>
+<Route method="GET">/gateway</Route>
 
 :::info
 This endpoint does not require authentication.
@@ -716,7 +716,7 @@ Returns an object with a valid WSS URL which the app can use when [Connecting](/
 
 ## Get Gateway Bot
 
-<Route type="GET">/gateway/bot</Route>
+<Route method="GET">/gateway/bot</Route>
 
 :::warn
 This endpoint requires authentication using a valid bot token.

--- a/docs/interactions/application-commands.mdx
+++ b/docs/interactions/application-commands.mdx
@@ -1157,7 +1157,7 @@ For authorization, all endpoints take either a [bot token](/docs/reference#authe
 :::
 
 ## Get Global Application Commands
-<Route type="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/commands</Route>
+<Route method="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/commands</Route>
 
 :::warn
 The objects returned by this endpoint may be augmented with [additional fields if localization is active](/docs/interactions/application-commands#retrieving-localized-commands).
@@ -1172,7 +1172,7 @@ Fetch all of the global commands for your application. Returns an array of [appl
 | with_localizations? | [boolean](/docs/reference#boolean-query-strings) | Whether to include full localization dictionaries (`name_localizations` and `description_localizations`) in the returned objects, instead of the `name_localized` and `description_localized` fields. Default `false`. |
 
 ## Create Global Application Command
-<Route type="POST">/applications/[\{application.id\}](/docs/resources/application#application-object)/commands</Route>
+<Route method="POST">/applications/[\{application.id\}](/docs/resources/application#application-object)/commands</Route>
 
 :::warn
 Creating a command with the same name as an existing command for your application will overwrite the old command.
@@ -1198,12 +1198,12 @@ Create a new global command. Returns `201` if a command with the same name does 
 | nsfw?                       | boolean                                                                                                                                        | Indicates whether the command is [age-restricted](/docs/interactions/application-commands#agerestricted-commands)                                                                       |
 
 ## Get Global Application Command
-<Route type="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/commands/[\{command.id\}](/docs/interactions/application-commands#application-command-object)</Route>
+<Route method="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/commands/[\{command.id\}](/docs/interactions/application-commands#application-command-object)</Route>
 
 Fetch a global command for your application. Returns an [application command](/docs/interactions/application-commands#application-command-object) object.
 
 ## Edit Global Application Command
-<Route type="PATCH">/applications/[\{application.id\}](/docs/resources/application#application-object)/commands/[\{command.id\}](/docs/interactions/application-commands#application-command-object)</Route>
+<Route method="PATCH">/applications/[\{application.id\}](/docs/resources/application#application-object)/commands/[\{command.id\}](/docs/interactions/application-commands#application-command-object)</Route>
 
 :::info
 All parameters for this endpoint are optional.
@@ -1228,12 +1228,12 @@ Edit a global command. Returns `200` and an [application command](/docs/interact
 | nsfw?                       | boolean                                                                                                                                        | Indicates whether the command is [age-restricted](/docs/interactions/application-commands#agerestricted-commands)                                                                       |
 
 ## Delete Global Application Command
-<Route type="DELETE">/applications/[\{application.id\}](/docs/resources/application#application-object)/commands/[\{command.id\}](/docs/interactions/application-commands#application-command-object)</Route>
+<Route method="DELETE">/applications/[\{application.id\}](/docs/resources/application#application-object)/commands/[\{command.id\}](/docs/interactions/application-commands#application-command-object)</Route>
 
 Deletes a global command. Returns `204 No Content` on success.
 
 ## Bulk Overwrite Global Application Commands
-<Route type="PUT">/applications/[\{application.id\}](/docs/resources/application#application-object)/commands</Route>
+<Route method="PUT">/applications/[\{application.id\}](/docs/resources/application#application-object)/commands</Route>
 
 Takes a list of application commands, overwriting the existing global command list for this application. Returns `200` and a list of [application command](/docs/interactions/application-commands#application-command-object) objects. Commands that do not already exist will count toward daily application command create limits.
 
@@ -1242,7 +1242,7 @@ This will overwrite **all** types of application commands: slash commands, user 
 :::
 
 ## Get Guild Application Commands
-<Route type="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/commands</Route>
+<Route method="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/commands</Route>
 
 :::warn
 The objects returned by this endpoint may be augmented with [additional fields if localization is active](/docs/interactions/application-commands#retrieving-localized-commands).
@@ -1257,7 +1257,7 @@ Fetch all of the guild commands for your application for a specific guild. Retur
 | with_localizations? | [boolean](/docs/reference#boolean-query-strings) | Whether to include full localization dictionaries (`name_localizations` and `description_localizations`) in the returned objects, instead of the `name_localized` and `description_localized` fields. Default `false`. |
 
 ## Create Guild Application Command
-<Route type="POST">/applications/[\{application.id\}](/docs/resources/application#application-object)/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/commands</Route>
+<Route method="POST">/applications/[\{application.id\}](/docs/resources/application#application-object)/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/commands</Route>
 
 :::danger
 Creating a command with the same name as an existing command for your application will overwrite the old command.
@@ -1280,12 +1280,12 @@ Create a new guild command. New guild commands will be available in the guild im
 | nsfw?                       | boolean                                                                                                                                        | Indicates whether the command is [age-restricted](/docs/interactions/application-commands#agerestricted-commands)                                                                       |
 
 ## Get Guild Application Command
-<Route type="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/commands/[\{command.id\}](/docs/interactions/application-commands#application-command-object)</Route>
+<Route method="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/commands/[\{command.id\}](/docs/interactions/application-commands#application-command-object)</Route>
 
 Fetch a guild command for your application. Returns an [application command](/docs/interactions/application-commands#application-command-object) object.
 
 ## Edit Guild Application Command
-<Route type="PATCH">/applications/[\{application.id\}](/docs/resources/application#application-object)/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/commands/[\{command.id\}](/docs/interactions/application-commands#application-command-object)</Route>
+<Route method="PATCH">/applications/[\{application.id\}](/docs/resources/application#application-object)/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/commands/[\{command.id\}](/docs/interactions/application-commands#application-command-object)</Route>
 
 :::info
 All parameters for this endpoint are optional.
@@ -1308,13 +1308,13 @@ Edit a guild command. Updates for guild commands will be available immediately. 
 
 ## Delete Guild Application Command
 
-<Route type="DELETE">/applications/[\{application.id\}](/docs/resources/application#application-object)/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/commands/[\{command.id\}](/docs/interactions/application-commands#application-command-object)</Route>
+<Route method="DELETE">/applications/[\{application.id\}](/docs/resources/application#application-object)/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/commands/[\{command.id\}](/docs/interactions/application-commands#application-command-object)</Route>
 
 Delete a guild command. Returns `204 No Content` on success.
 
 ## Bulk Overwrite Guild Application Commands
 
-<Route type="PUT">/applications/\{application.id/docs/resources/application#application-object\}/guilds/\{guild.id/docs/resources/guild#guild-object\}/commands</Route>
+<Route method="PUT">/applications/\{application.id/docs/resources/application#application-object\}/guilds/\{guild.id/docs/resources/guild#guild-object\}/commands</Route>
 
 Takes a list of application commands, overwriting the existing command list for this application for the targeted guild. Returns `200` and a list of [application command](/docs/interactions/application-commands#application-command-object) objects.
 
@@ -1342,17 +1342,17 @@ This will overwrite **all** types of application commands: slash commands, user 
 
 ## Get Guild Application Command Permissions
 
-<Route type="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/commands/permissions</Route>
+<Route method="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/commands/permissions</Route>
 
 Fetches permissions for all commands for your application in a guild. Returns an array of [guild application command permissions](/docs/interactions/application-commands#application-command-permissions-object-guild-application-command-permissions-structure) objects.
 
 ## Get Application Command Permissions
-<Route type="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/commands/[\{command.id\}](/docs/interactions/application-commands#application-command-object)/permissions</Route>
+<Route method="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/commands/[\{command.id\}](/docs/interactions/application-commands#application-command-object)/permissions</Route>
 
 Fetches permissions for a specific command for your application in a guild. Returns a [guild application command permissions](/docs/interactions/application-commands#application-command-permissions-object-guild-application-command-permissions-structure) object.
 
 ## Edit Application Command Permissions
-<Route type="PUT">/applications/[\{application.id\}](/docs/resources/application#application-object)/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/commands/[\{command.id\}](/docs/interactions/application-commands#application-command-object)/permissions</Route>
+<Route method="PUT">/applications/[\{application.id\}](/docs/resources/application#application-object)/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/commands/[\{command.id\}](/docs/interactions/application-commands#application-command-object)/permissions</Route>
 
 :::warn
 This endpoint will overwrite existing permissions for the command in that guild
@@ -1377,7 +1377,7 @@ Deleting or renaming a command will permanently delete all permissions for the c
 | permissions | array of [application command permissions](/docs/interactions/application-commands#application-command-permissions-object-application-command-permissions-structure) | Permissions for the command in the guild |
 
 ## Batch Edit Application Command Permissions
-<Route type="PUT">/applications/[\{application.id\}](/docs/resources/application#application-object)/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/commands/permissions</Route>
+<Route method="PUT">/applications/[\{application.id\}](/docs/resources/application#application-object)/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/commands/permissions</Route>
 
 :::danger
 This endpoint has been disabled with [updates to command permissions (Permissions v2)](/docs/change-log#updated-command-permissions). Instead, you can [edit each application command permissions](/docs/interactions/application-commands#edit-application-command-permissions) (though you should be careful to handle any potential [rate limits](/docs/topics/rate-limits)).

--- a/docs/interactions/receiving-and-responding.mdx
+++ b/docs/interactions/receiving-and-responding.mdx
@@ -389,7 +389,7 @@ The endpoints below are not bound to the application's [Global Rate Limit](/docs
 :::
 
 ## Create Interaction Response
-<Route type="POST">/interactions/[\{interaction.id}](/docs/interactions/receiving-and-responding#interaction-object)/[\{interaction.token\}](/docs/interactions/receiving-and-responding#interaction-object)/callback</Route>
+<Route method="POST">/interactions/[\{interaction.id}](/docs/interactions/receiving-and-responding#interaction-object)/[\{interaction.token\}](/docs/interactions/receiving-and-responding#interaction-object)/callback</Route>
 
 Create a response to an Interaction. Body is an [interaction response](/docs/interactions/receiving-and-responding#interaction-response-object). Returns `204` unless `with_response` is set to `true` which returns `200` with the body as [interaction callback response](/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object).
 
@@ -403,22 +403,22 @@ This endpoint also supports file attachments similar to the webhook endpoints. R
 
 
 ## Get Original Interaction Response
-<Route type="GET">/webhooks/[\{application.id\}](/docs/resources/application#application-object)/[\{interaction.token\}](/docs/interactions/receiving-and-responding#interaction-object)/messages/@original</Route>
+<Route method="GET">/webhooks/[\{application.id\}](/docs/resources/application#application-object)/[\{interaction.token\}](/docs/interactions/receiving-and-responding#interaction-object)/messages/@original</Route>
 
 Returns the initial Interaction response. Functions the same as [Get Webhook Message](/docs/resources/webhook#get-webhook-message).
 
 ## Edit Original Interaction Response
-<Route type="PATCH">/webhooks/[\{application.id\}](/docs/resources/application#application-object)/[\{interaction.token\}](/docs/interactions/receiving-and-responding#interaction-object)/messages/@original</Route>
+<Route method="PATCH">/webhooks/[\{application.id\}](/docs/resources/application#application-object)/[\{interaction.token\}](/docs/interactions/receiving-and-responding#interaction-object)/messages/@original</Route>
 
 Edits the initial Interaction response. Functions the same as [Edit Webhook Message](/docs/resources/webhook#edit-webhook-message).
 
 ## Delete Original Interaction Response
-<Route type="DELETE">/webhooks/[\{application.id\}](/docs/resources/application#application-object)/[\{interaction.token\}](/docs/interactions/receiving-and-responding#interaction-object)/messages/@original</Route>
+<Route method="DELETE">/webhooks/[\{application.id\}](/docs/resources/application#application-object)/[\{interaction.token\}](/docs/interactions/receiving-and-responding#interaction-object)/messages/@original</Route>
 
 Deletes the initial Interaction response. Returns `204 No Content` on success.
 
 ## Create Followup Message
-<Route type="POST">/webhooks/[\{application.id\}](/docs/resources/application#application-object)/[\{interaction.token\}](/docs/interactions/receiving-and-responding#interaction-object)</Route>
+<Route method="POST">/webhooks/[\{application.id\}](/docs/resources/application#application-object)/[\{interaction.token\}](/docs/interactions/receiving-and-responding#interaction-object)</Route>
 
 :::info
 Apps are limited to 5 followup messages per interaction if it was initiated from a user-installed app and isn't installed in the server (meaning the [authorizing integration owners object](/docs/interactions/receiving-and-responding#interaction-object-authorizing-integration-owners-object) only contains `USER_INSTALL`)
@@ -429,16 +429,16 @@ Create a followup message for an Interaction. Functions the same as [Execute Web
 When using this endpoint directly after responding to an interaction with `DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE`, this endpoint will function as [Edit Original Interaction Response](/docs/interactions/receiving-and-responding#edit-original-interaction-response) for backwards compatibility. In this case, no new message will be created, and the loading message will be edited instead. The ephemeral flag will be ignored, and the value you provided in the initial defer response will be preserved, as an existing message's ephemeral state cannot be changed. This behavior is deprecated, and you should use the Edit Original Interaction Response endpoint in this case instead.
 
 ## Get Followup Message
-<Route type="GET">/webhooks/[\{application.id\}](/docs/resources/application#application-object)/[\{interaction.token\}](/docs/interactions/receiving-and-responding#interaction-object)/messages/[\{message.id\}](/docs/resources/message#message-object)</Route>
+<Route method="GET">/webhooks/[\{application.id\}](/docs/resources/application#application-object)/[\{interaction.token\}](/docs/interactions/receiving-and-responding#interaction-object)/messages/[\{message.id\}](/docs/resources/message#message-object)</Route>
 
 Returns a followup message for an Interaction. Functions the same as [Get Webhook Message](/docs/resources/webhook#get-webhook-message).
 
 ## Edit Followup Message
-<Route type="PATCH">/webhooks/[\{application.id\}](/docs/resources/application#application-object)/[\{interaction.token\}](/docs/interactions/receiving-and-responding#interaction-object)/messages/[\{message.id\}](/docs/resources/message#message-object)</Route>
+<Route method="PATCH">/webhooks/[\{application.id\}](/docs/resources/application#application-object)/[\{interaction.token\}](/docs/interactions/receiving-and-responding#interaction-object)/messages/[\{message.id\}](/docs/resources/message#message-object)</Route>
 
 Edits a followup message for an Interaction. Functions the same as [Edit Webhook Message](/docs/resources/webhook#edit-webhook-message).
 
 ## Delete Followup Message
-<Route type="DELETE">/webhooks/[\{application.id\}](/docs/resources/application#application-object)/[\{interaction.token\}](/docs/interactions/receiving-and-responding#interaction-object)/messages/[\{message.id\}](/docs/resources/message#message-object)</Route>
+<Route method="DELETE">/webhooks/[\{application.id\}](/docs/resources/application#application-object)/[\{interaction.token\}](/docs/interactions/receiving-and-responding#interaction-object)/messages/[\{message.id\}](/docs/resources/message#message-object)</Route>
 
 Deletes a followup message for an Interaction. Returns `204 No Content` on success.

--- a/docs/resources/application-role-connection-metadata.mdx
+++ b/docs/resources/application-role-connection-metadata.mdx
@@ -40,13 +40,13 @@ Each metadata type offers a comparison operation that allows guilds to configure
 
 ## Get Application Role Connection Metadata Records
 
-<Route type="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/role-connections/metadata</Route>
+<Route method="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/role-connections/metadata</Route>
 
 Returns a list of [application role connection metadata](/docs/resources/application-role-connection-metadata#application-role-connection-metadata-object) objects for the given application.
 
 ## Update Application Role Connection Metadata Records
 
-<Route type="PUT">/applications/[\{application.id\}](/docs/resources/application#application-object)/role-connections/metadata</Route>
+<Route method="PUT">/applications/[\{application.id\}](/docs/resources/application#application-object)/role-connections/metadata</Route>
 
 Updates and returns a list of [application role connection metadata](/docs/resources/application-role-connection-metadata#application-role-connection-metadata-object) objects for the given application.
 

--- a/docs/resources/application.mdx
+++ b/docs/resources/application.mdx
@@ -227,12 +227,12 @@ You can configure your app's install link in your [app's settings](https://disco
 The Default Install Settings will appear on the **Installation** page when you have "Discord Provided Link" selected as your install link type.
 
 ## Get Current Application
-<Route type="GET">/applications/@me</Route>
+<Route method="GET">/applications/@me</Route>
 
 Returns the [application](/docs/resources/application#application-object) object associated with the requesting bot user.
 
 ## Edit Current Application
-<Route type="PATCH">/applications/@me</Route>
+<Route method="PATCH">/applications/@me</Route>
 
 Edit properties of the app associated with the requesting bot user. Only properties that are passed will be updated. Returns the updated [application](/docs/resources/application#application-object) object on success.
 

--- a/docs/resources/audit-log.mdx
+++ b/docs/resources/audit-log.mdx
@@ -198,7 +198,7 @@ For most objects, the change keys may be any field on the changed object. The fo
 | [Webhook](/docs/resources/webhook#webhook-object)                                                                                              | `avatar_hash` key (instead of `avatar`)                        |                                                                                                                                                                                                                                                             |
 
 ## Get Guild Audit Log
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/audit-logs</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/audit-logs</Route>
 
 Returns an [audit log](/docs/resources/audit-log#audit-log-object) object for the guild. Requires the [`VIEW_AUDIT_LOG`](/docs/topics/permissions#permissions-bitwise-permission-flags) permission.
 

--- a/docs/resources/auto-moderation.mdx
+++ b/docs/resources/auto-moderation.mdx
@@ -199,7 +199,7 @@ Users are required to have the `MANAGE_GUILD` permission to access all Auto Mode
 Some [action types](/docs/resources/auto-moderation#auto-moderation-action-object-action-types) require additional permissions, e.g. the `TIMEOUT` action type requires an additional `MODERATE_MEMBERS` permission.
 
 ## List Auto Moderation Rules for Guild
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/auto-moderation/rules</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/auto-moderation/rules</Route>
 
 Get a list of all rules currently configured for the guild. Returns a list of [auto moderation rule](/docs/resources/auto-moderation#auto-moderation-rule-object) objects for the given guild.
 
@@ -208,7 +208,7 @@ This endpoint requires the `MANAGE_GUILD` [permission](/docs/resources/auto-mode
 :::
 
 ## Get Auto Moderation Rule
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/auto-moderation/rules/[\{auto_moderation_rule.id\}](/docs/resources/auto-moderation#auto-moderation-rule-object)</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/auto-moderation/rules/[\{auto_moderation_rule.id\}](/docs/resources/auto-moderation#auto-moderation-rule-object)</Route>
 
 Get a single rule. Returns an [auto moderation rule](/docs/resources/auto-moderation#auto-moderation-rule-object) object.
 
@@ -217,7 +217,7 @@ This endpoint requires the `MANAGE_GUILD` [permission](/docs/resources/auto-mode
 :::
 
 ## Create Auto Moderation Rule
-<Route type="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/auto-moderation/rules</Route>
+<Route method="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/auto-moderation/rules</Route>
 
 Create a new rule. Returns an [auto moderation rule](/docs/resources/auto-moderation#auto-moderation-rule-object) on success. Fires an [Auto Moderation Rule Create](/docs/events/gateway-events#auto-moderation-rule-create) Gateway event.
 
@@ -250,7 +250,7 @@ See [Trigger Types](/docs/resources/auto-moderation#auto-moderation-rule-object-
 
 
 ## Modify Auto Moderation Rule
-<Route type="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/auto-moderation/rules/[\{auto_moderation_rule.id\}](/docs/resources/auto-moderation#auto-moderation-rule-object)</Route>
+<Route method="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/auto-moderation/rules/[\{auto_moderation_rule.id\}](/docs/resources/auto-moderation#auto-moderation-rule-object)</Route>
 
 Modify an existing rule. Returns an [auto moderation rule](/docs/resources/auto-moderation#auto-moderation-rule-object) on success. Fires an [Auto Moderation Rule Update](/docs/events/gateway-events#auto-moderation-rule-update) Gateway event.
 
@@ -281,7 +281,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 \* Can be omitted based on `trigger_type`. See the `Associated Trigger Types` column in [trigger metadata](/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata) to understand which `trigger_type` values require `trigger_metadata` to be set.
 
 ## Delete Auto Moderation Rule
-<Route type="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/auto-moderation/rules/[\{auto_moderation_rule.id\}](/docs/resources/auto-moderation#auto-moderation-rule-object)</Route>
+<Route method="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/auto-moderation/rules/[\{auto_moderation_rule.id\}](/docs/resources/auto-moderation#auto-moderation-rule-object)</Route>
 
 Delete a rule. Returns a `204` on success. Fires an [Auto Moderation Rule Delete](/docs/events/gateway-events#auto-moderation-rule-delete) Gateway event.
 

--- a/docs/resources/channel.mdx
+++ b/docs/resources/channel.mdx
@@ -346,12 +346,12 @@ When updating a `GUILD_FORUM` or a `GUILD_MEDIA` channel, tag objects in `availa
 \* At most one of `emoji_id` and `emoji_name` may be set to a non-null value.
 
 ## Get Channel
-<Route type="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)</Route>
+<Route method="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)</Route>
 
 Get a channel by ID. Returns a [channel](/docs/resources/channel#channel-object) object.  If the channel is a thread, a [thread member](/docs/resources/channel#thread-member-object) object is included in the returned result.
 
 ## Modify Channel
-<Route type="PATCH">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)</Route>
+<Route method="PATCH">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)</Route>
 
 Update a channel's settings. Returns a [channel](/docs/resources/channel#channel-object) on success, and a 400 BAD REQUEST on invalid parameters.
 
@@ -420,7 +420,7 @@ Otherwise, requires the `MANAGE_THREADS` permission. Fires a [Thread Update](/do
 | applied_tags?         | array of snowflakes | the IDs of the set of tags that have been applied to a thread in a `GUILD_FORUM` or a `GUILD_MEDIA` channel; limited to 5                                                                                 |
 
 ## Delete/Close Channel
-<Route type="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)</Route>
+<Route method="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)</Route>
 
 Delete a channel, or close a private message. Requires the `MANAGE_CHANNELS` permission for the guild, or `MANAGE_THREADS` if the channel is a thread. Deleting a category does not delete its child channels; they will have their `parent_id` removed and a [Channel Update](/docs/events/gateway-events#channel-update) Gateway event will fire for each of them. Returns a [channel](/docs/resources/channel#channel-object) object on success. Fires a [Channel Delete](/docs/events/gateway-events#channel-delete) Gateway event (or [Thread Delete](/docs/events/gateway-events#thread-delete) if the channel was a thread).
 
@@ -437,7 +437,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 :::
 
 ## Edit Channel Permissions
-<Route type="PUT">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/permissions/[\{overwrite.id\}](/docs/resources/channel#overwrite-object)</Route>
+<Route method="PUT">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/permissions/[\{overwrite.id\}](/docs/resources/channel#overwrite-object)</Route>
 
 Edit the channel permission overwrites for a user or role in a channel. Only usable for guild channels. Requires the `MANAGE_ROLES` permission. Only permissions your bot has in the guild or parent channel (if applicable) can be allowed/denied (unless your bot has a `MANAGE_ROLES` overwrite in the channel). Returns a 204 empty response on success. Fires a [Channel Update](/docs/events/gateway-events#channel-update) Gateway event. For more information about permissions, see [permissions](/docs/topics/permissions#permissions).
 
@@ -454,12 +454,12 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | type   | integer | 0 for a role or 1 for a member                                  |
 
 ## Get Channel Invites
-<Route type="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/invites</Route>
+<Route method="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/invites</Route>
 
 Returns a list of [invite](/docs/resources/invite#invite-object) objects (with [invite metadata](/docs/resources/invite#invite-metadata-object)) for the channel. Only usable for guild channels. Requires the `MANAGE_CHANNELS` permission.
 
 ## Create Channel Invite
-<Route type="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/invites</Route>
+<Route method="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/invites</Route>
 
 Create a new [invite](/docs/resources/invite#invite-object) object for the channel. Only usable for guild channels. Requires the `CREATE_INSTANT_INVITE` permission. All JSON parameters for this route are optional, however the request body is not. If you are not sending any fields, you still have to send an empty JSON object (`{}`). Returns an [invite](/docs/resources/invite#invite-object) object. Fires an [Invite Create](/docs/events/gateway-events#invite-create) Gateway event.
 
@@ -480,7 +480,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | target_application_id | snowflake | the id of the embedded application to open for this invite, required if `target_type` is 2, the application must have the `EMBEDDED` flag |                  |
 
 ## Delete Channel Permission
-<Route type="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/permissions/[\{overwrite.id\}](/docs/resources/channel#overwrite-object)</Route>
+<Route method="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/permissions/[\{overwrite.id\}](/docs/resources/channel#overwrite-object)</Route>
 
 Delete a channel permission overwrite for a user or role in a channel. Only usable for guild channels. Requires the `MANAGE_ROLES` permission. Returns a 204 empty response on success. Fires a [Channel Update](/docs/events/gateway-events#channel-update) Gateway event. For more information about permissions, see [permissions](/docs/topics/permissions#permissions)
 
@@ -489,7 +489,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 :::
 
 ## Follow Announcement Channel
-<Route type="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/followers</Route>
+<Route method="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/followers</Route>
 
 Follow an Announcement Channel to send messages to a target channel. Requires the `MANAGE_WEBHOOKS` permission in the target channel. Returns a [followed channel](/docs/resources/channel#followed-channel-object) object. Fires a [Webhooks Update](/docs/events/gateway-events#webhooks-update) Gateway event for the target channel.
 
@@ -504,19 +504,19 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | webhook_channel_id | snowflake | id of target channel |
 
 ## Trigger Typing Indicator
-<Route type="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/typing</Route>
+<Route method="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/typing</Route>
 
 Post a typing indicator for the specified channel, which expires after 10 seconds. Returns a 204 empty response on success. Fires a [Typing Start](/docs/events/gateway-events#typing-start) Gateway event.
 
 Generally bots should **not** use this route. However, if a bot is responding to a command and expects the computation to take a few seconds, this endpoint may be called to let the user know that the bot is processing their message.
 
 ## Get Pinned Messages
-<Route type="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/pins</Route>
+<Route method="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/pins</Route>
 
 Returns all pinned messages in the channel as an array of [message](/docs/resources/message#message-object) objects.
 
 ## Pin Message
-<Route type="PUT">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/pins/[\{message.id\}](/docs/resources/message#message-object)</Route>
+<Route method="PUT">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/pins/[\{message.id\}](/docs/resources/message#message-object)</Route>
 
 Pin a message in a channel. Requires the `MANAGE_MESSAGES` permission. Returns a 204 empty response on success. Fires a [Channel Pins Update](/docs/events/gateway-events#channel-pins-update) Gateway event.
 
@@ -529,7 +529,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 :::
 
 ## Unpin Message
-<Route type="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/pins/[\{message.id\}](/docs/resources/message#message-object)</Route>
+<Route method="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/pins/[\{message.id\}](/docs/resources/message#message-object)</Route>
 
 Unpin a message in a channel. Requires the `MANAGE_MESSAGES` permission. Returns a 204 empty response on success. Fires a [Channel Pins Update](/docs/events/gateway-events#channel-pins-update) Gateway event.
 
@@ -538,7 +538,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 :::
 
 ## Group DM Add Recipient
-<Route type="PUT">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/recipients/[\{user.id\}](/docs/resources/user#user-object)</Route>
+<Route method="PUT">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/recipients/[\{user.id\}](/docs/resources/user#user-object)</Route>
 
 Adds a recipient to a Group DM using their access token.
 
@@ -550,12 +550,12 @@ Adds a recipient to a Group DM using their access token.
 | nick         | string | nickname of the user being added                                      |
 
 ## Group DM Remove Recipient
-<Route type="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/recipients/[\{user.id\}](/docs/resources/user#user-object)</Route>
+<Route method="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/recipients/[\{user.id\}](/docs/resources/user#user-object)</Route>
 
 Removes a recipient from a Group DM.
 
 ## Start Thread from Message
-<Route type="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)/threads</Route>
+<Route method="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)/threads</Route>
 
 Creates a new thread from an existing message. Returns a [channel](/docs/resources/channel#channel-object) on success, and a 400 BAD REQUEST on invalid parameters. Fires a [Thread Create](/docs/events/gateway-events#thread-create) and a [Message Update](/docs/events/gateway-events#message-update) Gateway event.
 
@@ -574,7 +574,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | rate_limit_per_user?   | ?integer | amount of seconds a user has to wait before sending another message (0-21600)                                                              |
 
 ## Start Thread without Message
-<Route type="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/threads</Route>
+<Route method="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/threads</Route>
 
 Creates a new thread that is not connected to an existing message. Returns a [channel](/docs/resources/channel#channel-object) on success, and a 400 BAD REQUEST on invalid parameters. Fires a [Thread Create](/docs/events/gateway-events#thread-create) Gateway event.
 
@@ -595,7 +595,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 \* `type` currently defaults to `PRIVATE_THREAD` in order to match the behavior when thread documentation was first published. In a future API version this will be changed to be a required field, with no default.
 
 ## Start Thread in Forum or Media Channel
-<Route type="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/threads</Route>
+<Route method="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/threads</Route>
 
 Creates a new thread in a forum or a media channel, and sends a message within the created thread. Returns a [channel](/docs/resources/channel#channel-object), with a nested [message](/docs/resources/message#message-object) object, on success, and a 400 BAD REQUEST on invalid parameters. Fires a [Thread Create](/docs/events/gateway-events#thread-create) and [Message Create](/docs/events/gateway-events#message-create) Gateway event.
 
@@ -648,27 +648,27 @@ When sending a message, apps must provide a value for **at least one of** `conte
 \* At least one of `content`, `embeds`, `sticker_ids`, `components`, or `files[n]` is required.
 
 ## Join Thread
-<Route type="PUT">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/thread-members/@me</Route>
+<Route method="PUT">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/thread-members/@me</Route>
 
 Adds the current user to a thread. Also requires the thread is not archived. Returns a 204 empty response on success. Fires a [Thread Members Update](/docs/events/gateway-events#thread-members-update) and a [Thread Create](/docs/events/gateway-events#thread-create) Gateway event.
 
 ## Add Thread Member
-<Route type="PUT">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/thread-members/[\{user.id\}](/docs/resources/user#user-object)</Route>
+<Route method="PUT">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/thread-members/[\{user.id\}](/docs/resources/user#user-object)</Route>
 
 Adds another member to a thread. Requires the ability to send messages in the thread. Also requires the thread is not archived. Returns a 204 empty response if the member is successfully added or was already a member of the thread. Fires a [Thread Members Update](/docs/events/gateway-events#thread-members-update) Gateway event.
 
 ## Leave Thread
-<Route type="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/thread-members/@me</Route>
+<Route method="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/thread-members/@me</Route>
 
 Removes the current user from a thread. Also requires the thread is not archived. Returns a 204 empty response on success. Fires a [Thread Members Update](/docs/events/gateway-events#thread-members-update) Gateway event.
 
 ## Remove Thread Member
-<Route type="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/thread-members/[\{user.id\}](/docs/resources/user#user-object)</Route>
+<Route method="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/thread-members/[\{user.id\}](/docs/resources/user#user-object)</Route>
 
 Removes another member from a thread. Requires the `MANAGE_THREADS` permission, or the creator of the thread if it is a `PRIVATE_THREAD`. Also requires the thread is not archived. Returns a 204 empty response on success. Fires a [Thread Members Update](/docs/events/gateway-events#thread-members-update) Gateway event.
 
 ## Get Thread Member
-<Route type="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/thread-members/[\{user.id\}](/docs/resources/user#user-object)</Route>
+<Route method="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/thread-members/[\{user.id\}](/docs/resources/user#user-object)</Route>
 
 Returns a [thread member](/docs/resources/channel#thread-member-object) object for the specified user if they are a member of the thread, returns a 404 response otherwise.
 
@@ -681,7 +681,7 @@ When `with_member` is set to `true`, the thread member object will include a `me
 | with_member? | [boolean](/docs/reference#boolean-query-strings) | Whether to include a [guild member](/docs/resources/guild#guild-member-object) object for the thread member |
 
 ## List Thread Members
-<Route type="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/thread-members</Route>
+<Route method="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/thread-members</Route>
 
 :::warn
 Starting in API v11, this endpoint will always return paginated results. Paginated results can be enabled before API v11 by setting `with_member` to `true`. Read [the changelog](/docs/change-log#thread-member-details-and-pagination) for details.
@@ -704,7 +704,7 @@ This endpoint is restricted according to whether the `GUILD_MEMBERS` [Privileged
 | limit?       | integer                                          | Max number of thread members to return (1-100). Defaults to 100.                                             |
 
 ## List Public Archived Threads
-<Route type="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/threads/archived/public</Route>
+<Route method="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/threads/archived/public</Route>
 
 Returns archived threads in the channel that are public. When called on a `GUILD_TEXT` channel, returns threads of [type](/docs/resources/channel#channel-object-channel-types) `PUBLIC_THREAD`. When called on a `GUILD_ANNOUNCEMENT` channel returns threads of [type](/docs/resources/channel#channel-object-channel-types) `ANNOUNCEMENT_THREAD`. Threads are ordered by `archive_timestamp`, in descending order. Requires the `READ_MESSAGE_HISTORY` permission.
 
@@ -724,7 +724,7 @@ Returns archived threads in the channel that are public. When called on a `GUILD
 | has_more | boolean                                                                         | whether there are potentially additional threads that could be returned on a subsequent call |
 
 ## List Private Archived Threads
-<Route type="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/threads/archived/private</Route>
+<Route method="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/threads/archived/private</Route>
 
 Returns archived threads in the channel that are of [type](/docs/resources/channel#channel-object-channel-types) `PRIVATE_THREAD`. Threads are ordered by `archive_timestamp`, in descending order. Requires both the `READ_MESSAGE_HISTORY` and `MANAGE_THREADS` permissions.
 
@@ -744,7 +744,7 @@ Returns archived threads in the channel that are of [type](/docs/resources/chann
 | has_more | boolean                                                                         | whether there are potentially additional threads that could be returned on a subsequent call |
 
 ## List Joined Private Archived Threads
-<Route type="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/users/@me/threads/archived/private</Route>
+<Route method="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/users/@me/threads/archived/private</Route>
 
 Returns archived threads in the channel that are of [type](/docs/resources/channel#channel-object-channel-types) `PRIVATE_THREAD`, and the user has joined. Threads are ordered by their `id`, in descending order. Requires the `READ_MESSAGE_HISTORY` permission.
 

--- a/docs/resources/emoji.mdx
+++ b/docs/resources/emoji.mdx
@@ -92,17 +92,17 @@ In `MESSAGE_REACTION_ADD` and `MESSAGE_REACTION_REMOVE` gateway events `name` ma
 ```
 
 ## List Guild Emojis
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/emojis</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/emojis</Route>
 
 Returns a list of [emoji](/docs/resources/emoji#emoji-object) objects for the given guild. Includes `user` fields if the bot has the `CREATE_GUILD_EXPRESSIONS` or `MANAGE_GUILD_EXPRESSIONS` permission.
 
 ## Get Guild Emoji
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/emojis/[\{emoji.id\}](/docs/resources/emoji#emoji-object)</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/emojis/[\{emoji.id\}](/docs/resources/emoji#emoji-object)</Route>
 
 Returns an [emoji](/docs/resources/emoji#emoji-object) object for the given guild and emoji IDs. Includes the `user` field if the bot has the `MANAGE_GUILD_EXPRESSIONS` permission, or if the bot created the emoji and has the the `CREATE_GUILD_EXPRESSIONS` permission.
 
 ## Create Guild Emoji
-<Route type="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/emojis</Route>
+<Route method="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/emojis</Route>
 
 Create a new emoji for the guild. Requires the `CREATE_GUILD_EXPRESSIONS` permission. Returns the new [emoji](/docs/resources/emoji#emoji-object) object on success. Fires a [Guild Emojis Update](/docs/events/gateway-events#guild-emojis-update) Gateway event.
 
@@ -123,7 +123,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | roles | array of snowflakes                      | roles allowed to use this emoji |
 
 ## Modify Guild Emoji
-<Route type="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/emojis/[\{emoji.id\}](/docs/resources/emoji#emoji-object)</Route>
+<Route method="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/emojis/[\{emoji.id\}](/docs/resources/emoji#emoji-object)</Route>
 
 Modify the given emoji. For emojis created by the current user, requires either the `CREATE_GUILD_EXPRESSIONS` or `MANAGE_GUILD_EXPRESSIONS` permission. For other emojis, requires the `MANAGE_GUILD_EXPRESSIONS` permission. Returns the updated [emoji](/docs/resources/emoji#emoji-object) object on success. Fires a [Guild Emojis Update](/docs/events/gateway-events#guild-emojis-update) Gateway event.
 
@@ -143,7 +143,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | roles | ?array of snowflakes | roles allowed to use this emoji |
 
 ## Delete Guild Emoji
-<Route type="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/emojis/[\{emoji.id\}](/docs/resources/emoji#emoji-object)</Route>
+<Route method="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/emojis/[\{emoji.id\}](/docs/resources/emoji#emoji-object)</Route>
 
 Delete the given emoji. For emojis created by the current user, requires either the `CREATE_GUILD_EXPRESSIONS` or `MANAGE_GUILD_EXPRESSIONS` permission. For other emojis, requires the `MANAGE_GUILD_EXPRESSIONS` permission. Returns `204 No Content` on success. Fires a [Guild Emojis Update](/docs/events/gateway-events#guild-emojis-update) Gateway event.
 
@@ -152,7 +152,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 :::
 
 ## List Application Emojis
-<Route type="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/emojis</Route>
+<Route method="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/emojis</Route>
 
 Returns an object containing a list of [emoji](/docs/resources/emoji#emoji-object) objects for the given application under the `items` key. Includes a `user` object for the team member that uploaded the emoji from the app's settings, or for the bot user if uploaded using the API.
 
@@ -179,12 +179,12 @@ Returns an object containing a list of [emoji](/docs/resources/emoji#emoji-objec
 ```
 
 ## Get Application Emoji
-<Route type="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/emojis/[\{emoji.id\}](/docs/resources/emoji#emoji-object)</Route>
+<Route method="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/emojis/[\{emoji.id\}](/docs/resources/emoji#emoji-object)</Route>
 
 Returns an [emoji](/docs/resources/emoji#emoji-object) object for the given application and emoji IDs. Includes the `user` field.
 
 ## Create Application Emoji
-<Route type="POST">/applications/[\{application.id\}](/docs/resources/application#application-object)/emojis</Route>
+<Route method="POST">/applications/[\{application.id\}](/docs/resources/application#application-object)/emojis</Route>
 
 Create a new emoji for the application. Returns the new [emoji](/docs/resources/emoji#emoji-object) object on success.
 
@@ -200,7 +200,7 @@ Emojis and animated emojis have a maximum file size of 256 KiB. Attempting to up
 | image | [image data](/docs/reference#image-data) | the 128x128 emoji image |
 
 ## Modify Application Emoji
-<Route type="PATCH">/applications/[\{application.id\}](/docs/resources/application#application-object)/emojis/[\{emoji.id\}](/docs/resources/emoji#emoji-object)</Route>
+<Route method="PATCH">/applications/[\{application.id\}](/docs/resources/application#application-object)/emojis/[\{emoji.id\}](/docs/resources/emoji#emoji-object)</Route>
 
 Modify the given emoji. Returns the updated [emoji](/docs/resources/emoji#emoji-object) object on success.
 
@@ -211,6 +211,6 @@ Modify the given emoji. Returns the updated [emoji](/docs/resources/emoji#emoji-
 | name  | string | name of the emoji |
 
 ## Delete Application Emoji
-<Route type="DELETE">/applications/[\{application.id\}](/docs/resources/application#application-object)/emojis/[\{emoji.id\}](/docs/resources/emoji#emoji-object)</Route>
+<Route method="DELETE">/applications/[\{application.id\}](/docs/resources/application#application-object)/emojis/[\{emoji.id\}](/docs/resources/emoji#emoji-object)</Route>
 
 Delete the given emoji. Returns `204 No Content` on success.

--- a/docs/resources/entitlement.mdx
+++ b/docs/resources/entitlement.mdx
@@ -59,7 +59,7 @@ Refer to the [Monetization Overview](/docs/monetization/overview) for more infor
 | APPLICATION_SUBSCRIPTION | 8     | Entitlement was purchased as an app subscription               |
 
 ## List Entitlements
-<Route type="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/entitlements</Route>
+<Route method="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/entitlements</Route>
 
 Returns all entitlements for a given app, active and expired.
 
@@ -97,7 +97,7 @@ Returns all entitlements for a given app, active and expired.
 ```
 
 ## Get Entitlement
-<Route type="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/entitlements/[\{entitlement.id\}](/docs/resources/entitlement#entitlement-object)</Route>
+<Route method="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/entitlements/[\{entitlement.id\}](/docs/resources/entitlement#entitlement-object)</Route>
 
 Returns an entitlement.
 
@@ -120,14 +120,14 @@ Returns an entitlement.
 ```
 
 ## Consume an Entitlement
-<Route type="POST">/applications/[\{application.id\}](/docs/resources/application#application-object)/entitlements/[\{entitlement.id\}](/docs/resources/entitlement#entitlement-object)/consume</Route>
+<Route method="POST">/applications/[\{application.id\}](/docs/resources/application#application-object)/entitlements/[\{entitlement.id\}](/docs/resources/entitlement#entitlement-object)/consume</Route>
 
 For One-Time Purchase consumable SKUs, marks a given entitlement for the user as consumed. The entitlement will have `consumed: true` when using [List Entitlements](/docs/resources/entitlement#list-entitlements).
 
 Returns a `204 No Content` on success.
 
 ## Create Test Entitlement
-<Route type="POST">/applications/[\{application.id\}](/docs/resources/application#application-object)/entitlements</Route>
+<Route method="POST">/applications/[\{application.id\}](/docs/resources/application#application-object)/entitlements</Route>
 
 Creates a test entitlement to a given SKU for a given guild or user. Discord will act as though that user or guild has entitlement to your premium offering.
 
@@ -152,7 +152,7 @@ After creating a test entitlement, you'll need to reload your Discord client. Af
 ```
 
 ## Delete Test Entitlement
-  <Route type="DELETE">/applications/[\{application.id\}](/docs/resources/application#application-object)/entitlements/[\{entitlement.id\}](/docs/resources/entitlement#entitlement-object)</Route>
+  <Route method="DELETE">/applications/[\{application.id\}](/docs/resources/application#application-object)/entitlements/[\{entitlement.id\}](/docs/resources/entitlement#entitlement-object)</Route>
 
 Deletes a currently-active test entitlement. Discord will act as though that user or guild _no longer has_ entitlement to your premium offering.
 

--- a/docs/resources/guild-scheduled-event.mdx
+++ b/docs/resources/guild-scheduled-event.mdx
@@ -261,7 +261,7 @@ by_month_day = [24]
 | DECEMBER  | 12    |
 
 ## List Scheduled Events for Guild
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/scheduled-events</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/scheduled-events</Route>
 
 Returns a list of [guild scheduled event](/docs/resources/guild-scheduled-event#guild-scheduled-event-object) objects for the given guild.
 
@@ -272,7 +272,7 @@ Returns a list of [guild scheduled event](/docs/resources/guild-scheduled-event#
 | with_user_count? | [boolean](/docs/reference#boolean-query-strings) | include number of users subscribed to each event |
 
 ## Create Guild Scheduled Event
-<Route type="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/scheduled-events</Route>
+<Route method="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/scheduled-events</Route>
 
 Create a guild scheduled event in the guild. Returns a [guild scheduled event](/docs/resources/guild-scheduled-event#guild-scheduled-event-object) object on success. Fires a [Guild Scheduled Event Create](/docs/events/gateway-events#guild-scheduled-event-create) Gateway event.
 
@@ -305,7 +305,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 \*\* Required for events with `'entity_type': EXTERNAL`
 
 ## Get Guild Scheduled Event
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/scheduled-events/[\{guild-scheduled-event.id\}](/docs/resources/guild-scheduled-event#guild-scheduled-event-object)</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/scheduled-events/[\{guild-scheduled-event.id\}](/docs/resources/guild-scheduled-event#guild-scheduled-event-object)</Route>
 
 Get a guild scheduled event. Returns a [guild scheduled event](/docs/resources/guild-scheduled-event#guild-scheduled-event-object) object on success.
 
@@ -316,7 +316,7 @@ Get a guild scheduled event. Returns a [guild scheduled event](/docs/resources/g
 | with_user_count? | [boolean](/docs/reference#boolean-query-strings) | include number of users subscribed to this event |
 
 ## Modify Guild Scheduled Event
-<Route type="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/scheduled-events/[\{guild-scheduled-event.id\}](/docs/resources/guild-scheduled-event#guild-scheduled-event-object)</Route>
+<Route method="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/scheduled-events/[\{guild-scheduled-event.id\}](/docs/resources/guild-scheduled-event#guild-scheduled-event-object)</Route>
 
 Modify a guild scheduled event. Returns the modified [guild scheduled event](/docs/resources/guild-scheduled-event#guild-scheduled-event-object) object on success. Fires a [Guild Scheduled Event Update](/docs/events/gateway-events#guild-scheduled-event-update) Gateway event.
 
@@ -360,12 +360,12 @@ All parameters to this endpoint are optional
 - `scheduled_end_time` must be provided
 
 ## Delete Guild Scheduled Event
-<Route type="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/scheduled-events/[\{guild-scheduled-event.id\}](/docs/resources/guild-scheduled-event#guild-scheduled-event-object)</Route>
+<Route method="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/scheduled-events/[\{guild-scheduled-event.id\}](/docs/resources/guild-scheduled-event#guild-scheduled-event-object)</Route>
 
 Delete a guild scheduled event. Returns a `204` on success. Fires a [Guild Scheduled Event Delete](/docs/events/gateway-events#guild-scheduled-event-delete) Gateway event.
 
 ## Get Guild Scheduled Event Users
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/scheduled-events/[\{guild-scheduled-event.id\}](/docs/resources/guild-scheduled-event#guild-scheduled-event-object)/users</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/scheduled-events/[\{guild-scheduled-event.id\}](/docs/resources/guild-scheduled-event#guild-scheduled-event-object)/users</Route>
 
 Get a list of guild scheduled event users subscribed to a guild scheduled event. Returns a list of [guild scheduled event user](/docs/resources/guild-scheduled-event#guild-scheduled-event-user-object) objects on success. Guild member data, if it exists, is included if the `with_member` query parameter is set.
 

--- a/docs/resources/guild-template.mdx
+++ b/docs/resources/guild-template.mdx
@@ -100,12 +100,12 @@ Represents a code that when used, creates a guild based on a snapshot of an exis
 ```
 
 ## Get Guild Template
-<Route type="GET">/guilds/templates/[\{template.code\}](/docs/resources/guild-template#guild-template-object)</Route>
+<Route method="GET">/guilds/templates/[\{template.code\}](/docs/resources/guild-template#guild-template-object)</Route>
 
 Returns a [guild template](/docs/resources/guild-template#guild-template-object) object for the given code.
 
 ## Create Guild from Guild Template
-<Route type="POST">/guilds/templates/[\{template.code\}](/docs/resources/guild-template#guild-template-object)</Route>
+<Route method="POST">/guilds/templates/[\{template.code\}](/docs/resources/guild-template#guild-template-object)</Route>
 
 Create a new guild based on a template. Returns a [guild](/docs/resources/guild#guild-object) object on success. Fires a [Guild Create](/docs/events/gateway-events#guild-create) Gateway event.
 
@@ -121,12 +121,12 @@ This endpoint can be used only by bots in less than 10 guilds.
 | icon? | [image data](/docs/reference#image-data) | base64 128x128 image for the guild icon |
 
 ## Get Guild Templates
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/templates</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/templates</Route>
 
 Returns an array of [guild template](/docs/resources/guild-template#guild-template-object) objects. Requires the `MANAGE_GUILD` permission.
 
 ## Create Guild Template
-<Route type="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/templates</Route>
+<Route method="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/templates</Route>
 
 Creates a template for the guild. Requires the `MANAGE_GUILD` permission. Returns the created [guild template](/docs/resources/guild-template#guild-template-object) object on success.
 
@@ -138,12 +138,12 @@ Creates a template for the guild. Requires the `MANAGE_GUILD` permission. Return
 | description? | ?string | description for the template (0-120 characters) |
 
 ## Sync Guild Template
-<Route type="PUT">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/templates/[\{template.code\}](/docs/resources/guild-template#guild-template-object)</Route>
+<Route method="PUT">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/templates/[\{template.code\}](/docs/resources/guild-template#guild-template-object)</Route>
 
 Syncs the template to the guild's current state. Requires the `MANAGE_GUILD` permission. Returns the [guild template](/docs/resources/guild-template#guild-template-object) object on success.
 
 ## Modify Guild Template
-<Route type="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/templates/[\{template.code\}](/docs/resources/guild-template#guild-template-object)</Route>
+<Route method="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/templates/[\{template.code\}](/docs/resources/guild-template#guild-template-object)</Route>
 
 Modifies the template's metadata. Requires the `MANAGE_GUILD` permission. Returns the [guild template](/docs/resources/guild-template#guild-template-object) object on success.
 
@@ -155,6 +155,6 @@ Modifies the template's metadata. Requires the `MANAGE_GUILD` permission. Return
 | description? | ?string | description for the template (0-120 characters) |
 
 ## Delete Guild Template
-<Route type="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/templates/[\{template.code\}](/docs/resources/guild-template#guild-template-object)</Route>
+<Route method="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/templates/[\{template.code\}](/docs/resources/guild-template#guild-template-object)</Route>
 
 Deletes the template. Requires the `MANAGE_GUILD` permission. Returns the deleted [guild template](/docs/resources/guild-template#guild-template-object) object on success.

--- a/docs/resources/guild.mdx
+++ b/docs/resources/guild.mdx
@@ -694,7 +694,7 @@ We are making significant changes to the Membership Screening API specifically r
 ```
 
 ## Create Guild
-<Route type="POST">/guilds</Route>
+<Route method="POST">/guilds</Route>
 
 Create a new guild. Returns a [guild](/docs/resources/guild#guild-object) object on success. Fires a [Guild Create](/docs/events/gateway-events#guild-create) Gateway event.
 
@@ -765,7 +765,7 @@ The `region` field is deprecated and is replaced by [channel.rtc_region](/docs/r
 ```
 
 ## Get Guild
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)</Route>
 
 Returns the [guild](/docs/resources/guild#guild-object) object for the given id. If `with_counts` is set to `true`, this endpoint will also return `approximate_member_count` and `approximate_presence_count` for the guild.
 
@@ -847,13 +847,13 @@ Returns the [guild](/docs/resources/guild#guild-object) object for the given id.
 ```
 
 ## Get Guild Preview
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/preview</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/preview</Route>
 
 Returns the [guild preview](/docs/resources/guild#guild-preview-object) object for the given id.
 If the user is not in the guild, then the guild must be [discoverable](/docs/resources/guild#guild-object-guild-features).
 
 ## Modify Guild
-<Route type="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)</Route>
+<Route method="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)</Route>
 
 Modify a guild's settings. Requires the `MANAGE_GUILD` permission. Returns the updated [guild](/docs/resources/guild#guild-object) object on success. Fires a [Guild Update](/docs/events/gateway-events#guild-update) Gateway event.
 
@@ -896,17 +896,17 @@ Attempting to add or remove the `COMMUNITY` [guild feature](/docs/resources/guil
 | safety_alerts_channel_id      | ?snowflake                                                                          | the id of the channel where admins and moderators of Community guilds receive safety alerts from Discord                                                          |
 
 ## Delete Guild
-<Route type="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)</Route>
+<Route method="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)</Route>
 
 Delete a guild permanently. User must be owner. Returns `204 No Content` on success. Fires a [Guild Delete](/docs/events/gateway-events#guild-delete) Gateway event.
 
 ## Get Guild Channels
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/channels</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/channels</Route>
 
 Returns a list of guild [channel](/docs/resources/channel#channel-object) objects. Does not include threads.
 
 ## Create Guild Channel
-<Route type="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/channels</Route>
+<Route method="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/channels</Route>
 
 Create a new [channel](/docs/resources/channel#channel-object) object for the guild. Requires the `MANAGE_CHANNELS` permission. If setting permission overwrites, only permissions your bot has in the guild can be allowed/denied. Setting `MANAGE_ROLES` permission in channels is only possible for guild administrators. Returns the new [channel](/docs/resources/channel#channel-object) object on success. Fires a [Channel Create](/docs/events/gateway-events#channel-create) Gateway event.
 
@@ -946,7 +946,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 \*\* In each overwrite object, the `allow` and `deny` keys can be omitted or set to `null`, which both default to `"0"`.
 
 ## Modify Guild Channel Positions
-<Route type="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/channels</Route>
+<Route method="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/channels</Route>
 
 Modify the positions of a set of [channel](/docs/resources/channel#channel-object) objects for the guild. Requires `MANAGE_CHANNELS` permission. Returns a 204 empty response on success. Fires multiple [Channel Update](/docs/events/gateway-events#channel-update) Gateway events.
 
@@ -966,7 +966,7 @@ This endpoint takes a JSON array of parameters in the following format:
 | parent_id?        | ?snowflake | the new parent ID for the channel that is moved                                    |
 
 ## List Active Guild Threads
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/threads/active</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/threads/active</Route>
 
 Returns all active threads in the guild, including public and private threads. Threads are ordered by their `id`, in descending order.
 
@@ -978,12 +978,12 @@ Returns all active threads in the guild, including public and private threads. T
 | members | array of [thread members](/docs/resources/channel#thread-member-object) objects | a thread member object for each returned thread the current user has joined |
 
 ## Get Guild Member
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members/[\{user.id\}](/docs/resources/user#user-object)</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members/[\{user.id\}](/docs/resources/user#user-object)</Route>
 
 Returns a [guild member](/docs/resources/guild#guild-member-object) object for the specified user.
 
 ## List Guild Members
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members</Route>
 
 Returns a list of [guild member](/docs/resources/guild#guild-member-object) objects that are members of the guild.
 
@@ -1003,7 +1003,7 @@ All parameters to this endpoint are optional
 | after | snowflake | the highest user id in the previous page | 0       |
 
 ## Search Guild Members
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members/search</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members/search</Route>
 
 Returns a list of [guild member](/docs/resources/guild#guild-member-object) objects whose username or nickname starts with a provided string.
 
@@ -1019,7 +1019,7 @@ All parameters to this endpoint except for `query` are optional
 | limit | integer | max number of members to return (1-1000)                   | 1       |
 
 ## Add Guild Member
-<Route type="PUT">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members/[\{user.id\}](/docs/resources/user#user-object)</Route>
+<Route method="PUT">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members/[\{user.id\}](/docs/resources/user#user-object)</Route>
 
 Adds a user to the guild, provided you have a valid oauth2 access token for the user with the `guilds.join` scope. Returns a 201 Created with the [guild member](/docs/resources/guild#guild-member-object) as the body, or 204 No Content if the user is already a member of the guild. Fires a [Guild Member Add](/docs/events/gateway-events#guild-member-add) Gateway event.
 
@@ -1045,7 +1045,7 @@ The Authorization header must be a Bot token (belonging to the same application 
 
 
 ## Modify Guild Member
-<Route type="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members/[\{user.id\}](/docs/resources/user#user-object)</Route>
+<Route method="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members/[\{user.id\}](/docs/resources/user#user-object)</Route>
 
 Modify attributes of a [guild member](/docs/resources/guild#guild-member-object). Returns a 200 OK with the [guild member](/docs/resources/guild#guild-member-object) as the body. Fires a [Guild Member Update](/docs/events/gateway-events#guild-member-update) Gateway event. If the `channel_id` is set to null, this will force the target user to be disconnected from voice.
 
@@ -1070,7 +1070,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | flags                        | integer             | [guild member flags](/docs/resources/guild#guild-member-object-guild-member-flags)                                                                                                                                                                                                                                                         | MANAGE_GUILD or MANAGE_ROLES or (MODERATE_MEMBERS and KICK_MEMBERS and BAN_MEMBERS) |
 
 ## Modify Current Member
-<Route type="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members/@me</Route>
+<Route method="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members/@me</Route>
 
 Modifies the current member in a guild. Returns a 200 with the updated member object on success. Fires a [Guild Member Update](/docs/events/gateway-events#guild-member-update) Gateway event.
 
@@ -1085,7 +1085,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | nick? | ?string | value to set user's nickname to | CHANGE_NICKNAME |
 
 ## Modify Current User Nick
-<Route type="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members/@me/nick</Route>
+<Route method="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members/@me/nick</Route>
 
 :::danger
 Deprecated in favor of [Modify Current Member](/docs/resources/guild#modify-current-member).
@@ -1104,7 +1104,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | nick? | ?string | value to set user's nickname to | CHANGE_NICKNAME |
 
 ## Add Guild Member Role
-<Route type="PUT">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members/[\{user.id\}](/docs/resources/user#user-object)/roles/[\{role.id\}](/docs/topics/permissions#role-object)</Route>
+<Route method="PUT">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members/[\{user.id\}](/docs/resources/user#user-object)/roles/[\{role.id\}](/docs/topics/permissions#role-object)</Route>
 
 Adds a role to a [guild member](/docs/resources/guild#guild-member-object). Requires the `MANAGE_ROLES` permission. Returns a 204 empty response on success. Fires a [Guild Member Update](/docs/events/gateway-events#guild-member-update) Gateway event.
 
@@ -1113,7 +1113,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 :::
 
 ## Remove Guild Member Role
-<Route type="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members/[\{user.id\}](/docs/resources/user#user-object)/roles/[\{role.id\}](/docs/topics/permissions#role-object)</Route>
+<Route method="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members/[\{user.id\}](/docs/resources/user#user-object)/roles/[\{role.id\}](/docs/topics/permissions#role-object)</Route>
 
 Removes a role from a [guild member](/docs/resources/guild#guild-member-object). Requires the `MANAGE_ROLES` permission. Returns a 204 empty response on success. Fires a [Guild Member Update](/docs/events/gateway-events#guild-member-update) Gateway event.
 
@@ -1122,7 +1122,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 :::
 
 ## Remove Guild Member
-<Route type="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members/[\{user.id\}](/docs/resources/user#user-object)</Route>
+<Route method="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members/[\{user.id\}](/docs/resources/user#user-object)</Route>
 
 Remove a member from a guild. Requires `KICK_MEMBERS` permission. Returns a 204 empty response on success. Fires a [Guild Member Remove](/docs/events/gateway-events#guild-member-remove) Gateway event.
 
@@ -1131,7 +1131,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 :::
 
 ## Get Guild Bans
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/bans</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/bans</Route>
 
 Returns a list of [ban](/docs/resources/guild#ban-object) objects for the users banned from this guild. Requires the `BAN_MEMBERS` permission.
 
@@ -1146,12 +1146,12 @@ Returns a list of [ban](/docs/resources/guild#ban-object) objects for the users 
 \* Provide a user id to `before` and `after` for pagination. Users will always be returned in ascending order by `user.id`. If both `before` and `after` are provided, only `before` is respected.
 
 ## Get Guild Ban
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/bans/[\{user.id\}](/docs/resources/user#user-object)</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/bans/[\{user.id\}](/docs/resources/user#user-object)</Route>
 
 Returns a [ban](/docs/resources/guild#ban-object) object for the given user or a 404 not found if the ban cannot be found. Requires the `BAN_MEMBERS` permission.
 
 ## Create Guild Ban
-<Route type="PUT">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/bans/[\{user.id\}](/docs/resources/user#user-object)</Route>
+<Route method="PUT">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/bans/[\{user.id\}](/docs/resources/user#user-object)</Route>
 
 Create a guild ban, and optionally delete previous messages sent by the banned user. Requires the `BAN_MEMBERS` permission. Returns a 204 empty response on success. Fires a [Guild Ban Add](/docs/events/gateway-events#guild-ban-add) Gateway event.
 
@@ -1167,7 +1167,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | delete_message_seconds? | integer | number of seconds to delete messages for, between 0 and 604800 (7 days) | 0       |
 
 ## Remove Guild Ban
-<Route type="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/bans/[\{user.id\}](/docs/resources/user#user-object)</Route>
+<Route method="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/bans/[\{user.id\}](/docs/resources/user#user-object)</Route>
 
 Remove the ban for a user. Requires the `BAN_MEMBERS` permissions. Returns a 204 empty response on success. Fires a [Guild Ban Remove](/docs/events/gateway-events#guild-ban-remove) Gateway event.
 
@@ -1176,7 +1176,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 :::
 
 ## Bulk Guild Ban
-<Route type="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/bulk-ban</Route>
+<Route method="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/bulk-ban</Route>
 
 Ban up to 200 users from a guild, and optionally delete previous messages sent by the banned users. Requires both the `BAN_MEMBERS` and `MANAGE_GUILD` permissions. Returns a 200 response on success, including the fields `banned_users` with the IDs of the banned users and `failed_users` with IDs that could not be banned or were already banned.
 
@@ -1205,17 +1205,17 @@ If none of the users could be banned, an error response code `500000: Failed to 
 :::
 
 ## Get Guild Roles
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/roles</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/roles</Route>
 
 Returns a list of [role](/docs/topics/permissions#role-object) objects for the guild.
 
 ## Get Guild Role
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/roles/[\{role.id\}](/docs/topics/permissions#role-object)</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/roles/[\{role.id\}](/docs/topics/permissions#role-object)</Route>
 
 Returns a [role](/docs/topics/permissions#role-object) object for the specified role.
 
 ## Create Guild Role
-<Route type="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/roles</Route>
+<Route method="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/roles</Route>
 
 Create a new [role](/docs/topics/permissions#role-object) for the guild. Requires the `MANAGE_ROLES` permission. Returns the new [role](/docs/topics/permissions#role-object) object on success. Fires a [Guild Role Create](/docs/events/gateway-events#guild-role-create) Gateway event. All JSON params are optional.
 
@@ -1236,7 +1236,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | mentionable   | boolean                                   | whether the role should be mentionable                                                                                         | false                          |
 
 ## Modify Guild Role Positions
-<Route type="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/roles</Route>
+<Route method="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/roles</Route>
 
 Modify the positions of a set of [role](/docs/topics/permissions#role-object) objects for the guild. Requires the `MANAGE_ROLES` permission. Returns a list of all of the guild's [role](/docs/topics/permissions#role-object) objects on success. Fires multiple [Guild Role Update](/docs/events/gateway-events#guild-role-update) Gateway events.
 
@@ -1254,7 +1254,7 @@ This endpoint takes a JSON array of parameters in the following format:
 | position? | ?integer  | sorting position of the role (roles with the same position are sorted by id) |
 
 ## Modify Guild Role
-<Route type="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/roles/[\{role.id\}](/docs/topics/permissions#role-object)</Route>
+<Route method="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/roles/[\{role.id\}](/docs/topics/permissions#role-object)</Route>
 
 Modify a guild role. Requires the `MANAGE_ROLES` permission. Returns the updated [role](/docs/topics/permissions#role-object) on success. Fires a [Guild Role Update](/docs/events/gateway-events#guild-role-update) Gateway event.
 
@@ -1279,7 +1279,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | mentionable   | boolean                                  | whether the role should be mentionable                                                                                         |
 
 ## Modify Guild MFA Level
-<Route type="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/mfa</Route>
+<Route method="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/mfa</Route>
 
 Modify a guild's MFA level. Requires guild ownership. Returns the updated [level](/docs/resources/guild#guild-object-mfa-level) on success. Fires a [Guild Update](/docs/events/gateway-events#guild-update) Gateway event.
 
@@ -1294,7 +1294,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | level | integer | [MFA level](/docs/resources/guild#guild-object-mfa-level) |
 
 ## Delete Guild Role
-<Route type="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/roles/[\{role.id\}](/docs/topics/permissions#role-object)</Route>
+<Route method="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/roles/[\{role.id\}](/docs/topics/permissions#role-object)</Route>
 
 Delete a guild role. Requires the `MANAGE_ROLES` permission. Returns a 204 empty response on success. Fires a [Guild Role Delete](/docs/events/gateway-events#guild-role-delete) Gateway event.
 
@@ -1303,7 +1303,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 :::
 
 ## Get Guild Prune Count
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/prune</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/prune</Route>
 
 Returns an object with one `pruned` key indicating the number of members that would be removed in a prune operation. Requires the `MANAGE_GUILD` and `KICK_MEMBERS` permissions.
 
@@ -1317,7 +1317,7 @@ By default, prune will not remove users with roles. You can optionally include s
 | include_roles | string; comma-delimited array of snowflakes | role(s) to include                       | none    |
 
 ## Begin Guild Prune
-<Route type="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/prune</Route>
+<Route method="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/prune</Route>
 
 Begin a prune operation. Requires the `MANAGE_GUILD` and `KICK_MEMBERS` permissions. Returns an object with one `pruned` key indicating the number of members that were removed in the prune operation. For large guilds it's recommended to set the `compute_prune_count` option to `false`, forcing `pruned` to `null`. Fires multiple [Guild Member Remove](/docs/events/gateway-events#guild-member-remove) Gateway events.
 
@@ -1337,17 +1337,17 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | reason?             | string              | reason for the prune (deprecated)                          |         |
 
 ## Get Guild Voice Regions
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/regions</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/regions</Route>
 
 Returns a list of [voice region](/docs/resources/voice#voice-region-object) objects for the guild. Unlike the similar `/voice` route, this returns VIP servers when the guild is VIP-enabled.
 
 ## Get Guild Invites
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/invites</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/invites</Route>
 
 Returns a list of [invite](/docs/resources/invite#invite-object) objects (with [invite metadata](/docs/resources/invite#invite-metadata-object)) for the guild. Requires the `MANAGE_GUILD` permission.
 
 ## Get Guild Integrations
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/integrations</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/integrations</Route>
 
 Returns a list of [integration](/docs/resources/guild#integration-object) objects for the guild. Requires the `MANAGE_GUILD` permission.
 
@@ -1356,7 +1356,7 @@ This endpoint returns a maximum of 50 integrations. If a guild has more integrat
 :::
 
 ## Delete Guild Integration
-<Route type="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/integrations/[\{integration.id\}](/docs/resources/guild#integration-object)</Route>
+<Route method="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/integrations/[\{integration.id\}](/docs/resources/guild#integration-object)</Route>
 
 Delete the attached [integration](/docs/resources/guild#integration-object) object for the guild. Deletes any associated webhooks and kicks the associated bot if there is one. Requires the `MANAGE_GUILD` permission. Returns a 204 empty response on success. Fires [Guild Integrations Update](/docs/events/gateway-events#guild-integrations-update) and [Integration Delete](/docs/events/gateway-events#integration-delete) Gateway events.
 
@@ -1365,12 +1365,12 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 :::
 
 ## Get Guild Widget Settings
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/widget</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/widget</Route>
 
 Returns a [guild widget settings](/docs/resources/guild#guild-widget-settings-object) object. Requires the `MANAGE_GUILD` permission.
 
 ## Modify Guild Widget
-<Route type="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/widget</Route>
+<Route method="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/widget</Route>
 
 Modify a [guild widget settings](/docs/resources/guild#guild-widget-settings-object) object for the guild. All attributes may be passed in with JSON and modified. Requires the `MANAGE_GUILD` permission. Returns the updated [guild widget settings](/docs/resources/guild#guild-widget-settings-object) object. Fires a [Guild Update](/docs/events/gateway-events#guild-update) Gateway event.
 
@@ -1379,12 +1379,12 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 :::
 
 ## Get Guild Widget
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/widget.json</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/widget.json</Route>
 
 Returns the [widget](/docs/resources/guild#guild-widget-object) for the guild. Fires an [Invite Create](/docs/events/gateway-events#invite-create) Gateway event when an invite channel is defined and a new [Invite](/docs/resources/invite#invite-object) is generated.
 
 ## Get Guild Vanity URL
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/vanity-url</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/vanity-url</Route>
 
 Returns a partial [invite](/docs/resources/invite#invite-object) object for guilds with that feature enabled. Requires the `MANAGE_GUILD` permission. `code` will be null if a vanity url for the guild is not set.
 
@@ -1402,7 +1402,7 @@ This endpoint is required to get the usage count of the vanity invite, but the i
 ```
 
 ## Get Guild Widget Image
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/widget.png</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/widget.png</Route>
 
 Returns a PNG image widget for the guild. Requires no permissions or authentication.
 
@@ -1427,12 +1427,12 @@ All parameters to this endpoint are optional.
 | banner4 | large Discord logo at the top of the widget. Guild icon, name and online count in the middle portion of the widget and a "JOIN MY SERVER" button at the bottom | [Example](https://discord.com/api/guilds/81384788765712384/widget.png?style=banner4) |
 
 ## Get Guild Welcome Screen
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/welcome-screen</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/welcome-screen</Route>
 
 Returns the [Welcome Screen](/docs/resources/guild#welcome-screen-object) object for the guild. If the welcome screen is not enabled, the `MANAGE_GUILD` permission is required.
 
 ## Modify Guild Welcome Screen
-<Route type="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/welcome-screen</Route>
+<Route method="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/welcome-screen</Route>
 
 Modify the guild's [Welcome Screen](/docs/resources/guild#welcome-screen-object). Requires the `MANAGE_GUILD` permission. Returns the updated [Welcome Screen](/docs/resources/guild#welcome-screen-object) object. May fire a [Guild Update](/docs/events/gateway-events#guild-update) Gateway event.
 
@@ -1453,12 +1453,12 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | description      | string                                                                                                                  | the server description to show in the welcome screen            |
 
 ## Get Guild Onboarding
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/onboarding</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/onboarding</Route>
 
 Returns the [Onboarding](/docs/resources/guild#guild-onboarding-object) object for the guild.
 
 ## Modify Guild Onboarding
-<Route type="PUT">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/onboarding</Route>
+<Route method="PUT">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/onboarding</Route>
 
 Modifies the onboarding configuration of the guild. Returns a 200 with the [Onboarding](/docs/resources/guild#guild-onboarding-object) object for the guild. Requires the `MANAGE_GUILD` and `MANAGE_ROLES` permissions.
 
@@ -1480,7 +1480,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | mode                | [onboarding mode](/docs/resources/guild#guild-onboarding-object-onboarding-mode)                                | Current mode of onboarding                                 |
 
 ## Modify Guild Incident Actions
-<Route type="PUT">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/incident-actions</Route>
+<Route method="PUT">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/incident-actions</Route>
 
 Modifies the incident actions of the guild. Returns a 200 with the [Incidents Data](/docs/resources/guild#incidents-data-object) object for the guild. Requires the `MANAGE_GUILD` permission.
 

--- a/docs/resources/invite.mdx
+++ b/docs/resources/invite.mdx
@@ -146,7 +146,7 @@ This is deprecated.
 ```
 
 ## Get Invite
-<Route type="GET">/invites/[\{invite.code\}](/docs/resources/invite#invite-object)</Route>
+<Route method="GET">/invites/[\{invite.code\}](/docs/resources/invite#invite-object)</Route>
 
 Returns an [invite](/docs/resources/invite#invite-object) object for the given code.
 
@@ -159,7 +159,7 @@ Returns an [invite](/docs/resources/invite#invite-object) object for the given c
 | guild_scheduled_event_id? | snowflake                                        | the guild scheduled event to include with the invite        |
 
 ## Delete Invite
-<Route type="DELETE">/invites/[\{invite.code\}](/docs/resources/invite#invite-object)</Route>
+<Route method="DELETE">/invites/[\{invite.code\}](/docs/resources/invite#invite-object)</Route>
 
 Delete an invite. Requires the `MANAGE_CHANNELS` permission on the channel this invite belongs to, or `MANAGE_GUILD` to remove any invite across the guild. Returns an [invite](/docs/resources/invite#invite-object) object on success. Fires an [Invite Delete](/docs/events/gateway-events#invite-delete) Gateway event.
 

--- a/docs/resources/lobby.mdx
+++ b/docs/resources/lobby.mdx
@@ -57,7 +57,7 @@ Represents a member of a lobby, including optional metadata and flags.
 ```
 
 ## Create Lobby
-<Route type="POST">/lobbies</Route>
+<Route method="POST">/lobbies</Route>
 
 Creates a new lobby, adding any of the specified members to it, if provided. 
 
@@ -84,12 +84,12 @@ Returns a [lobby](/docs/resources/lobby#lobby-object) object.
 | flags?    | integer                 | [lobby member flags](/docs/resources/lobby#lobby-member-object-lobby-member-flags) combined as a [bitfield](https://en.wikipedia.org/wiki/Bit_field) |
 
 ## Get Lobby
-<Route type="GET">/lobbies/[\{lobby.id\}](/docs/resources/lobby#lobby-object)</Route>
+<Route method="GET">/lobbies/[\{lobby.id\}](/docs/resources/lobby#lobby-object)</Route>
 
 Returns a [lobby](/docs/resources/lobby#lobby-object) object for the specified lobby id, if it exists.
 
 ## Modify Lobby
-<Route type="PATCH">/lobbies/[\{lobby.id\}](/docs/resources/lobby#lobby-object)</Route>
+<Route method="PATCH">/lobbies/[\{lobby.id\}](/docs/resources/lobby#lobby-object)</Route>
 
 Modifies the specified lobby with new values, if provided. 
 
@@ -104,7 +104,7 @@ Returns the updated [lobby](/docs/resources/lobby#lobby-object) object.
 | idle_timeout_seconds? | integer                                                                    | seconds to wait before shutting down a lobby after it becomes idle. Value can be between 5 and 604800 (7 days). See [`LobbyHandle`] for more details on this behavior. |
 
 ## Delete Lobby
-<Route type="DELETE">/lobbies/[\{lobby.id\}](/docs/resources/lobby#lobby-object)</Route>
+<Route method="DELETE">/lobbies/[\{lobby.id\}](/docs/resources/lobby#lobby-object)</Route>
 
 Deletes the specified lobby if it exists.  
 
@@ -113,7 +113,7 @@ It is safe to call even if the lobby is already deleted as well.
 Returns nothing.
 
 ## Add a Member to a Lobby
-<Route type="PUT">/lobbies/[\{lobby.id\}](/docs/resources/lobby#lobby-object)/members/[\{user.id\}](/docs/resources/user#user-object)</Route>
+<Route method="PUT">/lobbies/[\{lobby.id\}](/docs/resources/lobby#lobby-object)/members/[\{user.id\}](/docs/resources/user#user-object)</Route>
 
 Adds the provided user to the specified lobby. If called when the user is already a member of the lobby will update fields such as metadata on that user instead. 
 
@@ -127,14 +127,14 @@ Returns the [lobby member](/docs/resources/lobby#lobby-member-object) object.
 | flags?    | integer                 | [lobby member flags](/docs/resources/lobby#lobby-member-object-lobby-member-flags) combined as a [bitfield](https://en.wikipedia.org/wiki/Bit_field) |
 
 ## Remove a Member from a Lobby
-<Route type="DELETE">/lobbies/[\{lobby.id\}](/docs/resources/lobby#lobby-object)/members/[\{user.id\}](/docs/resources/user#user-object)</Route>
+<Route method="DELETE">/lobbies/[\{lobby.id\}](/docs/resources/lobby#lobby-object)/members/[\{user.id\}](/docs/resources/user#user-object)</Route>
 
 Removes the provided user from the specified lobby. It is safe to call this even if the user is no longer a member of the lobby, but will fail if the lobby does not exist.
 
 Returns nothing.
 
 ## Leave Lobby
-<Route type="DELETE">/lobbies/[\{lobby.id\}](/docs/resources/lobby#lobby-object)/members/@me</Route>
+<Route method="DELETE">/lobbies/[\{lobby.id\}](/docs/resources/lobby#lobby-object)/members/@me</Route>
 
 Removes the current user from the specified lobby. It is safe to call this even if the user is no longer a member of the lobby, but will fail if the lobby does not exist.
 
@@ -143,7 +143,7 @@ Uses `Bearer` token for authorization.
 Returns nothing.
 
 ## Link Channel to Lobby
-<Route type="PATCH">/lobbies/[\{lobby.id\}](/docs/resources/lobby#lobby-object)/channel-linking</Route>
+<Route method="PATCH">/lobbies/[\{lobby.id\}](/docs/resources/lobby#lobby-object)/channel-linking</Route>
 
 Links an existing text channel to a lobby. See [Linked Channels](/docs/discord-social-sdk/development-guides/linked-channels) for more information.
 
@@ -158,7 +158,7 @@ Returns a [lobby](/docs/resources/lobby#lobby-object) object with a linked chann
 | channel_id? | snowflake | the id of the channel to link to the lobby. If not provided, will unlink any currently linked channels from the lobby. |
 
 ## Unlink Channel from Lobby
-<Route type="PATCH">/lobbies/[\{lobby.id\}](/docs/resources/lobby#lobby-object)/channel-linking</Route>
+<Route method="PATCH">/lobbies/[\{lobby.id\}](/docs/resources/lobby#lobby-object)/channel-linking</Route>
 
 Unlinks any currently linked channels from the specified lobby.
 

--- a/docs/resources/message.mdx
+++ b/docs/resources/message.mdx
@@ -736,7 +736,7 @@ user 125 in the content.
 | is_renewal                   | boolean   | whether this notification is for a renewal rather than a new purchase |
 
 ## Get Channel Messages
-<Route type="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages</Route>
+<Route method="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages</Route>
 
 Retrieves the messages in a channel. Returns an array of [message](/docs/resources/message#message-object) objects on success.
 
@@ -758,14 +758,14 @@ The `before`, `after`, and `around` parameters are mutually exclusive, only one 
 | limit?  | integer   | Max number of messages to return (1-100) | 50      |
 
 ## Get Channel Message
-<Route type="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)</Route>
+<Route method="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)</Route>
 
 Retrieves a specific message in the channel. Returns a [message](/docs/resources/message#message-object) object on success.
 
 If operating on a guild channel, this endpoint requires the current user to have the `VIEW_CHANNEL` and `READ_MESSAGE_HISTORY` permissions. If the channel is a voice channel, they must _also_ have the `CONNECT` permission.
 
 ## Create Message
-<Route type="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages</Route>
+<Route method="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages</Route>
 
 :::warn
 Discord may strip certain characters from message content, like invalid unicode characters or characters which cause unexpected message formatting. If you are passing user-generated strings into message content, consider sanitizing the data to prevent unexpected behavior and using `allowed_mentions` to prevent unexpected mentions.
@@ -828,32 +828,32 @@ When creating a message, apps must provide a value for **at least one of** `cont
 Examples for file uploads are available in [Uploading Files](/docs/reference#uploading-files).
 
 ## Crosspost Message
-<Route type="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)/crosspost</Route>
+<Route method="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)/crosspost</Route>
 
 Crosspost a message in an Announcement Channel to following channels. This endpoint requires the `SEND_MESSAGES` permission, if the current user sent the message, or additionally the `MANAGE_MESSAGES` permission, for all other messages, to be present for the current user.
 
 Returns a [message](/docs/resources/message#message-object) object. Fires a [Message Update](/docs/events/gateway-events#message-update) Gateway event.
 
 ## Create Reaction
-<Route type="PUT">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)/reactions/[\{emoji/docs/resources/emoji#emoji-object}/@me</Route>
+<Route method="PUT">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)/reactions/[\{emoji/docs/resources/emoji#emoji-object}/@me</Route>
 
 Create a reaction for the message. This endpoint requires the `READ_MESSAGE_HISTORY` permission to be present on the current user. Additionally, if nobody else has reacted to the message using this emoji, this endpoint requires the `ADD_REACTIONS` permission to be present on the current user. Returns a 204 empty response on success. Fires a [Message Reaction Add](/docs/events/gateway-events#message-reaction-add) Gateway event.
 The `emoji` must be [URL Encoded](https://en.wikipedia.org/wiki/Percent-encoding) or the request will fail with `10014: Unknown Emoji`. To use custom emoji, you must encode it in the format `name:id` with the emoji name and emoji id.
 
 ## Delete Own Reaction
-<Route type="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)/reactions/[\{emoji/docs/resources/emoji#emoji-object}/@me</Route>
+<Route method="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)/reactions/[\{emoji/docs/resources/emoji#emoji-object}/@me</Route>
 
 Delete a reaction the current user has made for the message. Returns a 204 empty response on success. Fires a [Message Reaction Remove](/docs/events/gateway-events#message-reaction-remove) Gateway event.
 The `emoji` must be [URL Encoded](https://en.wikipedia.org/wiki/Percent-encoding) or the request will fail with `10014: Unknown Emoji`. To use custom emoji, you must encode it in the format `name:id` with the emoji name and emoji id.
 
 ## Delete User Reaction
-<Route type="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)/reactions/[\{emoji/docs/resources/emoji#emoji-object}/[\{user.id\}](/docs/resources/user#user-object)</Route>
+<Route method="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)/reactions/[\{emoji/docs/resources/emoji#emoji-object}/[\{user.id\}](/docs/resources/user#user-object)</Route>
 
 Deletes another user's reaction. This endpoint requires the `MANAGE_MESSAGES` permission to be present on the current user. Returns a 204 empty response on success. Fires a [Message Reaction Remove](/docs/events/gateway-events#message-reaction-remove) Gateway event.
 The `emoji` must be [URL Encoded](https://en.wikipedia.org/wiki/Percent-encoding) or the request will fail with `10014: Unknown Emoji`. To use custom emoji, you must encode it in the format `name:id` with the emoji name and emoji id.
 
 ## Get Reactions
-<Route type="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)/reactions/[\{emoji/docs/resources/emoji#emoji-object}</Route>
+<Route method="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)/reactions/[\{emoji/docs/resources/emoji#emoji-object}</Route>
 
 Get a list of users that reacted with this emoji. Returns an array of [user](/docs/resources/user#user-object) objects on success.
 The `emoji` must be [URL Encoded](https://en.wikipedia.org/wiki/Percent-encoding) or the request will fail with `10014: Unknown Emoji`. To use custom emoji, you must encode it in the format `name:id` with the emoji name and emoji id.
@@ -874,18 +874,18 @@ The `emoji` must be [URL Encoded](https://en.wikipedia.org/wiki/Percent-encoding
 | BURST  | 1     |
 
 ## Delete All Reactions
-<Route type="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)/reactions</Route>
+<Route method="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)/reactions</Route>
 
 Deletes all reactions on a message. This endpoint requires the `MANAGE_MESSAGES` permission to be present on the current user. Fires a [Message Reaction Remove All](/docs/events/gateway-events#message-reaction-remove-all) Gateway event.
 
 ## Delete All Reactions for Emoji
-<Route type="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)/reactions/[\{emoji/docs/resources/emoji#emoji-object}</Route>
+<Route method="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)/reactions/[\{emoji/docs/resources/emoji#emoji-object}</Route>
 
 Deletes all the reactions for a given emoji on a message. This endpoint requires the `MANAGE_MESSAGES` permission to be present on the current user. Fires a [Message Reaction Remove Emoji](/docs/events/gateway-events#message-reaction-remove-emoji) Gateway event.
 The `emoji` must be [URL Encoded](https://en.wikipedia.org/wiki/Percent-encoding) or the request will fail with `10014: Unknown Emoji`. To use custom emoji, you must encode it in the format `name:id` with the emoji name and emoji id.
 
 ## Edit Message
-<Route type="PATCH">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)</Route>
+<Route method="PATCH">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)</Route>
 
 Edit a previously sent message. The fields `content`, `embeds`, and `flags` can be edited by the original message author. Other users can only edit `flags` and only if they have the `MANAGE_MESSAGES` permission in the corresponding channel. When specifying flags, ensure to include all previously set flags/bits in addition to ones that you are modifying. Only `flags` documented in the table below may be modified by users (unsupported flag changes are currently ignored without error).
 
@@ -918,7 +918,7 @@ All parameters to this endpoint are optional and nullable.
 | attachments      | array of [attachment](/docs/resources/message#attachment-object) objects  | Attached files to keep and possible descriptions for new files. See [Uploading Files](/docs/reference#uploading-files)                  |
 
 ## Delete Message
-<Route type="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)</Route>
+<Route method="DELETE">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/[\{message.id\}](/docs/resources/message#message-object)</Route>
 
 Delete a message. If operating on a guild channel and trying to delete a message that was not sent by the current user, this endpoint requires the `MANAGE_MESSAGES` permission. Returns a 204 empty response on success. Fires a [Message Delete](/docs/events/gateway-events#message-delete) Gateway event.
 
@@ -927,7 +927,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 :::
 
 ## Bulk Delete Messages
-<Route type="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/bulk-delete</Route>
+<Route method="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages/bulk-delete</Route>
 
 Delete multiple messages in a single request. This endpoint can only be used on guild channels and requires the `MANAGE_MESSAGES` permission. Returns a 204 empty response on success. Fires a [Message Delete Bulk](/docs/events/gateway-events#message-delete-bulk) Gateway event.
 

--- a/docs/resources/poll.mdx
+++ b/docs/resources/poll.mdx
@@ -124,7 +124,7 @@ For creating a poll, see [Create Message](/docs/resources/message#create-message
 Apps are not allowed to vote on polls. No rights! :)
 
 ## Get Answer Voters
-<Route type="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/polls/[\{message.id\}](/docs/resources/message#message-object)/answers/[\{answer_id\}](/docs/resources/poll#poll-answer-object)</Route>
+<Route method="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/polls/[\{message.id\}](/docs/resources/message#message-object)/answers/[\{answer_id\}](/docs/resources/poll#poll-answer-object)</Route>
 
 Get a list of users that voted for this specific answer.
 
@@ -142,7 +142,7 @@ Get a list of users that voted for this specific answer.
 | users | array of [user](/docs/resources/user#user-object) | Users who voted for this answer |
 
 ## End Poll
-<Route type="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/polls/[\{message.id\}](/docs/resources/message#message-object)/expire</Route>
+<Route method="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/polls/[\{message.id\}](/docs/resources/message#message-object)/expire</Route>
 
 Immediately ends the poll. You cannot end polls from other users.
 

--- a/docs/resources/sku.mdx
+++ b/docs/resources/sku.mdx
@@ -66,7 +66,7 @@ The `flags` field can be used to differentiate user and server subscriptions wit
 | USER_SUBSCRIPTION  | `1 << 8` | Recurring SKU purchased by a user for themselves. Grants access to the purchasing user in every server.                   |
 
 ## List SKUs
-<Route type="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/skus</Route>
+<Route method="GET">/applications/[\{application.id\}](/docs/resources/application#application-object)/skus</Route>
 
 Returns all SKUs for a given application. 
 

--- a/docs/resources/soundboard.mdx
+++ b/docs/resources/soundboard.mdx
@@ -61,7 +61,7 @@ https://cdn.discordapp.com/soundboard-sounds/{sound_id}
 ```
 
 ## Send Soundboard Sound
-<Route type="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/send-soundboard-sound</Route>
+<Route method="POST">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/send-soundboard-sound</Route>
 
 Send a soundboard sound to a voice channel the user is connected to. Fires a [Voice Channel Effect Send](/docs/events/gateway-events#voice-channel-effect-send) Gateway event.
 
@@ -75,12 +75,12 @@ Requires the `SPEAK` and `USE_SOUNDBOARD` permissions, and also the `USE_EXTERNA
 | source_guild_id? | snowflake | the id of the guild the soundboard sound is from, required to play sounds from different servers |
 
 ## List Default Soundboard Sounds
-<Route type="GET">/soundboard-default-sounds</Route>
+<Route method="GET">/soundboard-default-sounds</Route>
 
 Returns an array of [soundboard sound](/docs/resources/soundboard#soundboard-sound-object) objects that can be used by all users.
 
 ## List Guild Soundboard Sounds
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/soundboard-sounds</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/soundboard-sounds</Route>
 
 Returns a list of the guild's soundboard sounds. Includes `user` fields if the bot has the `CREATE_GUILD_EXPRESSIONS` or `MANAGE_GUILD_EXPRESSIONS` permission.
 
@@ -91,12 +91,12 @@ Returns a list of the guild's soundboard sounds. Includes `user` fields if the b
 | items | array of [soundboard sound](/docs/resources/soundboard#soundboard-sound-object) objects |
 
 ## Get Guild Soundboard Sound
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/soundboard-sounds/[\{sound.id\}](/docs/resources/soundboard#soundboard-sound-object)</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/soundboard-sounds/[\{sound.id\}](/docs/resources/soundboard#soundboard-sound-object)</Route>
 
 Returns a [soundboard sound](/docs/resources/soundboard#soundboard-sound-object) object for the given sound id. Includes the `user` field if the bot has the `CREATE_GUILD_EXPRESSIONS` or `MANAGE_GUILD_EXPRESSIONS` permission.
 
 ## Create Guild Soundboard Sound
-<Route type="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/soundboard-sounds</Route>
+<Route method="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/soundboard-sounds</Route>
 
 Create a new soundboard sound for the guild. Requires the `CREATE_GUILD_EXPRESSIONS` permission. Returns the new [soundboard sound](/docs/resources/soundboard#soundboard-sound-object) object on success. Fires a [Guild Soundboard Sound Create](/docs/events/gateway-events#guild-soundboard-sound-create) Gateway event.
 
@@ -119,7 +119,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | emoji_name? | ?string    | the unicode character of a standard emoji for the soundboard sound                             |
 
 ## Modify Guild Soundboard Sound
-<Route type="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/soundboard-sounds/[\{sound.id\}](/docs/resources/soundboard#soundboard-sound-object)</Route>
+<Route method="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/soundboard-sounds/[\{sound.id\}](/docs/resources/soundboard#soundboard-sound-object)</Route>
 
 Modify the given soundboard sound. For sounds created by the current user, requires either the `CREATE_GUILD_EXPRESSIONS` or `MANAGE_GUILD_EXPRESSIONS` permission. For other sounds, requires the `MANAGE_GUILD_EXPRESSIONS` permission. Returns the updated [soundboard sound](/docs/resources/soundboard#soundboard-sound-object) object on success. Fires a [Guild Soundboard Sound Update](/docs/events/gateway-events#guild-soundboard-sound-update) Gateway event.
 
@@ -141,7 +141,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | emoji_name | ?string    | the unicode character of a standard emoji for the soundboard sound |
 
 ## Delete Guild Soundboard Sound
-<Route type="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/soundboard-sounds/[\{sound.id\}](/docs/resources/soundboard#soundboard-sound-object)</Route>
+<Route method="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/soundboard-sounds/[\{sound.id\}](/docs/resources/soundboard#soundboard-sound-object)</Route>
 
 Delete the given soundboard sound. For sounds created by the current user, requires either the `CREATE_GUILD_EXPRESSIONS` or `MANAGE_GUILD_EXPRESSIONS` permission. For other sounds, requires the `MANAGE_GUILD_EXPRESSIONS` permission. Returns `204 No Content` on success. Fires a [Guild Soundboard Sound Delete](/docs/events/gateway-events#guild-soundboard-sound-delete) Gateway event.
 

--- a/docs/resources/stage-instance.mdx
+++ b/docs/resources/stage-instance.mdx
@@ -62,7 +62,7 @@ Below are some definitions related to stages.
 When a Stage channel has no speakers for a certain period of time (on the order of minutes), the Stage instance will be automatically deleted.
 
 ## Create Stage Instance
-<Route type="POST">/stage-instances</Route>
+<Route method="POST">/stage-instances</Route>
 
 Creates a new Stage instance associated to a Stage channel. Returns that [Stage instance](/docs/resources/stage-instance#stage-instance-object-stage-instance-structure). Fires a [Stage Instance Create](/docs/events/gateway-events#stage-instance-create) Gateway event.
 
@@ -85,12 +85,12 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 \* The stage moderator must have the `MENTION_EVERYONE` permission for this notification to be sent.
 
 ## Get Stage Instance
-<Route type="GET">/stage-instances/[\{channel.id\}](/docs/resources/channel#channel-object)</Route>
+<Route method="GET">/stage-instances/[\{channel.id\}](/docs/resources/channel#channel-object)</Route>
 
 Gets the stage instance associated with the Stage channel, if it exists.
 
 ## Modify Stage Instance
-<Route type="PATCH">/stage-instances/[\{channel.id\}](/docs/resources/channel#channel-object)</Route>
+<Route method="PATCH">/stage-instances/[\{channel.id\}](/docs/resources/channel#channel-object)</Route>
 
 Updates fields of an existing Stage instance. Returns the updated [Stage instance](/docs/resources/stage-instance#stage-instance-object-stage-instance-structure). Fires a [Stage Instance Update](/docs/events/gateway-events#stage-instance-update) Gateway event.
 
@@ -108,7 +108,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | privacy_level? | integer | The [privacy level](/docs/resources/stage-instance#stage-instance-object-privacy-level) of the Stage instance |
 
 ## Delete Stage Instance
-<Route type="DELETE">/stage-instances/[\{channel.id\}](/docs/resources/channel#channel-object)</Route>
+<Route method="DELETE">/stage-instances/[\{channel.id\}](/docs/resources/channel#channel-object)</Route>
 
 Deletes the Stage instance. Returns `204 No Content`. Fires a [Stage Instance Delete](/docs/events/gateway-events#stage-instance-delete) Gateway event.
 

--- a/docs/resources/sticker.mdx
+++ b/docs/resources/sticker.mdx
@@ -101,12 +101,12 @@ Represents a pack of standard stickers.
 ```
 
 ## Get Sticker
-<Route type="GET">/stickers/[\{sticker.id\}](/docs/resources/sticker#sticker-object)</Route> 
+<Route method="GET">/stickers/[\{sticker.id\}](/docs/resources/sticker#sticker-object)</Route> 
 
 Returns a [sticker](/docs/resources/sticker#sticker-object) object for the given sticker ID.
 
 ## List Sticker Packs
-<Route type="GET">/sticker-packs</Route>
+<Route method="GET">/sticker-packs</Route>
 
 Returns a list of available sticker packs.
 
@@ -117,22 +117,22 @@ Returns a list of available sticker packs.
 | sticker_packs | array of [sticker pack](/docs/resources/sticker#sticker-pack-object) objects |
 
 ## Get Sticker Pack
-<Route type="GET">/sticker-packs/[\{pack.id\}](/docs/resources/sticker#sticker-pack-object)</Route>
+<Route method="GET">/sticker-packs/[\{pack.id\}](/docs/resources/sticker#sticker-pack-object)</Route>
 
 Returns a [sticker pack](/docs/resources/sticker#sticker-pack-object) object for the given sticker pack ID.
 
 ## List Guild Stickers
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/stickers</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/stickers</Route>
 
 Returns an array of [sticker](/docs/resources/sticker#sticker-object) objects for the given guild. Includes `user` fields if the bot has the `CREATE_GUILD_EXPRESSIONS` or `MANAGE_GUILD_EXPRESSIONS` permission.
 
 ## Get Guild Sticker
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/stickers/[\{sticker.id\}](/docs/resources/sticker#sticker-object)</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/stickers/[\{sticker.id\}](/docs/resources/sticker#sticker-object)</Route>
 
 Returns a [sticker](/docs/resources/sticker#sticker-object) object for the given guild and sticker IDs. Includes the `user` field if the bot has the `CREATE_GUILD_EXPRESSIONS` or `MANAGE_GUILD_EXPRESSIONS` permission.
 
 ## Create Guild Sticker
-<Route type="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/stickers</Route>
+<Route method="POST">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/stickers</Route>
 
 Create a new sticker for the guild. Send a `multipart/form-data` body. Requires the `CREATE_GUILD_EXPRESSIONS` permission. Returns the new [sticker](/docs/resources/sticker#sticker-object) object on success. Fires a [Guild Stickers Update](/docs/events/gateway-events#guild-stickers-update) Gateway event.
 
@@ -160,7 +160,7 @@ Uploaded stickers are constrained to 5 seconds in length for animated stickers, 
 | file        | file contents | the sticker file to upload, must be a PNG, APNG, GIF, or Lottie JSON file, max 512 KiB |
 
 ## Modify Guild Sticker
-<Route type="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/stickers/[\{sticker.id\}](/docs/resources/sticker#sticker-object)</Route>
+<Route method="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/stickers/[\{sticker.id\}](/docs/resources/sticker#sticker-object)</Route>
 
 Modify the given sticker. For stickers created by the current user, requires either the `CREATE_GUILD_EXPRESSIONS` or `MANAGE_GUILD_EXPRESSIONS` permission. For other stickers, requires the `MANAGE_GUILD_EXPRESSIONS` permission. Returns the updated [sticker](/docs/resources/sticker#sticker-object) object on success. Fires a [Guild Stickers Update](/docs/events/gateway-events#guild-stickers-update) Gateway event.
 
@@ -181,7 +181,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | tags        | string  | autocomplete/suggestion tags for the sticker (max 200 characters) |
 
 ## Delete Guild Sticker
-<Route type="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/stickers/[\{sticker.id\}](/docs/resources/sticker#sticker-object)</Route>
+<Route method="DELETE">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/stickers/[\{sticker.id\}](/docs/resources/sticker#sticker-object)</Route>
 
 Delete the given sticker. For stickers created by the current user, requires either the `CREATE_GUILD_EXPRESSIONS` or `MANAGE_GUILD_EXPRESSIONS` permission. For other stickers, requires the `MANAGE_GUILD_EXPRESSIONS` permission. Returns `204 No Content` on success. Fires a [Guild Stickers Update](/docs/events/gateway-events#guild-stickers-update) Gateway event.
 

--- a/docs/resources/subscription.mdx
+++ b/docs/resources/subscription.mdx
@@ -61,7 +61,7 @@ Some examples of this behavior include:
 - A refund or chargeback during the current period would make the subscription `INACTIVE`.
 
 ## List SKU Subscriptions
-<Route type="GET">/skus/[\{sku.id\}](/docs/resources/sku#sku-object)/subscriptions</Route>
+<Route method="GET">/skus/[\{sku.id\}](/docs/resources/sku#sku-object)/subscriptions</Route>
 
 Returns all subscriptions containing the SKU, filtered by user. Returns a list of [subscription](/docs/resources/subscription#subscription-object) objects.
 
@@ -75,6 +75,6 @@ Returns all subscriptions containing the SKU, filtered by user. Returns a list o
 | user_id? | snowflake | User ID for which to return subscriptions. Required except for OAuth queries. | absent  |
 
 ## Get SKU Subscription
-<Route type="GET">/skus/[\{sku.id\}](/docs/resources/sku#sku-object)/subscriptions/[\{subscription.id\}](/docs/resources/subscription#subscription-object)</Route>
+<Route method="GET">/skus/[\{sku.id\}](/docs/resources/sku#sku-object)/subscriptions/[\{subscription.id\}](/docs/resources/subscription#subscription-object)</Route>
 
 Get a subscription by its ID. Returns a [subscription](/docs/resources/subscription#subscription-object) object.

--- a/docs/resources/user.mdx
+++ b/docs/resources/user.mdx
@@ -184,17 +184,17 @@ The role connection object that an application has attached to a user.
 | metadata          | object  | object mapping [application role connection metadata](/docs/resources/application-role-connection-metadata#application-role-connection-metadata-object) keys to their `string`-ified value (max 100 characters) for the user on the platform a bot has connected |
 
 ## Get Current User
-<Route type="GET">/users/@me</Route>
+<Route method="GET">/users/@me</Route>
 
 Returns the [user](/docs/resources/user#user-object) object of the requester's account. For OAuth2, this requires the `identify` scope, which will return the object _without_ an email, and optionally the `email` scope, which returns the object _with_ an email if the user has one.
 
 ## Get User
-<Route type="GET">/users/[\{user.id\}](/docs/resources/user#user-object)</Route>
+<Route method="GET">/users/[\{user.id\}](/docs/resources/user#user-object)</Route>
 
 Returns a [user](/docs/resources/user#user-object) object for a given user ID.
 
 ## Modify Current User
-<Route type="PATCH">/users/@me</Route>
+<Route method="PATCH">/users/@me</Route>
 
 Modify the requester's user account settings. Returns a [user](/docs/resources/user#user-object) object on success. Fires a [User Update](/docs/events/gateway-events#user-update) Gateway event.
 
@@ -211,7 +211,7 @@ All parameters to this endpoint are optional.
 | banner   | ?[image data](/docs/reference#image-data) | if passed, modifies the user's banner                                            |
 
 ## Get Current User Guilds
-<Route type="GET">/users/@me/guilds</Route>
+<Route method="GET">/users/@me/guilds</Route>
 
 Returns a list of partial [guild](/docs/resources/guild#guild-object) objects the current user is a member of. For OAuth2, requires the `guilds` scope.
 
@@ -245,17 +245,17 @@ This endpoint returns 200 guilds by default, which is the maximum number of guil
 | with_counts | [boolean](/docs/reference#boolean-query-strings) | include approximate member and presence counts in response | false    | false   |
 
 ## Get Current User Guild Member
-<Route type="GET">/users/@me/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/member</Route>
+<Route method="GET">/users/@me/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/member</Route>
 
 Returns a [guild member](/docs/resources/guild#guild-member-object) object for the current user. Requires the `guilds.members.read` OAuth2 scope.
 
 ## Leave Guild
-<Route type="DELETE">/users/@me/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)</Route>
+<Route method="DELETE">/users/@me/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)</Route>
 
 Leave a guild. Returns a 204 empty response on success. Fires a [Guild Delete](/docs/events/gateway-events#guild-delete) Gateway event and a [Guild Member Remove](/docs/events/gateway-events#guild-member-remove) Gateway event.
 
 ## Create DM
-<Route type="POST">/users/@me/channels</Route>
+<Route method="POST">/users/@me/channels</Route>
 
 Create a new DM channel with a user. Returns a [DM channel](/docs/resources/channel#channel-object) object (if one already exists, it will be returned instead).
 
@@ -270,7 +270,7 @@ You should not use this endpoint to DM everyone in a server about something. DMs
 | recipient_id | snowflake | the recipient to open a DM channel with |
 
 ## Create Group DM
-<Route type="POST">/users/@me/channels</Route>
+<Route method="POST">/users/@me/channels</Route>
 
 Create a new group DM channel with multiple users. Returns a [DM channel](/docs/resources/channel#channel-object) object. This endpoint was intended to be used with the now-deprecated GameBridge SDK. Fires a [Channel Create](/docs/events/gateway-events#channel-create) Gateway event.
 
@@ -286,17 +286,17 @@ This endpoint is limited to 10 active group DMs.
 | nicks         | dict             | a dictionary of user ids to their respective nicknames                 |
 
 ## Get Current User Connections
-<Route type="GET">/users/@me/connections</Route>
+<Route method="GET">/users/@me/connections</Route>
 
 Returns a list of [connection](/docs/resources/user#connection-object) objects. Requires the `connections` OAuth2 scope.
 
 ## Get Current User Application Role Connection
-<Route type="GET">/users/@me/applications/[\{application.id\}](/docs/resources/application#application-object)/role-connection</Route>
+<Route method="GET">/users/@me/applications/[\{application.id\}](/docs/resources/application#application-object)/role-connection</Route>
 
 Returns the [application role connection](/docs/resources/user#application-role-connection-object) for the user. Requires an OAuth2 access token with `role_connections.write` scope for the application specified in the path.
 
 ## Update Current User Application Role Connection
-<Route type="PUT">/users/@me/applications/[\{application.id\}](/docs/resources/application#application-object)/role-connection</Route>
+<Route method="PUT">/users/@me/applications/[\{application.id\}](/docs/resources/application#application-object)/role-connection</Route>
 
 Updates and returns the [application role connection](/docs/resources/user#application-role-connection-object) for the user. Requires an OAuth2 access token with `role_connections.write` scope for the application specified in the path.
 

--- a/docs/resources/voice.mdx
+++ b/docs/resources/voice.mdx
@@ -55,22 +55,22 @@ Used to represent a user's voice connection status.
 | custom     | boolean | whether this is a custom voice region (used for events/etc)           |
 
 ## List Voice Regions
-<Route type="GET">/voice/regions</Route>
+<Route method="GET">/voice/regions</Route>
 
 Returns an array of [voice region](/docs/resources/voice#voice-region-object) objects that can be used when setting a voice or stage channel's [`rtc_region`](/docs/resources/channel#channel-object-channel-structure).
 
 ## Get Current User Voice State
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/voice-states/@me</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/voice-states/@me</Route>
 
 Returns the current user's [voice state](/docs/resources/voice#voice-state-object) in the guild.
 
 ## Get User Voice State
-<Route type="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/voice-states/[\{user.id\}](/docs/resources/user#user-object)</Route>
+<Route method="GET">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/voice-states/[\{user.id\}](/docs/resources/user#user-object)</Route>
 
 Returns the specified user's [voice state](/docs/resources/voice#voice-state-object) in the guild.
 
 ## Modify Current User Voice State
-<Route type="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/voice-states/@me</Route>
+<Route method="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/voice-states/@me</Route>
 
 Updates the current user's voice state. Returns `204 No Content` on success. Fires a [Voice State Update](/docs/events/gateway-events#voice-state-update) Gateway event.
 
@@ -93,7 +93,7 @@ There are currently several caveats for this endpoint:
 - You are able to set `request_to_speak_timestamp` to any present or future time.
 
 ## Modify User Voice State
-<Route type="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/voice-states/[\{user.id\}](/docs/resources/user#user-object)</Route>
+<Route method="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/voice-states/[\{user.id\}](/docs/resources/user#user-object)</Route>
 
 Updates another user's voice state. Fires a [Voice State Update](/docs/events/gateway-events#voice-state-update) Gateway event.
 

--- a/docs/topics/oauth2.mdx
+++ b/docs/topics/oauth2.mdx
@@ -416,12 +416,12 @@ From this object, you should store the `webhook.token` and `webhook.id`. See the
 Any user that wishes to add your webhook to their channel will need to go through the full OAuth2 flow. A new webhook is created each time, so you will need to save the token and id. If you wish to send a message to all your webhooks, you'll need to iterate over each stored id:token combination and make `POST` requests to each one. Be mindful of our [Rate Limits](/docs/topics/rate-limits#rate-limits)!
 
 ## Get Current Bot Application Information
-<Route type="GET">/oauth2/applications/@me</Route>
+<Route method="GET">/oauth2/applications/@me</Route>
 
 Returns the bot's [application](/docs/resources/application#application-object) object.
 
 ## Get Current Authorization Information
-<Route type="GET">/oauth2/@me</Route>
+<Route method="GET">/oauth2/@me</Route>
 
 Returns info about the current authorization. Requires authentication with a bearer token.
 


### PR DESCRIPTION
Currently the docs incorrectly show all requests as using the GET method for Resources.

See https://discord.com/developers/docs/resources/soundboard#delete-guild-soundboard-sound: 
![image](https://github.com/user-attachments/assets/1838f7e5-c1da-4c53-8dd4-0c6dd222d7bd)

PR switches from `<Route type="">` to `<Route method="">` to resolve this issue.

Solution is based on https://discord.com/developers/docs/resources/webhook#create-webhook which renders correctly currently and uses `<Route method="">`