### PR TITLE
Social SDK: Fix OAuth2 device authorization endpoint URL

### DIFF
--- a/docs/discord-social-sdk/development-guides/account-linking-on-consoles.mdx
+++ b/docs/discord-social-sdk/development-guides/account-linking-on-consoles.mdx
@@ -114,7 +114,7 @@ def authorize_device():
     data = {"scope": SCOPE}
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
     
-    response = requests.post(f"{API_ENDPOINT}/oauth2/device/code", data=data, headers=headers, auth=(CLIENT_ID, CLIENT_SECRET))
+    response = requests.post(f"{API_ENDPOINT}/oauth2/device/authorize", data=data, headers=headers, auth=(CLIENT_ID, CLIENT_SECRET))
     response.raise_for_status()
     return response.json()
 ```


### PR DESCRIPTION
Correct the OAuth2 device flow endpoint from `/oauth2/device/code` to `/oauth2/device/authorize` in the console account linking example.

