### PR TITLE
fix: set announce transition opcode as a binary message

### DIFF
--- a/docs/topics/opcodes-and-status-codes.md
+++ b/docs/topics/opcodes-and-status-codes.md
@@ -71,7 +71,7 @@ Our voice gateways have their own set of opcodes and close codes.
 | 26   | DAVE MLS Key Package                | client            | MLS Key Package for pending group member                 | X      |
 | 27   | DAVE MLS Proposals                  | server            | MLS Proposals to be appended or revoked                  | X      |
 | 28   | DAVE MLS Commit Welcome             | client            | MLS Commit with optional MLS Welcome messages            | X      |
-| 29   | DAVE MLS Announce Commit Transition | server            | MLS Commit to be processed for upcoming transition       |        |
+| 29   | DAVE MLS Announce Commit Transition | server            | MLS Commit to be processed for upcoming transition       | X      |
 | 30   | DAVE MLS Welcome                    | server            | MLS Welcome to group for upcoming transition             | X      |
 | 31   | DAVE MLS Invalid Commit Welcome     | client            | Flag invalid commit or welcome, request re-add           |        |
 


### PR DESCRIPTION
This opcode is a binary message according to the [DAVE protocol whitepaper](https://daveprotocol.com/#dave_mls_announce_commit_transition-29).