### PR TITLE
Add Unity to provisional account providers

### DIFF
--- a/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
+++ b/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
@@ -78,6 +78,7 @@ We currently support the following provider types:
 - OpenID Connect (OIDC)
 - Steam Session Tickets
 - Epic Online Services (EOS)
+- Unity
 
 ---
 


### PR DESCRIPTION
We added support Unity as a provider for provisional accounts, this adds them to the bulleted list