### PR TITLE
Clarify messages sorted newest to oldest in load channel messages endpoint

### DIFF
--- a/docs/resources/message.mdx
+++ b/docs/resources/message.mdx
@@ -769,7 +769,7 @@ Any entities whose id is included can be mentioned. Do note the API will silentl
 ## Get Channel Messages
 <Route method="GET">/channels/[\{channel.id\}](/docs/resources/channel#channel-object)/messages</Route>
 
-Retrieves the messages in a channel. Returns an array of [message](/docs/resources/message#message-object) objects on success.
+Retrieves the messages in a channel. Returns an array of [message](/docs/resources/message#message-object) objects from newest to oldest on success.
 
 If operating on a guild channel, this endpoint requires the current user to have the `VIEW_CHANNEL` permission. If the channel is a voice channel, they must _also_ have the `CONNECT` permission.
 


### PR DESCRIPTION
Currently, the documentation doesn't state that the messages returned by the **[Get Channel Messages](https://discord.com/developers/docs/resources/message#get-channel-messages)** Endpoint are sorted newest to oldest - so lets add it.
Especially when using after/before options, one might think that the messages are sorted differently.