### PR TITLE
Fix syntax errors in code example for Generating a Link in Growth and Referrals

### DIFF
--- a/docs/activities/development-guides/growth-and-referrals.mdx
+++ b/docs/activities/development-guides/growth-and-referrals.mdx
@@ -166,9 +166,10 @@ const linkIdResponse = await fetch(`${env.discordAPI}/applications/${env.applica
   method: 'POST',
   headers: {
     Authorization: `Bearer ${accessToken}`,
+    'Content-Type': 'application/json',
   },
   body: {
-    custom_id: 'user_123/game_456'
+    custom_id: 'user_123/game_456',
     description: 'I just beat level 10 with a perfect score',
     title: 'Check out my high score!',
     image,
@@ -178,7 +179,8 @@ const {link_id} = await linkIdResponse.json();
 
 // Open the Share modal with the generated link
 const {success} = await discordSdk.commands.shareLink({
-  linkId: link_id
+  message: 'Check out my high score!',
+  link_id,
 });
 success ? console.log('User shared link!') : console.log('User did not share link!');
 ```


### PR DESCRIPTION
### 1. Add Content-Type Header (required)
<img width="635" alt="image" src="https://github.com/user-attachments/assets/aba76328-d8cd-458d-9f45-4b33fbd28d5a" />

### 2. Add missing comma to line 172

### 3. Add message to shareLink
Required, a empty string does not work also.

### 4. Update linkId to link_id
<img width="342" alt="image" src="https://github.com/user-attachments/assets/4efc4f1e-e261-4e06-9bae-417641170d1b" />
