### PR TITLE
CV2: Add missing limits for alt texts, ID clarifications

### DIFF
--- a/docs/components/reference.mdx
+++ b/docs/components/reference.mdx
@@ -924,7 +924,7 @@ To use this component, you need to send the [message flag](/docs/resources/messa
 | type         | integer                                                                         | `11` for thumbnail component                                                    |
 | id?          | integer                                                                         | Optional identifier for component                                               |
 | media        | [unfurled media item](/docs/components/reference#unfurled-media-item-structure) | A url or attachment                                                             |
-| description? | string                                                                          | Alt text for the media                                                          |
+| description? | string                                                                          | Alt text for the media, max 1024 characters                                     |
 | spoiler?     | boolean                                                                         | Whether the thumbnail should be a spoiler (or blurred out). Defaults to `false` |
 
 ###### Example
@@ -954,7 +954,7 @@ To use this component, you need to send the [message flag](/docs/resources/messa
 | Field        | Type                                                                            | Description                                                                 |
 |--------------|---------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
 | media        | [unfurled media item](/docs/components/reference#unfurled-media-item-structure) | A url or attachment                                                         |
-| description? | string                                                                          | Alt text for the media                                                      |
+| description? | string                                                                          | Alt text for the media, max 1024 characters                                 |
 | spoiler?     | boolean                                                                         | Whether the media should be a spoiler (or blurred out). Defaults to `false` |
 
 ###### Example

--- a/docs/components/reference.mdx
+++ b/docs/components/reference.mdx
@@ -66,10 +66,6 @@ All components have the following fields:
 
 The `id` field is optional and is used to identify components in the response from an interaction that aren't interactive components. The `id` must be unique within the message and is generated sequentially if left empty. Generation of `id`s won't use another `id` that exists in the message if you have one defined for another component.
 
-::: info
-Messages preceding components V2 will contain an `id` of `0`, sending `0` is allowed but will be incremented to `1` then follow the numbering rule mentioned above.
-:::
-
 ###### Custom ID
 
 Additionally, interactive components like buttons and selects must have a `custom_id` field. The developer defines this field when sending the component payload, and it is returned in the interaction payload sent when a user interacts with the component. For example, if you set `custom_id: click_me` on a button, you'll receive an interaction containing `custom_id: click_me` when a user clicks that button.
@@ -1175,6 +1171,8 @@ To upload a file with your message, you'll need to send your payload as `multipa
 ## Legacy Message Component Behavior
 
 Before the introduction of the `IS_COMPONENTS_V2` flag ([see changelog](/docs/change-log/2025-04-22-components-v2)), message components were sent in conjunction with message content. This means that you could send a message using a subset of the available components without setting the `IS_COMPONENTS_V2` flag, and the components would be included in the message content along with `content` and `embeds`.
+
+Messages preceding components V2 will contain an `id` of `0`, sending back `0` is allowed but will be incremented to 1, then generated sequentially while avoiding duplicates.
 
 Apps using this Legacy Message Component behavior will continue to work as expected, but it is recommended to use the new `IS_COMPONENTS_V2` flag for new apps or features as they offer more options for layout and customization.
 

--- a/docs/components/reference.mdx
+++ b/docs/components/reference.mdx
@@ -64,7 +64,7 @@ All components have the following fields:
 | type  | integer | The [type](/docs/components/reference#component-object-component-types) of the component |
 | id?   | integer | 32 bit integer used as an optional identifier for component                              |
 
-The `id` field is optional and is used to identify components in the response from an interaction that aren't interactive components. The `id` must be unique within the message and is generated sequentially if left empty. Generation of `id`s won't use another `id` that exists in the message if you have one defined for another component.
+The `id` field is optional and is used to identify components in the response from an interaction. The `id` must be unique within the message and is generated sequentially if left empty. Generation of `id`s won't use another `id` that exists in the message if you have one defined for another component. Sending components with an `id` of `0` is allowed but will be treated as empty and replaced by the API.
 
 ###### Custom ID
 
@@ -1172,7 +1172,7 @@ To upload a file with your message, you'll need to send your payload as `multipa
 
 Before the introduction of the `IS_COMPONENTS_V2` flag ([see changelog](/docs/change-log/2025-04-22-components-v2)), message components were sent in conjunction with message content. This means that you could send a message using a subset of the available components without setting the `IS_COMPONENTS_V2` flag, and the components would be included in the message content along with `content` and `embeds`.
 
-Messages preceding components V2 will contain an `id` of `0`, sending back `0` is allowed but will be incremented to 1, then generated sequentially while avoiding duplicates.
+Additionally, components of messages preceding components V2 will contain an `id` of `0`.
 
 Apps using this Legacy Message Component behavior will continue to work as expected, but it is recommended to use the new `IS_COMPONENTS_V2` flag for new apps or features as they offer more options for layout and customization.
 

--- a/docs/components/reference.mdx
+++ b/docs/components/reference.mdx
@@ -66,6 +66,10 @@ All components have the following fields:
 
 The `id` field is optional and is used to identify components in the response from an interaction that aren't interactive components. The `id` must be unique within the message and is generated sequentially if left empty. Generation of `id`s won't use another `id` that exists in the message if you have one defined for another component.
 
+::: info
+Messages preceding components V2 will contain an `id` of `0`, sending `0` is allowed but will be incremented to `1` then follow the numbering rule mentioned above.
+:::
+
 ###### Custom ID
 
 Additionally, interactive components like buttons and selects must have a `custom_id` field. The developer defines this field when sending the component payload, and it is returned in the interaction payload sent when a user interacts with the component. For example, if you set `custom_id: click_me` on a button, you'll receive an interaction containing `custom_id: click_me` when a user clicks that button.


### PR DESCRIPTION
- Added limits to alt text of Thumbnail and Media Gallery Item
- Added details on pre-CV2 component IDs
- Added details of the behavior when sending `0` IDs