### PR TITLE
Social SDK: Add Explainer video to overview page

### DIFF
--- a/docs/discord-social-sdk/overview.mdx
+++ b/docs/discord-social-sdk/overview.mdx
@@ -36,11 +36,17 @@ Start integrating the SDK into your game with our getting started guides, design
   </Card>
 </Container>
 
+<iframe width="100%" height="380"
+        src="https://www.youtube.com/embed/pInGO8AvojE?si=VnChE6xbuy4jNzSx"
+        title="YouTube video player" frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 ---
 
 ## Limited Access Features
 
-Discord Social SDK features for text and voice communication are available but have limited access. 
+Discord Social SDK features for text and voice communication are available but have limited access.
 
 :::preview
 For more information on how to access these features, please see [Core Concepts: Limited Access Features](/docs/discord-social-sdk/core-concepts#limited-access-features).
@@ -50,7 +56,7 @@ For more information on how to access these features, please see [Core Concepts:
 
 ## Get Help & Join the Community
 
-Need support or looking to connect with other game developers? 
+Need support or looking to connect with other game developers?
 
 - Join our [DDevs Discord Server](https://discord.gg/discord-developers) and get help from the community, share best practices, and discover new ways to enhance your game. Find us in the `#social-sdk-dev-help` channel!
 - For additional support, you can [file a ticket with Developer Support](https://dis.gd/social-sdk) to report issues.


### PR DESCRIPTION
Puts the explainer video on the bottom of the Discord SDK Overview page
- let's see how it does!

