### PR TITLE
Social SDK: Remove "cross-platform" language

### DIFF
--- a/docs/discord-social-sdk/development-guides.mdx
+++ b/docs/discord-social-sdk/development-guides.mdx
@@ -48,7 +48,7 @@ If you are new to the Discord Social SDK, we recommend you start with the [Getti
     Display detailed game status in Discord profiles.
   </Card>
   <Card title="Managing Game Invites" link="/docs/discord-social-sdk/development-guides/managing-game-invites" icon="InboxIcon">
-    Implement cross-platform game invites.
+    Allow players to invite friends to join their game session or party.
   </Card>
 </Container>
 

--- a/docs/discord-social-sdk/development-guides/linked-channels.mdx
+++ b/docs/discord-social-sdk/development-guides/linked-channels.mdx
@@ -13,7 +13,7 @@ import CommsScopeWarning from '../partials/callouts/oauth-comms-scopes.mdx';
 
 ## Overview
 
-Linked Channels let players connect in-game lobbies with Discord text channels, enabling cross-platform chat between your game and Discord servers.
+Linked Channels let players connect in-game lobbies with Discord text channels, enabling chat between your game and Discord servers.
 
 When linked:
 - In-game messages appear in the Discord channel

--- a/docs/discord-social-sdk/development-guides/sending-direct-messages.mdx
+++ b/docs/discord-social-sdk/development-guides/sending-direct-messages.mdx
@@ -141,7 +141,7 @@ Now that you know how to send and receive messages, check out these other Discor
     Bring players together in a shared lobby with invites, text chat, and voice comms.
   </Card>
   <Card title="Linked Channels" link="/docs/discord-social-sdk/development-guides/linked-channels" icon="TextControllerIcon">
-    Enable cross-platform text chat between a Discord channel and your game.
+    Enable text chat between a Discord channel and your game.
   </Card>
 </Container>
 


### PR DESCRIPTION
Change language around "cross-platform" as it's definition to game developers doesn't align with the original intent in the documentation.
