### PR TITLE
[Social SDK] Move several pages into the How-to section

### DIFF
--- a/docs/discord-social-sdk/development-guides.mdx
+++ b/docs/discord-social-sdk/development-guides.mdx
@@ -13,9 +13,6 @@ subpages:
  - development-guides/managing-lobbies.mdx
  - development-guides/linked-channels.mdx
  - development-guides/managing-voice-chat.mdx
- - development-guides/integrating-moderation.mdx
- - development-guides/debugging-logging.mdx
- - development-guides/using-with-discord-apis.mdx
 ---
 
 [Home](/docs/intro) > [Discord Social SDK](/docs/discord-social-sdk/overview) > Development Guides
@@ -73,14 +70,4 @@ If you are new to the Discord Social SDK, we recommend you start with the [Getti
 ## Developer Best Practices
 
 <Container>
-  <Card title="Debugging & Logging" link="/docs/discord-social-sdk/development-guides/debugging-logging" icon="BugIcon">
-    Use logging and debugging tools to troubleshoot issues.
-  </Card>
-  <Card title="Integrating Moderation" link="/docs/discord-social-sdk/development-guides/integrating-moderation"
-        icon="ShieldIcon">
-      Integrating and managing content moderation for your game when using the Discord Social SDK.
-  </Card>
-  <Card title="Using with Discord APIs" link="/docs/discord-social-sdk/development-guides/using-with-discord-apis" icon="ClydeIcon">
-    Make requests to Discord's HTTP APIs from your game.
-  </Card>
 </Container>

--- a/docs/discord-social-sdk/development-guides/managing-lobbies.mdx
+++ b/docs/discord-social-sdk/development-guides/managing-lobbies.mdx
@@ -62,7 +62,7 @@ There are two ways to manage lobbies:
 
 You can use the Discord HTTP API to create, update, and delete lobbies and manage lobby membership. 
 
-See the [Lobby](/docs/resources/lobby) API resource for available endpoints and [Using with Discord APIs](/docs/discord-social-sdk/development-guides/using-with-discord-apis) for information on how to authenticate your requests.
+See the [Lobby](/docs/resources/lobby) API resource for available endpoints and [Use with Discord APIs](/docs/discord-social-sdk/how-to/use-with-discord-apis) for information on how to authenticate your requests.
 
 :::info
 Clients will not be able to use [`Client::CreateOrJoinLobby`] or [`Client::LeaveLobby`] with lobbies created using the API.

--- a/docs/discord-social-sdk/development-guides/managing-voice-chat.mdx
+++ b/docs/discord-social-sdk/development-guides/managing-voice-chat.mdx
@@ -278,11 +278,11 @@ This information is particularly useful for:
 ## Next Steps
 
 <Container>
-    <Card title="Integrating Moderation" link="/docs/discord-social-sdk/development-guides/integrating-moderation"
+    <Card title="Integrate Moderation" link="/docs/discord-social-sdk/how-to/integrate-moderation"
           icon="ShieldIcon">
         Integrating and managing content moderation for your game when using the Discord Social SDK.
     </Card>
-    <Card title="Using with Discord APIs" link="/docs/discord-social-sdk/development-guides/using-with-discord-apis" icon="ClydeIcon">
+    <Card title="Use with Discord APIs" link="/docs/discord-social-sdk/how-to/use-with-discord-apis" icon="ClydeIcon">
         Make requests to Discord's HTTP APIs from your game.
     </Card>
     <Card title="Managing Game Invites" link="/docs/discord-social-sdk/development-guides/managing-game-invites"

--- a/docs/discord-social-sdk/how-to.mdx
+++ b/docs/discord-social-sdk/how-to.mdx
@@ -2,6 +2,9 @@
 sidebar_label: How To
 showTOC: false
 subpages:
+  - how-to/debug-log.mdx
+  - how-to/use-with-discord-apis.mdx
+  - how-to/integrate-moderation.mdx
   - how-to/handle-special-characters-display-names.mdx
 ---
 
@@ -12,9 +15,21 @@ subpages:
 These how-to guides offer common solutions for integrating Discord Social SDK features into your game.
 
 <Container>
-  <Card title="Handle Special Characters in Display Names" link="/docs/discord-social-sdk/how-to/handle-special-characters-display-names" icon="LettersIcon">
-    Handling Unicode characters in Discord Display Names for your game's chat and friend lists.
-  </Card>
+    <Card title="Debug & Log" link="/docs/discord-social-sdk/how-to/debug-log" icon="BugIcon">
+        Use logging and debugging tools to troubleshoot issues.
+    </Card>
+    <Card title="Use with Discord APIs" link="/docs/discord-social-sdk/how-to/use-with-discord-apis"
+          icon="ClydeIcon">
+        Make requests to Discord's HTTP APIs from your game.
+    </Card>
+    <Card title="Integrate Moderation" link="/docs/discord-social-sdk/how-to/integrate-moderation"
+          icon="ShieldIcon">
+        Integrating and managing content moderation for your game when using the Discord Social SDK.
+    </Card>
+    <Card title="Handle Special Characters in Display Names"
+          link="/docs/discord-social-sdk/how-to/handle-special-characters-display-names" icon="LettersIcon">
+        Handling Unicode characters in Discord Display Names for your game's chat and friend lists.
+    </Card>
 </Container>
 
 ---
@@ -23,4 +38,5 @@ These how-to guides offer common solutions for integrating Discord Social SDK fe
 
 | Date          | Changes               |
 |---------------|-----------------------|
+| July 23, 2025 | migrated several docs |
 | June 17, 2025 | added How To category |

--- a/docs/discord-social-sdk/how-to/debug-log.mdx
+++ b/docs/discord-social-sdk/how-to/debug-log.mdx
@@ -1,10 +1,10 @@
 ---
-sidebar_label: Debugging & Logging
+sidebar_label: Debug & Log
 ---
 import PublicClient from '../partials/callouts/public-client.mdx';
 import SupportCallout from '../partials/callouts/support.mdx';
 
-[Home](/docs/intro) > [Discord Social SDK](/docs/discord-social-sdk/overview) > [Development Guides](/docs/discord-social-sdk/development-guides) > {sidebar_label}
+[Home](/docs/intro) > [Discord Social SDK](/docs/discord-social-sdk/overview) > [How To](/docs/discord-social-sdk/how-to) > {sidebar_label}
 
 # {sidebar_label}
 

--- a/docs/discord-social-sdk/how-to/integrate-moderation.mdx
+++ b/docs/discord-social-sdk/how-to/integrate-moderation.mdx
@@ -1,10 +1,10 @@
 ---
-sidebar_label: Integrating Moderation
+sidebar_label: Integrate Moderation
 ---
 import PublicClient from '../partials/callouts/public-client.mdx';
 import SupportCallout from '../partials/callouts/support.mdx';
 
-[Home](/docs/intro) > [Discord Social SDK](/docs/discord-social-sdk/overview) > [Development Guides](/docs/discord-social-sdk/development-guides) > {sidebar_label}
+[Home](/docs/intro) > [Discord Social SDK](/docs/discord-social-sdk/overview) > [How To](/docs/discord-social-sdk/how-to) > {sidebar_label}
 
 # Moderation with the Discord Social SDK
 

--- a/docs/discord-social-sdk/how-to/use-with-discord-apis.mdx
+++ b/docs/discord-social-sdk/how-to/use-with-discord-apis.mdx
@@ -1,10 +1,10 @@
 ---
-sidebar_label: Using with Discord APIs
+sidebar_label: Use with Discord APIs
 ---
 import PublicClient from '../partials/callouts/public-client.mdx';
 import SupportCallout from '../partials/callouts/support.mdx';
 
-[Home](/docs/intro) > [Discord Social SDK](/docs/discord-social-sdk/overview) > [Development Guides](/docs/discord-social-sdk/development-guides) > {sidebar_label}
+[Home](/docs/intro) > [Discord Social SDK](/docs/discord-social-sdk/overview) > [How To](/docs/discord-social-sdk/how-to) > {sidebar_label}
 
 # {sidebar_label}
 


### PR DESCRIPTION
This PR moves Debugging and Logging, Using with the Discord APIs, and Integrating Moderation into the How-to section, since they aren't really feature development guides, and fit better in How-to.