### PR TITLE
Better Unity Social SDK project setup wording

### DIFF
--- a/docs/discord-social-sdk/getting-started/using-unity.mdx
+++ b/docs/discord-social-sdk/getting-started/using-unity.mdx
@@ -52,7 +52,7 @@ Let's set up your Unity project to include the Social SDK package and add the ne
 1. Create a new 2D project in Unity Hub using Unity version 2021.3 or later
 2. Either:
     1. Unzip the zip file in the Unity `Packages` folder, or
-    2. Unzip the zip file and [Install Package from Disk](https://docs.unity3d.com/Manual/upm-ui-local.html). Make sure the folder is in a permanent spot as Unity will reference it from that location.
+    2. Unzip the zip file and [Install Package from Disk](https://docs.unity3d.com/Manual/upm-ui-local.html). Make sure the folder is in a directory that won't get moved or deleted as your Unity project will load it from that location.
 3. In your project add a `Scripts` folder and create a `DiscordManager.cs` script
 4. Add the following code to `DiscordManager.cs`:
 ```cs

--- a/docs/discord-social-sdk/getting-started/using-unity.mdx
+++ b/docs/discord-social-sdk/getting-started/using-unity.mdx
@@ -51,8 +51,8 @@ Let's set up your Unity project to include the Social SDK package and add the ne
 
 1. Create a new 2D project in Unity Hub using Unity version 2021.3 or later
 2. Either:
-    1. Unzip the zip file in the `Packages` folder, or
-    2. Unzip the zip file to a temporary location, and [Install Package from Disk](https://docs.unity3d.com/Manual/upm-ui-local.html) from the temporary location.
+    1. Unzip the zip file in the Unity `Packages` folder, or
+    2. Unzip the zip file and [Install Package from Disk](https://docs.unity3d.com/Manual/upm-ui-local.html). Make sure the folder is in a permanent spot as Unity will reference it from that location.
 3. In your project add a `Scripts` folder and create a `DiscordManager.cs` script
 4. Add the following code to `DiscordManager.cs`:
 ```cs


### PR DESCRIPTION
Using `Install Package from Disk` in Unity actually references that package wherever it lives. Temporary here makes it sound like you can delete that folder after and it will still work but it won't. 