### PR TITLE
Update the description for identity_enabled to be clearer

### DIFF
--- a/docs/resources/user.mdx
+++ b/docs/resources/user.mdx
@@ -120,7 +120,7 @@ Premium types denote the level of premium a user has. Visit the [Nitro](https://
 ###### User Primary Guild
 
 | Field             | Type       | Description                                                                                                                                                                                             |
-|-------------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+|-------------------|------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | identity_guild_id | ?snowflake | the id of the user's primary guild                                                                                                                                                                      |
 | identity_enabled  | ?boolean   | whether the user is displaying the primary guild's server tag. This can be ``null``, if the system clears the identity, e.g. because the server no longer supports tags. This rarely returns ``false``. |
 | tag               | ?string    | the text of the user's server tag. Limited to 4 characters                                                                                                                                              |

--- a/docs/resources/user.mdx
+++ b/docs/resources/user.mdx
@@ -119,12 +119,12 @@ Premium types denote the level of premium a user has. Visit the [Nitro](https://
 
 ###### User Primary Guild
 
-| Field             | Type       | Description                                                                                                                                                                                                                      |
-|-------------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| identity_guild_id | ?snowflake | the id of the user's primary guild                                                                                                                                                                                               |
-| identity_enabled  | ?boolean   | whether the user is displaying the primary guild's server tag. This can be ``null`` if the system clears the identity, e.g. the server no longer supports tags. This can be ``false``, e.g. the user manually removes their tag. |
-| tag               | ?string    | the text of the user's server tag. Limited to 4 characters                                                                                                                                                                       |
-| badge             | ?string    | the [server tag badge hash](/docs/reference#image-formatting)                                                                                                                                                                    |
+| Field             | Type       | Description                                                                                                                                                                                                                  |
+|-------------------|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| identity_guild_id | ?snowflake | the id of the user's primary guild                                                                                                                                                                                           |
+| identity_enabled  | ?boolean   | whether the user is displaying the primary guild's server tag. This can be `null` if the system clears the identity, e.g. the server no longer supports tags. This can be `false`, e.g. the user manually removes their tag. |
+| tag               | ?string    | the text of the user's server tag. Limited to 4 characters                                                                                                                                                                   |
+| badge             | ?string    | the [server tag badge hash](/docs/reference#image-formatting)                                                                                                                                                                |
 
 ### Avatar Decoration Data Object
 

--- a/docs/resources/user.mdx
+++ b/docs/resources/user.mdx
@@ -119,12 +119,12 @@ Premium types denote the level of premium a user has. Visit the [Nitro](https://
 
 ###### User Primary Guild
 
-| Field             | Type       | Description                                                                                                                                                                                                                  |
-|-------------------|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| identity_guild_id | ?snowflake | the id of the user's primary guild                                                                                                                                                                                           |
-| identity_enabled  | ?boolean   | whether the user is displaying the primary guild's server tag. This can be `null` if the system clears the identity, e.g. the server no longer supports tags. This can be `false`, e.g. the user manually removes their tag. |
-| tag               | ?string    | the text of the user's server tag. Limited to 4 characters                                                                                                                                                                   |
-| badge             | ?string    | the [server tag badge hash](/docs/reference#image-formatting)                                                                                                                                                                |
+| Field             | Type       | Description                                                                                                                                                                                                                |
+|-------------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| identity_guild_id | ?snowflake | the id of the user's primary guild                                                                                                                                                                                         |
+| identity_enabled  | ?boolean   | whether the user is displaying the primary guild's server tag. This can be `null` if the system clears the identity, e.g. the server no longer supports tags. This will be `false` if the user manually removes their tag. |
+| tag               | ?string    | the text of the user's server tag. Limited to 4 characters                                                                                                                                                                 |
+| badge             | ?string    | the [server tag badge hash](/docs/reference#image-formatting)                                                                                                                                                              |
 
 ### Avatar Decoration Data Object
 

--- a/docs/resources/user.mdx
+++ b/docs/resources/user.mdx
@@ -119,12 +119,12 @@ Premium types denote the level of premium a user has. Visit the [Nitro](https://
 
 ###### User Primary Guild
 
-| Field             | Type       | Description                                                                                                                                                           |
-|-------------------|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| identity_guild_id | ?snowflake | the id of the user's primary guild                                                                                                                                    |
-| identity_enabled  | ?boolean   | whether the user is displaying the primary guild's server tag. This can be `null` if the system clears the identity, e.g. because the server no longer supports tags. |
-| tag               | ?string    | the text of the user's server tag. Limited to 4 characters                                                                                                            |
-| badge             | ?string    | the [server tag badge hash](/docs/reference#image-formatting)                                                                                                         |
+| Field             | Type       | Description                                                                                                                                                                                             |
+|-------------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| identity_guild_id | ?snowflake | the id of the user's primary guild                                                                                                                                                                      |
+| identity_enabled  | ?boolean   | whether the user is displaying the primary guild's server tag. This can be ``null``, if the system clears the identity, e.g. because the server no longer supports tags. This rarely returns ``false``. |
+| tag               | ?string    | the text of the user's server tag. Limited to 4 characters                                                                                                                                              |
+| badge             | ?string    | the [server tag badge hash](/docs/reference#image-formatting)                                                                                                                                           |
 
 ### Avatar Decoration Data Object
 

--- a/docs/resources/user.mdx
+++ b/docs/resources/user.mdx
@@ -122,7 +122,7 @@ Premium types denote the level of premium a user has. Visit the [Nitro](https://
 | Field             | Type       | Description                                                                                                                                                                                             |
 |-------------------|------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | identity_guild_id | ?snowflake | the id of the user's primary guild                                                                                                                                                                      |
-| identity_enabled  | ?boolean   | whether the user is displaying the primary guild's server tag. This can be ``null``, if the system clears the identity, e.g. because the server no longer supports tags. This rarely returns ``false``. |
+| identity_enabled  | ?boolean   | whether the user is displaying the primary guild's server tag. This can be ``null`` if the system clears the identity, e.g. because the server no longer supports tags. This rarely returns ``false``. |
 | tag               | ?string    | the text of the user's server tag. Limited to 4 characters                                                                                                                                              |
 | badge             | ?string    | the [server tag badge hash](/docs/reference#image-formatting)                                                                                                                                           |
 

--- a/docs/resources/user.mdx
+++ b/docs/resources/user.mdx
@@ -119,12 +119,12 @@ Premium types denote the level of premium a user has. Visit the [Nitro](https://
 
 ###### User Primary Guild
 
-| Field             | Type       | Description                                                                                                                                                                                             |
-|-------------------|------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| identity_guild_id | ?snowflake | the id of the user's primary guild                                                                                                                                                                      |
-| identity_enabled  | ?boolean   | whether the user is displaying the primary guild's server tag. This can be ``null`` if the system clears the identity, e.g. because the server no longer supports tags. This rarely returns ``false``. |
-| tag               | ?string    | the text of the user's server tag. Limited to 4 characters                                                                                                                                              |
-| badge             | ?string    | the [server tag badge hash](/docs/reference#image-formatting)                                                                                                                                           |
+| Field             | Type       | Description                                                                                                                                                                                                                      |
+|-------------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| identity_guild_id | ?snowflake | the id of the user's primary guild                                                                                                                                                                                               |
+| identity_enabled  | ?boolean   | whether the user is displaying the primary guild's server tag. This can be ``null`` if the system clears the identity, e.g. the server no longer supports tags. This can be ``false``, e.g. the user manually removes their tag. |
+| tag               | ?string    | the text of the user's server tag. Limited to 4 characters                                                                                                                                                                       |
+| badge             | ?string    | the [server tag badge hash](/docs/reference#image-formatting)                                                                                                                                                                    |
 
 ### Avatar Decoration Data Object
 


### PR DESCRIPTION
Discussion from the ddevs server: https://discord.com/channels/613425648685547541/1130595287078015027/1397115430438440981

Basically, it was noted that identity_enabled mostly returns `null` instead of `false`. 
This PR basically adds that it rarely returns `false`.