### PR TITLE
fix: CV2 File Display Component is missing name & size

### DIFF
--- a/docs/components/reference.mdx
+++ b/docs/components/reference.mdx
@@ -1033,6 +1033,8 @@ To use this component, you need to send the [message flag](/docs/resources/messa
 | id?      | integer                                                                         | Optional identifier for component                                                                                                |
 | file     | [unfurled media item](/docs/components/reference#unfurled-media-item-structure) | This unfurled media item is unique in that it **only** supports attachment references using the `attachment://<filename>` syntax |
 | spoiler? | boolean                                                                         | Whether the media should be a spoiler (or blurred out). Defaults to `false`                                                      |
+| name\*   | string                                                                          | The name of the file. This field is ignored and provided by the API as part of the response                                      |
+| size\*   | integer                                                                         | The size of the file in bytes. This field is ignored and provided by the API as part of the response                             |
 
 ###### Example
 

--- a/docs/components/reference.mdx
+++ b/docs/components/reference.mdx
@@ -1033,8 +1033,8 @@ To use this component, you need to send the [message flag](/docs/resources/messa
 | id?      | integer                                                                         | Optional identifier for component                                                                                                |
 | file     | [unfurled media item](/docs/components/reference#unfurled-media-item-structure) | This unfurled media item is unique in that it **only** supports attachment references using the `attachment://<filename>` syntax |
 | spoiler? | boolean                                                                         | Whether the media should be a spoiler (or blurred out). Defaults to `false`                                                      |
-| name\*   | string                                                                          | The name of the file. This field is ignored and provided by the API as part of the response                                      |
-| size\*   | integer                                                                         | The size of the file in bytes. This field is ignored and provided by the API as part of the response                             |
+| name     | string                                                                          | The name of the file. This field is ignored and provided by the API as part of the response                                      |
+| size     | integer                                                                         | The size of the file in bytes. This field is ignored and provided by the API as part of the response                             |
 
 ###### Example
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5cbc3e44-316f-4573-b106-9d515d115265)

Ref: https://canary.discord.com/channels/1317206872763404478/1317208024682725426/1382134778161270844

CC @DV8FromTheWorld 