### PR TITLE
Raise limits for components in messages

### DIFF
--- a/docs/change-log/2025-04-29-component-limits.md
+++ b/docs/change-log/2025-04-29-component-limits.md
@@ -1,0 +1,20 @@
+---
+title: "Raised Component Limits"
+date: "2025-04-29"
+topics:
+- "User Apps"
+- "HTTP API"
+- "Interactions"
+---
+
+We're removing the top level component limit and raising the limit on components in messages to 40 when using the [`IS_COMPONENTS_V2` message flag](/docs/resources/message#message-object-message-flags)! Legacy messages have not changed and continue to allow up to 5 action rows.
+
+#### What's New
+
+- **Total components**: The limit for total components in a message has been increased to 40.
+- **Top-level components**: There is no longer a limit on top level components in a message (previously it was 10).
+
+#### Developer Resources
+
+- Check out our [Component Reference](/docs/components/reference) for detailed specifications on all available components.
+- Learn how to build rich message layouts with components with [Using Message Components](/docs/components/using-message-components).

--- a/docs/change-log/2025-04-29-component-limits.md
+++ b/docs/change-log/2025-04-29-component-limits.md
@@ -7,12 +7,13 @@ topics:
 - "Interactions"
 ---
 
-We're removing the top level component limit and raising the limit on components in messages to 40 when using the [`IS_COMPONENTS_V2` message flag](/docs/resources/message#message-object-message-flags)! Legacy messages have not changed and continue to allow up to 5 action rows.
+We're removing the top level component limit and raising the limit on number of components in a message to 40 when using the [`IS_COMPONENTS_V2` message flag](/docs/resources/message#message-object-message-flags)! We're also removing the limit on the number of components in a [Container Component](/docs/components/reference#container). Legacy messages have not changed and continue to allow up to 5 action rows.
 
 #### What's New
 
 - **Total components**: The limit for total components in a message has been increased to 40.
 - **Top-level components**: There is no longer a limit on top level components in a message (previously it was 10).
+- **[Container Component](/docs/components/reference#container)**: There is no longer a limit on the number of components in a Container Component (previously it was 10).
 
 #### Developer Resources
 

--- a/docs/components/reference.mdx
+++ b/docs/components/reference.mdx
@@ -15,7 +15,7 @@ To use these components, you need to send the [message flag](/docs/resources/mes
 - The `content` and `embeds` fields will no longer work but you'll be able to use [Text Display](/docs/components/reference#text-display) and [Container](/docs/components/reference#container) as replacements
 - Attachments won't show by default - they must be exposed through components
 - The `poll` and `stickers` fields are disabled
-- Messages currently allow up to 10 top-level components and 30 total components
+- Messages allow up to 40 total components
 
 :::info
 [Legacy component behavior](/docs/components/reference#legacy-message-component-behavior) will continue to work but provide less flexibility and control over the message layout.
@@ -1171,6 +1171,10 @@ To upload a file with your message, you'll need to send your payload as `multipa
 Before the introduction of the `IS_COMPONENTS_V2` flag ([see changelog](/docs/change-log/2025-04-22-components-v2)), message components were sent in conjunction with message content. This means that you could send a message using a subset of the available components without setting the `IS_COMPONENTS_V2` flag, and the components would be included in the message content along with `content` and `embeds`.
 
 Apps using this Legacy Message Component behavior will continue to work as expected, but it is recommended to use the new `IS_COMPONENTS_V2` flag for new apps or features as they offer more options for layout and customization.
+
+:::info
+Legacy messages allow up to 5 action rows as top-level components
+:::
 
 Legacy Message Component Example
 

--- a/docs/components/reference.mdx
+++ b/docs/components/reference.mdx
@@ -1080,7 +1080,7 @@ To use this component, you need to send the [message flag](/docs/resources/messa
 
 ## Container
 
-A Container is a top-level layout component that holds up to 10 components. Containers are visually distinct from surrounding components and have an optional customizable color bar.
+A Container is a top-level layout component. Containers are visually distinct from surrounding components and have an optional customizable color bar.
 
 Containers are only available in messages.
 
@@ -1090,13 +1090,13 @@ To use this component, you need to send the [message flag](/docs/resources/messa
 
 ###### Container Structure
 
-| Field         | Type                | Description                                                                                                                                                                                                                                                                                                                                           |
-|---------------|---------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| type          | integer             | `17` for container component                                                                                                                                                                                                                                                                                                                          |
-| id?           | integer             | Optional identifier for component                                                                                                                                                                                                                                                                                                                     |
-| components    | array of components | Up to 10 components of the type [action row](/docs/components/reference#action-row), [text display](/docs/components/reference#text-display), [section](/docs/components/reference#section), [media gallery](/docs/components/reference#media-gallery), [separator](/docs/components/reference#separator), or [file](/docs/components/reference#file) |
-| accent_color? | ?integer            | Color for the accent on the container as RGB from `0x000000` to `0xFFFFFF`                                                                                                                                                                                                                                                                            |
-| spoiler?      | boolean             | Whether the container should be a spoiler (or blurred out). Defaults to `false`.                                                                                                                                                                                                                                                                      |
+| Field         | Type                | Description                                                                                                                                                                                                                                                                                                                                  |
+|---------------|---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| type          | integer             | `17` for container component                                                                                                                                                                                                                                                                                                                 |
+| id?           | integer             | Optional identifier for component                                                                                                                                                                                                                                                                                                            |
+| components    | array of components | Components of the type [action row](/docs/components/reference#action-row), [text display](/docs/components/reference#text-display), [section](/docs/components/reference#section), [media gallery](/docs/components/reference#media-gallery), [separator](/docs/components/reference#separator), or [file](/docs/components/reference#file) |
+| accent_color? | ?integer            | Color for the accent on the container as RGB from `0x000000` to `0xFFFFFF`                                                                                                                                                                                                                                                                   |
+| spoiler?      | boolean             | Whether the container should be a spoiler (or blurred out). Defaults to `false`.                                                                                                                                                                                                                                                             |
 
 ###### Example
 


### PR DESCRIPTION
We're removing the top level component limit and raising the limit on number of components in a message to 40 when using the `IS_COMPONENTS_V2` message flag. We're also removing the limit on the number of components in a Container Component. Legacy messages have not changed and continue to allow up to 5 action rows.