### PR TITLE
Fix extra parenthesis in Acitivites/Development Guides/Local Development

### DIFF
--- a/docs/activities/development-guides/local-development.mdx
+++ b/docs/activities/development-guides/local-development.mdx
@@ -56,7 +56,7 @@ The flow for setting up your production application is very similar:
 1. If not made yet, create a new application.
 2. Enable Activities for your app.
 3. Set up the application's [URL Mapping](/docs/activities/development-guides/local-development#url-mapping). The URL for your application's html should be set to the `/` route.
-4. Follow the instructions for [Launching your Application from the Discord Client](/docs/activities/development-guides/local-development#launch-your-application-from-the-discord-client)). Application URL Override should not be enabled.
+4. Follow the instructions for [Launching your Application from the Discord Client](/docs/activities/development-guides/local-development#launch-your-application-from-the-discord-client). Application URL Override should not be enabled.
 
 This application now uses the same configuration it will use once it is fully published ✨.
 ![application-test-mode-prod](images/activities/application-test-mode-prod.gif)


### PR DESCRIPTION
Fixed a typo in the Activities Local Development guide