### PR TITLE
Specify that the additional partial member field is optional

### DIFF
--- a/docs/events/gateway-events.mdx
+++ b/docs/events/gateway-events.mdx
@@ -1001,7 +1001,7 @@ Sent when a message is created. The inner payload is a [message](/docs/resources
 |-----------|-------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
 | guild_id? | snowflake                                                                                                                                       | ID of the guild the message was sent in - unless it is an ephemeral message                            |
 | member?   | partial [guild member](/docs/resources/guild#guild-member-object) object                                                                        | Member properties for this message's author. Missing for ephemeral messages and messages from webhooks |
-| mentions  | array of [user](/docs/resources/user#user-object) objects, with an additional partial [member](/docs/resources/guild#guild-member-object) field | Users specifically mentioned in the message                                                            |
+| mentions  | array of [user](/docs/resources/user#user-object) objects, optionally with an additional partial [member](/docs/resources/guild#guild-member-object) field | Users specifically mentioned in the message                                                            |
 
 #### Message Update
 

--- a/docs/events/gateway-events.mdx
+++ b/docs/events/gateway-events.mdx
@@ -997,10 +997,10 @@ Sent when a message is created. The inner payload is a [message](/docs/resources
 
 ###### Message Create Extra Fields
 
-| Field     | Type                                                                                                                                            | Description                                                                                            |
-|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
-| guild_id? | snowflake                                                                                                                                       | ID of the guild the message was sent in - unless it is an ephemeral message                            |
-| member?   | partial [guild member](/docs/resources/guild#guild-member-object) object                                                                        | Member properties for this message's author. Missing for ephemeral messages and messages from webhooks |
+| Field     | Type                                                                                                                                                       | Description                                                                                            |
+|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
+| guild_id? | snowflake                                                                                                                                                  | ID of the guild the message was sent in - unless it is an ephemeral message                            |
+| member?   | partial [guild member](/docs/resources/guild#guild-member-object) object                                                                                   | Member properties for this message's author. Missing for ephemeral messages and messages from webhooks |
 | mentions  | array of [user](/docs/resources/user#user-object) objects, optionally with an additional partial [member](/docs/resources/guild#guild-member-object) field | Users specifically mentioned in the message                                                            |
 
 #### Message Update


### PR DESCRIPTION
I came across a parsing error in `zigcord` (https://codeberg.org/lipfang/zigcord) which had incorrectly assumed that the `member` field within `mentions` array of the Message Create gateway event was required.

Not quite sure if this falls under "subjective wording changes" in the contributing guidelines, but I feel that the statement is incorrect since it seems to assert that the `member` field is required.

The following message is an example of a message which contains a `mentions` property that contains users which don't have `member` fields. It is a message from the Wordle Discord Bot with a summary of those who have played wordle today, mentioning many guild members.

https://gist.github.com/lipfangmoe/6130b9a42a4396ddb4f62ec91c0a6527