### PR TITLE
Fix typo: change "button components" to "button component"

### DIFF
--- a/docs/components/reference.mdx
+++ b/docs/components/reference.mdx
@@ -838,7 +838,7 @@ To use this component, you need to send the [message flag](/docs/resources/messa
 | type       | integer                                                                                                               | `9` for section component                                                                         |
 | id?        | integer                                                                                                               | Optional identifier for component                                                                 |
 | components | array of [text display components](/docs/components/reference#text-display)                                           | One to three text components                                                                      |
-| accessory  | [thumbnail component](/docs/components/reference#thumbnail) or [button components](/docs/components/reference#button) | A thumbnail or a button component, with a future possibility of adding more compatible components |
+| accessory  | [thumbnail component](/docs/components/reference#thumbnail) or [button component](/docs/components/reference#button)  | A thumbnail or a button component, with a future possibility of adding more compatible components |
 
 :::info
 Don't hardcode `components` to contain only text components. We may add other components in the future. Similarly, `accessory` may be expanded to include other components in the future.

--- a/docs/components/reference.mdx
+++ b/docs/components/reference.mdx
@@ -833,12 +833,12 @@ To use this component, you need to send the [message flag](/docs/resources/messa
 
 ###### Section Structure
 
-| Field      | Type                                                                                                                  | Description                                                                                       |
-|------------|-----------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
-| type       | integer                                                                                                               | `9` for section component                                                                         |
-| id?        | integer                                                                                                               | Optional identifier for component                                                                 |
-| components | array of [text display components](/docs/components/reference#text-display)                                           | One to three text components                                                                      |
-| accessory  | [thumbnail component](/docs/components/reference#thumbnail) or [button component](/docs/components/reference#button)  | A thumbnail or a button component, with a future possibility of adding more compatible components |
+| Field      | Type                                                                                                                 | Description                                                                                       |
+|------------|----------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| type       | integer                                                                                                              | `9` for section component                                                                         |
+| id?        | integer                                                                                                              | Optional identifier for component                                                                 |
+| components | array of [text display components](/docs/components/reference#text-display)                                          | One to three text components                                                                      |
+| accessory  | [thumbnail component](/docs/components/reference#thumbnail) or [button component](/docs/components/reference#button) | A thumbnail or a button component, with a future possibility of adding more compatible components |
 
 :::info
 Don't hardcode `components` to contain only text components. We may add other components in the future. Similarly, `accessory` may be expanded to include other components in the future.


### PR DESCRIPTION
Fixes a typo, changed "button components" to "button component" for consistency with the correct usage shown next to it.