### PR TITLE
Fix placeholder not appearing in latest changelog entry

### DIFF
--- a/docs/change-log/2025-07-30-remove-proxy-from-discord-activity-proxy-path.md
+++ b/docs/change-log/2025-07-30-remove-proxy-from-discord-activity-proxy-path.md
@@ -13,7 +13,7 @@ We've updated the Content Security Policy (CSP) for Discord Activities to remove
 Activities were required to make proxy requests through paths prefixed with `/.proxy/`:
 
 ```
-https://<app_id>.discordsays.com/.proxy/api/endpoint
+https://&lt;app_id&gt;.discordsays.com/.proxy/api/endpoint
 ```
 
 #### After
@@ -21,7 +21,7 @@ https://<app_id>.discordsays.com/.proxy/api/endpoint
 Activities can now make proxy requests directly without the `/.proxy/` prefix:
 
 ```
-https://<app_id>.discordsays.com/api/endpoint
+https://&lt;app_id&gt;.discordsays.com/api/endpoint
 ```
 
 #### Technical Details


### PR DESCRIPTION
Fixes the &lt;app_id&gt; placeholder text not appearing on https://discord.com/developers/docs/change-log#remove-proxy-from-discord-activity-proxy-path due to being treated as HTML.

<img width="500" height="401" alt="162841" src="https://github.com/user-attachments/assets/50f2df4e-a407-49d1-b771-9a21da0ad415" />

<br>

<img width="200" height="312" alt="162823" src="https://github.com/user-attachments/assets/b49dae09-a9d6-4999-a7c6-0e0299f653c5" />
<img width="200" height="66" alt="164024" src="https://github.com/user-attachments/assets/8bd4701a-617b-4e25-86c7-124b4ad8bf11" />

<br>

This escaping should work because it's the same used on https://discord.com/developers/docs/discord-social-sdk/getting-started/using-c++#step-5-project-setup ( https://github.com/discord/discord-api-docs/blob/5b778530510bbe5ab7f46339473835e4fac03e51/docs/discord-social-sdk/getting-started/using-c%2B%2B.mdx?plain=1#L134 )

Note: Due to markdown parsing differences, the escaping will not appear correctly on GitHub's preview, but should look correct on discord.dev