### PR TITLE
Remove .proxy/ from Discord Activity proxy path

### DIFF
--- a/docs/activities/building-an-activity.mdx
+++ b/docs/activities/building-an-activity.mdx
@@ -457,10 +457,6 @@ We can now run our server and client-side apps in separate terminal windows. You
 
 Before we call your backend activity server, we need to be aware of the Discord proxy and understand how to avoid any Content Security Policy (CSP) issues.
 
-:::info
-For this tutorial, we are going to prefix the API call to `/api/token/` with `/.proxy`, but you can also use the SDK's `patchUrlMappings()` method to automatically prefix calls to your external resources for the proxy.
-:::
-
 Learn more about this topic in the guides for [Constructing a Full URL](/docs/activities/development-guides/networking#construct-a-full-url) and [Using External Resources](/docs/activities/development-guides/networking#using-external-resources).
 
 ### Calling your backend server from your client
@@ -513,10 +509,7 @@ async function setupDiscordSdk() {
   });
 
   // Retrieve an access_token from your activity's server
-  // Note: We need to prefix our backend `/api/token` route with `/.proxy` to stay compliant with the CSP.
-  // Read more about constructing a full URL and using external resources at
-  // https://discord.com/developers/docs/activities/development-guides/networking#construct-a-full-url
-  const response = await fetch("/.proxy/api/token", {
+  const response = await fetch("/api/token", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/docs/activities/development-guides/networking.mdx
+++ b/docs/activities/development-guides/networking.mdx
@@ -42,8 +42,8 @@ const url = new URL(`${protocol}://${clientId}.${proxyDomain}${resourcePath}`);
 ```
 
 In other words, given an application client id of `12345678`
-| Relative Path | Full Path                                           |
-|---------------|-----------------------------------------------------|
+| Relative Path | Full Path                                    |
+|---------------|----------------------------------------------|
 | /foo/bar.jpg  | https://12345678.discordsays.com/foo/bar.jpg |
 
 ---

--- a/docs/activities/development-guides/networking.mdx
+++ b/docs/activities/development-guides/networking.mdx
@@ -29,8 +29,7 @@ There are scenarios where instead of using a relative url (`/path/to/my/thing`) 
 1. The protocol you wish to use
 2. Your application's client id
 3. The discord proxy domain
-4. The `/.proxy` path prefix
-5. Whatever you need to list
+4. Whatever you need to list
 
 Here's an example of how to build a full url, using the URL constructor:
 
@@ -39,13 +38,13 @@ const protocol = `https`;
 const clientId = '<YOUR CLIENT ID>';
 const proxyDomain = 'discordsays.com';
 const resourcePath = '/foo/bar.jpg';
-const url = new URL(`${protocol}://${clientId}.${proxyDomain}/.proxy${resourcePath}`);
+const url = new URL(`${protocol}://${clientId}.${proxyDomain}${resourcePath}`);
 ```
 
 In other words, given an application client id of `12345678`
 | Relative Path | Full Path                                           |
 |---------------|-----------------------------------------------------|
-| /foo/bar.jpg  | https://12345678.discordsays.com/.proxy/foo/bar.jpg |
+| /foo/bar.jpg  | https://12345678.discordsays.com/foo/bar.jpg |
 
 ---
 

--- a/docs/activities/how-activities-work.md
+++ b/docs/activities/how-activities-work.md
@@ -41,7 +41,7 @@ async function setup() {
   });
 
   // Retrieve an access_token from your application's server
-  const response = await fetch('/.proxy/api/token', {
+  const response = await fetch('/api/token', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/docs/change-log/2024-07-17-activities-proxy-csp-update.md
+++ b/docs/change-log/2024-07-17-activities-proxy-csp-update.md
@@ -2,6 +2,9 @@
 title: "Activities Proxy CSP Update"
 date: "2024-07-17"
 breaking: true
+topics:
+- "Activities"
+- "Embedded App SDK"
 ---
 
 :::warn

--- a/docs/change-log/2024-07-17-activities-proxy-csp-update.md
+++ b/docs/change-log/2024-07-17-activities-proxy-csp-update.md
@@ -4,6 +4,10 @@ date: "2024-07-17"
 breaking: true
 ---
 
+:::warn
+This change is outdated. We have since updated the Activities Proxy CSP and the use of `/.proxy/` is no longer required. For the latest information, please refer to [this changelog](/docs/change-log#remove-proxy-from-discord-activity-proxy-path).
+:::
+
 This change will be rolled out to all existing applications on **August 28, 2024**.
 
 We will be updating our Content Security Policy (CSP) for the Activities Domain (`https://<application_id>.discordsays.com`). This represents a **breaking change** for **all Activities**, and as such we have a migration plan in order.

--- a/docs/change-log/2025-07-30-remove-proxy-from-discord-activity-proxy-path.md
+++ b/docs/change-log/2025-07-30-remove-proxy-from-discord-activity-proxy-path.md
@@ -6,13 +6,9 @@ topics:
 - "Embedded App SDK"
 ---
 
-## Overview
-
 We've updated the Content Security Policy (CSP) for Discord Activities to remove the `.proxy/` path requirement when making requests through the discordsays.com proxy. This change simplifies the developer experience while maintaining full backwards compatibility. This was made possible by resolving the underlying privacy considerations that originally required the `.proxy/` path restriction.
 
-## What Changed
-
-### Before
+#### Before
 
 Activities were required to make proxy requests through paths prefixed with `/.proxy/`:
 
@@ -20,32 +16,30 @@ Activities were required to make proxy requests through paths prefixed with `/.p
 https://<app_id>.discordsays.com/.proxy/api/endpoint
 ```
 
-### After
+#### After
 
-Activities can now make proxy requests directly without the `.proxy/` prefix:
+Activities can now make proxy requests directly without the `/.proxy/` prefix:
 
 ```
 https://<app_id>.discordsays.com/api/endpoint
 ```
 
-## Technical Details
+#### Technical Details
 
 - **CSP Update**: The Content Security Policy now allows requests to `https://<app_id>.discordsays.com/*` instead of the more restrictive `https://<app_id>.discordsays.com/.proxy/*`
 - **Proxy Behavior**: Both URL patterns work identically - your existing proxy mappings (e.g., `/api -> example.com`) will function the same way regardless of whether you use `/.proxy/api` or `/api`
 - **Performance**: No performance differences between the two approaches
 
-## Developer Tooling Updates
+#### Developer Tooling Updates
 
 The `patchUrlMappings` utility will be updated in an upcoming Embedded App SDK release to generate the simplified URLs by default, though it will continue to support the `.proxy/` format for backward compatibility.
 
-## Backward Compatibility
+#### Backward Compatibility
 
-**All existing code will continue to work without changes.** The `.proxy/` path prefix is still fully supported and will be maintained indefinitely. You can:
+**All existing code will continue to work without changes.** The `/.proxy/` path prefix is still fully supported and will be maintained indefinitely. You can:
 
-- Continue using existing `.proxy/` URLs
+- Continue using existing `/.proxy/` URLs
 - Switch to the new, simplified URLs
 - Use both patterns simultaneously in the same application
-
-## Migration
 
 **No migration is required.** This is a purely additive change that expands what's possible rather than breaking existing functionality.

--- a/docs/change-log/2025-07-30-remove-proxy-from-discord-activity-proxy-path.md
+++ b/docs/change-log/2025-07-30-remove-proxy-from-discord-activity-proxy-path.md
@@ -1,5 +1,5 @@
 ---
-title: "Remove .proxy/ from Discord Activitiy proxy path"
+title: "Remove .proxy/ from Discord Activity proxy path"
 date: "2025-07-30"
 topics:
 - "Activities"

--- a/docs/change-log/2025-07-30-remove-proxy-from-discord-activity-proxy-path.md
+++ b/docs/change-log/2025-07-30-remove-proxy-from-discord-activity-proxy-path.md
@@ -1,0 +1,51 @@
+---
+title: "Remove .proxy/ from Discord Activitiy proxy path"
+date: "2025-07-30"
+topics:
+- "Activities"
+- "Embedded App SDK"
+---
+
+## Overview
+
+We've updated the Content Security Policy (CSP) for Discord Activities to remove the `.proxy/` path requirement when making requests through the discordsays.com proxy. This change simplifies the developer experience while maintaining full backwards compatibility. This was made possible by resolving the underlying privacy considerations that originally required the `.proxy/` path restriction.
+
+## What Changed
+
+### Before
+
+Activities were required to make proxy requests through paths prefixed with `/.proxy/`:
+
+```
+https://<app_id>.discordsays.com/.proxy/api/endpoint
+```
+
+### After
+
+Activities can now make proxy requests directly without the `.proxy/` prefix:
+
+```
+https://<app_id>.discordsays.com/api/endpoint
+```
+
+## Technical Details
+
+- **CSP Update**: The Content Security Policy now allows requests to `https://<app_id>.discordsays.com/*` instead of the more restrictive `https://<app_id>.discordsays.com/.proxy/*`
+- **Proxy Behavior**: Both URL patterns work identically - your existing proxy mappings (e.g., `/api -> example.com`) will function the same way regardless of whether you use `/.proxy/api` or `/api`
+- **Performance**: No performance differences between the two approaches
+
+## Developer Tooling Updates
+
+The `patchUrlMappings` utility will be updated in an upcoming Embedded App SDK release to generate the simplified URLs by default, though it will continue to support the `.proxy/` format for backward compatibility.
+
+## Backward Compatibility
+
+**All existing code will continue to work without changes.** The `.proxy/` path prefix is still fully supported and will be maintained indefinitely. You can:
+
+- Continue using existing `.proxy/` URLs
+- Switch to the new, simplified URLs
+- Use both patterns simultaneously in the same application
+
+## Migration
+
+**No migration is required.** This is a purely additive change that expands what's possible rather than breaking existing functionality.


### PR DESCRIPTION
We've updated the Activity CSP to allow us to drop the `.proxy/` prefix to paths in your activities