### PR TITLE
fix openShareMomentDialog command doc

### DIFF
--- a/docs/developer-tools/embedded-app-sdk.mdx
+++ b/docs/developer-tools/embedded-app-sdk.mdx
@@ -581,7 +581,7 @@ No scopes required
 #### Signature
 
 <Monospace>
-openInviteDialog(args: [OpenInviteDialogRequest](/docs/developer-tools/embedded-app-sdk#openinvitedialogrequest)) Promise\<void\>
+openShareMomentDialog(args: [OpenShareMomentDialogRequest](/docs/developer-tools/embedded-app-sdk#opensharemomentdialogrequest)) Promise\<void\>
 </Monospace>
 
 #### Usage
@@ -1417,7 +1417,7 @@ Coming soon! Not available during Developer Preview
 |----------|-----------------|
 | opened   | boolean \| null |
 
-#### OpenInviteDialogRequest
+#### OpenShareMomentDialogRequest
 
 | Property | Type   |
 |----------|--------|


### PR DESCRIPTION
it mistakenly was called openInviteDialog in the signature 