### PR TITLE
Fix Social SDK examples from Direct Messages and Friend List

### DIFF
--- a/docs/discord-social-sdk/development-guides/creating-a-unified-friends-list.mdx
+++ b/docs/discord-social-sdk/development-guides/creating-a-unified-friends-list.mdx
@@ -109,8 +109,8 @@ client->SetStatusChangedCallback([client](discordpp::Client::Status status, disc
         std::cout << "✅ Client is ready! You can now call SDK functions.\n";
         std::cout << "👥 Friends Count: " << client->GetRelationships().size() << std::endl;
         
-        SetRichPresence(*client);
-        DisplayFriendsList(*client);
+        SetRichPresence(client);
+        DisplayFriendsList(client);
 
     } else if (error != discordpp::Client::Error::None) {
         std::cerr << "❌ Connection Error: " << discordpp::Client::ErrorToString(error) << " - Details: " << errorDetail << std::endl;
@@ -142,7 +142,7 @@ This example is for reference only. Please make sure you use efficient data stru
 :::
 
 ```cpp
-void DisplayFriendsList(discordpp::Client& client) {
+void DisplayFriendsList(std::shared_ptr<discordpp::Client> client) {
     // Create vectors for each section
     std::vector<std::string> inGame;
     std::vector<std::string> online;
@@ -180,7 +180,10 @@ void DisplayFriendsList(discordpp::Client& client) {
         }
 
         // Categorize based on status
-        if (user->Status() != discordpp::StatusType::Offline) {
+        if (user->GameActivity()) {
+            // in game
+            inGame.push_back("🟣 " + str);
+        } else if (user->Status() != discordpp::StatusType::Offline) {
             // online
             online.push_back("🟢 " + str);
         } else {

--- a/docs/discord-social-sdk/development-guides/sending-direct-messages.mdx
+++ b/docs/discord-social-sdk/development-guides/sending-direct-messages.mdx
@@ -51,7 +51,7 @@ client->SendUserMessage(recipientId, message, [](auto result, uint64_t messageId
   if (result.Successful()) {
     std::cout << "✅ Message sent successfully\n";
   } else {
-    std::cout << "❌ Failed to send message: " << result.GetError() << "\n";
+    std::cout << "❌ Failed to send message: " << result.Error() << "\n";
   }
 });
 ```


### PR DESCRIPTION
In [Sending Direct Messages - Sending a Direct Message to a User](https://discord.com/developers/docs/discord-social-sdk/development-guides/sending-direct-messages#sending-a-direct-message-to-a-user), it calls `result.GetError()` when it should be `result.Error()`.  

---

In [Creating a Unified Friend List - Step 2: Organize Relationships](https://discord.com/developers/docs/discord-social-sdk/development-guides/creating-a-unified-friends-list#step-2-organize-relationships), `inGame` vector is never filled.  

I'm assuming that this is how I'm suppose to fill because previous example from this page showed:  
```C++
str += " IsOnlineInGame: " + std::to_string(user->GameActivity() != std::nullopt);
```

---

Also in [Creating a Unified Friend List - Step 2: Organize Relationships](https://discord.com/developers/docs/discord-social-sdk/development-guides/creating-a-unified-friends-list#step-2-organize-relationships), `DisplayFriendsList` signature is probably wrong because the code treat client as a pointer (`client->GetRelationships()`).  

I'm assuming that it's a `std::shared_ptr<discordpp::Client>` because in it is in [Getting Started with C++ and the Discord Social SDK](https://discord.com/developers/docs/discord-social-sdk/getting-started/using-c++).  