### PR TITLE
docs: Document attachment_id for unfurled media items

### DIFF
--- a/docs/components/reference.mdx
+++ b/docs/components/reference.mdx
@@ -1193,13 +1193,16 @@ To use this component, you need to send the [message flag](/docs/resources/messa
 
 ## Unfurled Media Item Structure
 
-| Field         | Type     | Description                                                                                                                                      |
-|---------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| url           | string   | Supports arbitrary urls and `attachment://<filename>` references                                                                                 |
-| proxy_url?    | string   | The proxied url of the media item. This field is ignored and provided by the API as part of the response                                         |
-| height?       | ?integer | The height of the media item. This field is ignored and provided by the API as part of the response                                              |
-| width?        | ?integer | The width of the media item. This field is ignored and provided by the API as part of the response                                               |
-| content_type? | string   | The [media type](https://en.wikipedia.org/wiki/Media_type) of the content. This field is ignored and provided by the API as part of the response |
+| Field            | Type      | Description                                                                                                                                      |
+|------------------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| url              | string    | Supports arbitrary urls and `attachment://<filename>` references                                                                                 |
+| proxy_url?       | string    | The proxied url of the media item. This field is ignored and provided by the API as part of the response                                         |
+| height?          | ?integer  | The height of the media item. This field is ignored and provided by the API as part of the response                                              |
+| width?           | ?integer  | The width of the media item. This field is ignored and provided by the API as part of the response                                               |
+| content_type?    | string    | The [media type](https://en.wikipedia.org/wiki/Media_type) of the content. This field is ignored and provided by the API as part of the response |
+| attachment_id?\* | snowflake | The id of the uploaded attachment. This field is ignored and provided by the API as part of the response                                         |
+
+\* Only present if the media item was uploaded as an attachment.
 
 ### Uploading a file
 


### PR DESCRIPTION
Unfurled Media Items now send back the attachment id (for uploaded and through `attachment://` referenced files)
![image](https://github.com/user-attachments/assets/c4540283-3571-409d-a8b0-732e1cc6635a)

References: 
- https://github.com/discord/discord/pull/223547
- https://github.com/discord/discord-api-spec/commit/2a2605c2df77df198aef8fc78e298a3652cbd746
- https://canary.discord.com/channels/1317206872763404478/1317208024682725426/1382093955138719897
