### PR TITLE
Specify that the `reason` in the `Ban Object` can be `null` if not set

### DIFF
--- a/docs/resources/guild.mdx
+++ b/docs/resources/guild.mdx
@@ -476,10 +476,10 @@ Some older integrations may not have an attached user.
 
 ###### Ban Structure
 
-| Field  | Type                                            | Description            |
-|--------|-------------------------------------------------|------------------------|
-| reason | ?string                                         | the reason for the ban |
-| user   | [user](/docs/resources/user#user-object) object | the banned user        |
+| Field  | Type                                            | Description                                 |
+|--------|-------------------------------------------------|---------------------------------------------|
+| reason | ?string                                         | the reason for the ban or `null` if not set |
+| user   | [user](/docs/resources/user#user-object) object | the banned user                             |
 
 ###### Example Ban
 


### PR DESCRIPTION
This PR specifies that the `reason` field for the `Ban Object` can be `null` if not set.