### PR TITLE
fix components v2 flag description

### DIFF
--- a/docs/resources/message.mdx
+++ b/docs/resources/message.mdx
@@ -133,21 +133,21 @@ Type `19` and `20` are only available in API v8 and above. In v6, they are repre
 
 ###### Message Flags
 
-| Flag                                   | Value     | Description                                                                                                      |
-|----------------------------------------|-----------|------------------------------------------------------------------------------------------------------------------|
-| CROSSPOSTED                            | `1 << 0`  | this message has been published to subscribed channels (via Channel Following)                                   |
-| IS_CROSSPOST                           | `1 << 1`  | this message originated from a message in another channel (via Channel Following)                                |
-| SUPPRESS_EMBEDS                        | `1 << 2`  | do not include any embeds when serializing this message                                                          |
-| SOURCE_MESSAGE_DELETED                 | `1 << 3`  | the source message for this crosspost has been deleted (via Channel Following)                                   |
-| URGENT                                 | `1 << 4`  | this message came from the urgent message system                                                                 |
-| HAS_THREAD                             | `1 << 5`  | this message has an associated thread, with the same id as the message                                           |
-| EPHEMERAL                              | `1 << 6`  | this message is only visible to the user who invoked the Interaction                                             |
-| LOADING                                | `1 << 7`  | this message is an Interaction Response and the bot is "thinking"                                                |
-| FAILED_TO_MENTION_SOME_ROLES_IN_THREAD | `1 << 8`  | this message failed to mention some roles and add their members to the thread                                    |
-| SUPPRESS_NOTIFICATIONS                 | `1 << 12` | this message will not trigger push and desktop notifications                                                     |
-| IS_VOICE_MESSAGE                       | `1 << 13` | this message is a voice message                                                                                  |
-| HAS_SNAPSHOT                           | `1 << 14` | this message has a snapshot (via Message Forwarding)                                                             |
-| IS_COMPONENTS_V2                       | `1 << 15` | this message allows you to create fully [component](/docs/components/reference#component-object) driven messages |
+| Flag                                   | Value     | Description                                                                       |
+|----------------------------------------|-----------|-----------------------------------------------------------------------------------|
+| CROSSPOSTED                            | `1 << 0`  | this message has been published to subscribed channels (via Channel Following)    |
+| IS_CROSSPOST                           | `1 << 1`  | this message originated from a message in another channel (via Channel Following) |
+| SUPPRESS_EMBEDS                        | `1 << 2`  | do not include any embeds when serializing this message                           |
+| SOURCE_MESSAGE_DELETED                 | `1 << 3`  | the source message for this crosspost has been deleted (via Channel Following)    |
+| URGENT                                 | `1 << 4`  | this message came from the urgent message system                                  |
+| HAS_THREAD                             | `1 << 5`  | this message has an associated thread, with the same id as the message            |
+| EPHEMERAL                              | `1 << 6`  | this message is only visible to the user who invoked the Interaction              |
+| LOADING                                | `1 << 7`  | this message is an Interaction Response and the bot is "thinking"                 |
+| FAILED_TO_MENTION_SOME_ROLES_IN_THREAD | `1 << 8`  | this message failed to mention some roles and add their members to the thread     |
+| SUPPRESS_NOTIFICATIONS                 | `1 << 12` | this message will not trigger push and desktop notifications                      |
+| IS_VOICE_MESSAGE                       | `1 << 13` | this message is a voice message                                                   |
+| HAS_SNAPSHOT                           | `1 << 14` | this message has a snapshot (via Message Forwarding)                              |
+| IS_COMPONENTS_V2                       | `1 << 15` | allows you to create fully [component](/docs/components/overview) driven messages |
 
 ###### Example Message
 

--- a/docs/resources/message.mdx
+++ b/docs/resources/message.mdx
@@ -147,7 +147,7 @@ Type `19` and `20` are only available in API v8 and above. In v6, they are repre
 | SUPPRESS_NOTIFICATIONS                 | `1 << 12` | this message will not trigger push and desktop notifications                      |
 | IS_VOICE_MESSAGE                       | `1 << 13` | this message is a voice message                                                   |
 | HAS_SNAPSHOT                           | `1 << 14` | this message has a snapshot (via Message Forwarding)                              |
-| IS_COMPONENTS_V2                       | `1 << 15` | allows you to create fully [component](/docs/components/overview) driven messages |
+| IS_COMPONENTS_V2                       | `1 << 15` | allows you to create fully [component](/docs/components/overview)-driven messages |
 
 ###### Example Message
 


### PR DESCRIPTION
"~~this message~~ allows you to create fully component driven messages"

also changed the link from component object reference to components overview since that is probably more helpful

