### PR TITLE
Updated absolute to relative links

### DIFF
--- a/docs/activities/development-guides/multiplayer-experience.mdx
+++ b/docs/activities/development-guides/multiplayer-experience.mdx
@@ -59,7 +59,7 @@ discordSdk.unsubscribe(Events.ACTIVITY_INSTANCE_PARTICIPANTS_UPDATE, updateParti
 
 ## Render Avatars and Names
 
-Check out detailed documentation on where and how Discord stores common image assets [here](https://discord.com/developers/docs/reference#image-formatting-cdn-endpoints).
+Check out detailed documentation on where and how Discord stores common image assets [here](/docs/reference#image-formatting-cdn-endpoints).
 
 Here's a basic example for retrieving a user's avatar and username
 

--- a/docs/activities/development-guides/production-readiness.mdx
+++ b/docs/activities/development-guides/production-readiness.mdx
@@ -14,7 +14,7 @@ All assets loaded by your application will respect [cache headers](https://devel
 
 ## Handling Rate Limits
 
-Be sure network requests made by your application's client and server will be able to respect Discord API's rate limiting [as described here](https://discord.com/developers/docs/topics/rate-limits).
+Be sure network requests made by your application's client and server will be able to respect Discord API's rate limiting [as described here](/docs/topics/rate-limits).
 
 See [this implementation in the Activity Starter project](https://github.com/discord/embedded-app-sdk-examples/blob/main/discord-activity-starter/packages/server/src/utils.ts) for an example of how to respect the `retry_after` header when you receive a 429 error.
 

--- a/docs/activities/development-guides/user-actions.mdx
+++ b/docs/activities/development-guides/user-actions.mdx
@@ -33,7 +33,7 @@ Users will see a modal inside the Discord app notifying them whether or not they
 
 ## Open Invite Dialog
 
-Getting an Application Channel Invite, as outlined in [these docs](https://discord.com/developers/docs/resources/invite#get-invite), is not granted by any OAuth scopes. Nonetheless, the `openInviteDialog` command is available via the SDK. This command opens the Application Channel Invite UI within the discord client without requiring additional OAuth scopes.
+Getting an Application Channel Invite, as outlined in [these docs](/docs/resources/invite#get-invite), is not granted by any OAuth scopes. Nonetheless, the `openInviteDialog` command is available via the SDK. This command opens the Application Channel Invite UI within the discord client without requiring additional OAuth scopes.
 
 This command returns an error when called from DM (Direct Message) contexts, so should only be called in Guild Voice or Text Channels. Similarly, this command returns an error if the user has invalid permissions for the channel, so using `getChannelPermissions` (requires OAuth scope `'guilds.members.read'`) is highly recommended.
 

--- a/docs/change-log/2023-10-17-global-rate-limit-added-to-discord.com.md
+++ b/docs/change-log/2023-10-17-global-rate-limit-added-to-discord.com.md
@@ -9,7 +9,7 @@ To limit impact on your app, please make sure you are making calls to `discord.c
 
 This does **not** apply for `cdn.discordapp.com`.
 
-Refer to the [API Reference](https://discord.com/developers/docs/reference) for more info on which url(s) to use when building on the REST API
+Refer to the [API Reference](/docs/reference) for more info on which url(s) to use when building on the REST API
 
-* [February 14, 2022 Change Log](https://discord.com/developers/docs/change-log#feb-14-2022): Requests to v10 and higher will no longer be supported on `discordapp.com` (this does not affect `cdn.discordapp.com`)
+* [February 14, 2022 Change Log](/docs/change-log#feb-14-2022): Requests to v10 and higher will no longer be supported on `discordapp.com` (this does not affect `cdn.discordapp.com`)
 * [May 4, 2020 #api-announcements](https://discord.com/channels/613425648685547541/697138785317814292/706944540971630662)

--- a/docs/change-log/2023-10-17-global-rate-limit-added-to-discord.com.md
+++ b/docs/change-log/2023-10-17-global-rate-limit-added-to-discord.com.md
@@ -11,5 +11,5 @@ This does **not** apply for `cdn.discordapp.com`.
 
 Refer to the [API Reference](/docs/reference) for more info on which url(s) to use when building on the REST API
 
-* [February 14, 2022 Change Log](/docs/change-log#feb-14-2022): Requests to v10 and higher will no longer be supported on `discordapp.com` (this does not affect `cdn.discordapp.com`)
+* [February 14, 2022 Change Log](/docs/change-log#api-v10): Requests to v10 and higher will no longer be supported on `discordapp.com` (this does not affect `cdn.discordapp.com`)
 * [May 4, 2020 #api-announcements](https://discord.com/channels/613425648685547541/697138785317814292/706944540971630662)

--- a/docs/change-log/2025-04-11-incentivized-links.md
+++ b/docs/change-log/2025-04-11-incentivized-links.md
@@ -13,6 +13,6 @@ Custom Incentivized Links are used to customize how your incentivized link embed
 - shareLink will now let you attach custom params to links you share about your game using `custom_id`.
 - Removed `referrer_id` from shareLink API. Any uses of `referrer_id` should be moved over to use `custom_id` instead. Passing `referrer_id` to shareLink will silently fail.
 
-Learn more about [creating and managing Custom Incentivized Links](/docs/activities/development-guides#creating-and-managing-custom-incentivized-links) and [how to generate them from within your activity](/docs/activities/development-guides#generating-a-custom-link-within-your-activity) with the shareLink API.
+Learn more about [creating and managing Custom Incentivized Links](/docs/activities/development-guides/growth-and-referrals#creating-and-managing-custom-incentivized-links) and [how to generate them from within your activity](/docs/activities/development-guides/growth-and-referrals#generating-a-custom-link-within-your-activity) with the shareLink API.
 
 The Embedded App SDK is available via [npm](https://www.npmjs.com/package/@discord/embedded-app-sdk) and [GitHub](https://github.com/discord/embedded-app-sdk). You can check out our [installation guide and reference](/docs/developer-tools/embedded-app-sdk) to get started with it!

--- a/docs/change-log/2025-04-11-incentivized-links.md
+++ b/docs/change-log/2025-04-11-incentivized-links.md
@@ -13,6 +13,6 @@ Custom Incentivized Links are used to customize how your incentivized link embed
 - shareLink will now let you attach custom params to links you share about your game using `custom_id`.
 - Removed `referrer_id` from shareLink API. Any uses of `referrer_id` should be moved over to use `custom_id` instead. Passing `referrer_id` to shareLink will silently fail.
 
-Learn more about [creating and managing Custom Incentivized Links](https://discord.com/developers/docs/activities/development-guides#creating-and-managing-custom-incentivized-links) and [how to generate them from within your activity](https://discord.com/developers/docs/activities/development-guides#generating-a-custom-link-within-your-activity) with the shareLink API.
+Learn more about [creating and managing Custom Incentivized Links](/docs/activities/development-guides#creating-and-managing-custom-incentivized-links) and [how to generate them from within your activity](/docs/activities/development-guides#generating-a-custom-link-within-your-activity) with the shareLink API.
 
-The Embedded App SDK is available via [npm](https://www.npmjs.com/package/@discord/embedded-app-sdk) and [GitHub](https://github.com/discord/embedded-app-sdk). You can check out our [installation guide and reference](https://discord.com/developers/docs/developer-tools/embedded-app-sdk) to get started with it!
+The Embedded App SDK is available via [npm](https://www.npmjs.com/package/@discord/embedded-app-sdk) and [GitHub](https://github.com/discord/embedded-app-sdk). You can check out our [installation guide and reference](/docs/developer-tools/embedded-app-sdk) to get started with it!

--- a/docs/components/using-modal-components.mdx
+++ b/docs/components/using-modal-components.mdx
@@ -21,7 +21,7 @@ Currently, only [Text Input](/docs/components/reference#text-input) fields are s
 
 ## Displaying a Modal
 
-Displaying a modal can be done in response to a [slash command](https://discord.com/developers/docs/tutorials/upgrading-to-application-commands#slash-commands) or when responding to an [interaction](/docs/interactions/receiving-and-responding). When displaying a modal you'll use an [interaction response](/docs/interactions/receiving-and-responding#interaction-response-object) with the [`MODAL`](/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-type) interaction callback type and [modal fields](/docs/interactions/receiving-and-responding#interaction-response-object-modal).
+Displaying a modal can be done in response to a [slash command](/docs/tutorials/upgrading-to-application-commands#slash-commands) or when responding to an [interaction](/docs/interactions/receiving-and-responding). When displaying a modal you'll use an [interaction response](/docs/interactions/receiving-and-responding#interaction-response-object) with the [`MODAL`](/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-type) interaction callback type and [modal fields](/docs/interactions/receiving-and-responding#interaction-response-object-modal).
 
 An example of a modal with two Text Inputs:
 

--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -14,7 +14,7 @@ https://discord.com/api
 Some API and Gateway versions are now non-functioning, and are labeled as discontinued in the table below for posterity. Trying to use these versions will fail and return 400 Bad Request.
 :::
 
-Discord exposes different versions of our API[.](https://c.tenor.com/BuZl66EegkgAAAAC/westworld-dolores.gif) You should specify which version to use by including it in the request path like `https://discord.com/api/v{version_number}`. Omitting the version number from the route will route requests to the current default version (marked below). You can find the change log for the newest API version [here](https://discord.com/developers/docs/change-log).
+Discord exposes different versions of our API[.](https://c.tenor.com/BuZl66EegkgAAAAC/westworld-dolores.gif) You should specify which version to use by including it in the request path like `https://discord.com/api/v{version_number}`. Omitting the version number from the route will route requests to the current default version (marked below). You can find the change log for the newest API version [here](/docs/change-log).
 
 ###### API Versions
 

--- a/docs/tutorials/configuring-app-metadata-for-linked-roles.md
+++ b/docs/tutorials/configuring-app-metadata-for-linked-roles.md
@@ -37,7 +37,7 @@ Apps need approval from installing users to perform actions inside of Discord. S
 - After the scope is selected, you should see a **Generated URL** which can be used to install your app
 
 :::info
-See a list of all [OAuth2 scopes](https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes), or read more on [user permissions](https://discord.com/developers/docs/topics/permissions) in the documentation.
+See a list of all [OAuth2 scopes](/docs/topics/oauth2#shared-resources-oauth2-scopes), or read more on [user permissions](/docs/topics/permissions) in the documentation.
 :::
 
 ### Installing your app
@@ -177,7 +177,7 @@ Finally, create a new private channel, and add the new linked role.
 
 ### Token storage
 
-This app largely relies on Discord's [OAuth2](https://discord.com/developers/docs/topics/oauth2) implementation to obtain access tokens. This model of user based authentication relies on storing refresh tokens, and using them to acquire access tokens. The example code in [`src/storage.js`](https://github.com/discord/linked-roles-sample/blob/main/src/storage.js) uses in-memory storage to manage these tokens, but for any production deployment a database with persistent storage should be used. 
+This app largely relies on Discord's [OAuth2](/docs/topics/oauth2) implementation to obtain access tokens. This model of user based authentication relies on storing refresh tokens, and using them to acquire access tokens. The example code in [`src/storage.js`](https://github.com/discord/linked-roles-sample/blob/main/src/storage.js) uses in-memory storage to manage these tokens, but for any production deployment a database with persistent storage should be used. 
 
 ### Advanced examples
 


### PR DESCRIPTION
Updated all remaining absolute documentation links to relative links. Those links were missed by the link check script and therefore could still contain outdated links (e. g. `/docs/activities/development-guides#creating-and-managing-custom-incentivized-links` is now `/docs/activities/development-guides/growth-and-referrals`) or outdated anchors (e. g. `https://discord.com/developers/docs/change-log#feb-14-2022` is now `#api-v10`)

Follow-up to https://github.com/discord/discord-api-docs/pull/7479#issuecomment-2822014708 (broken into smaller pieces)