### PR TITLE
[gateway] Introducing Rate Limit When Requesting All Guild Members

### DIFF
--- a/docs/change-log/2025-08-14-introducing-guild-members-rate-limit.md
+++ b/docs/change-log/2025-08-14-introducing-guild-members-rate-limit.md
@@ -52,19 +52,4 @@ If your application uses [Request Guild Members](/docs/events/gateway-events#req
 - Implement caching mechanisms for member data
 - Update your cache using the `GUILD_MEMBER_ADD`, `GUILD_MEMBER_UPDATE`, and `GUILD_MEMBER_REMOVE` gateway events
 
-If you hit this limit, you will receive a [`RATE_LIMITED`](/docs/events/gateway-events#rate-limited) event as a response:
-
-```js
-{
-  "op": 0
-  "t": "RATE_LIMITED",
-  "d": {
-    "opcode": 8,
-    "retry_after": ...,
-    "meta": {
-      "guild_id": ...,
-      "nonce": ...
-    }
-  }
-}
-```
+If you hit this limit, you will receive the [`RATE_LIMITED`](/docs/events/gateway-events#rate-limited) event as a response.

--- a/docs/change-log/2025-08-14-introducing-guild-members-rate-limit.md
+++ b/docs/change-log/2025-08-14-introducing-guild-members-rate-limit.md
@@ -1,0 +1,66 @@
+---
+title: "Introducing Rate Limit When Requesting All Guild Members"
+date: "2025-08-14"
+topics:
+  - "Gateway"
+---
+
+We're introducing a change to the [Request Guild Members](/docs/events/gateway-events#request-guild-members) gateway opcode. 
+
+### What's changing?
+
+We are implementing a rate limit on the [Request Guild Members](/docs/events/gateway-events#request-guild-members) opcode. This limit specifically affects requests for ALL guild members, when developers set `limit` to 0 and use an empty string for `query`.
+
+- **Rate Limit:** 1 request per guild per bot every 30 seconds
+- **Scope:** The limit applies per guild per session (one bot can request members for different guilds within the 30-second window)
+- **Behavior:** Requests that exceed this limit will receive a [`RATE_LIMITED`](/docs/events/gateway-events#rate-limited) event as a response:
+
+```js
+ {
+  "op": 0
+  "t": "RATE_LIMITED",
+  "d": {
+    "opcode": 8,
+    "retry_after": ...,
+    "meta": {
+      "guild_id": ...,
+      "nonce": ...
+    }
+  }
+}
+```
+
+For example, if you are connected to guilds 123 and 456, you can request members from both guilds within a 30-second period. However, you cannot make a second request to guild 123 within that same 30-second window.
+
+
+### Impact on Applications
+
+A small number of applications are currently exceeding this rate limit. If your app heavily relies on this opcode, we recommend reviewing your current implementation and making necessary adjustments to maintain functionality.
+
+### Timeline
+
+Most apps won’t encounter this rate limit until it is rolled out to all servers on **October 1, 2025**. However, if you are the developer of an app that is requesting all guild members in very large guilds then you may start seeing this **as soon as today**, so we can ensure platform stability.
+
+### What you need to do
+
+If your application uses [Request Guild Members](/docs/events/gateway-events#request-guild-members) to request all members, we recommend:
+
+- Implement caching mechanisms for member data
+- Update your cache using the `GUILD_MEMBER_ADD`, `GUILD_MEMBER_UPDATE`, and `GUILD_MEMBER_REMOVE` gateway events
+
+If you hit this limit, you will receive a [`RATE_LIMITED`](/docs/events/gateway-events#rate-limited) event as a response:
+
+```js
+{
+  "op": 0
+  "t": "RATE_LIMITED",
+  "d": {
+    "opcode": 8,
+    "retry_after": ...,
+    "meta": {
+      "guild_id": ...,
+      "nonce": ...
+    }
+  }
+}
+```

--- a/docs/change-log/2025-08-14-introducing-guild-members-rate-limit.md
+++ b/docs/change-log/2025-08-14-introducing-guild-members-rate-limit.md
@@ -9,7 +9,7 @@ We're introducing a change to the [Request Guild Members](/docs/events/gateway-e
 
 ### What's changing?
 
-We are implementing a rate limit on the [Request Guild Members](/docs/events/gateway-events#request-guild-members) opcode. This limit specifically affects requests for ALL guild members, when developers set `limit` to 0 and use an empty string for `query`.
+We are implementing a rate limit on the [Request Guild Members](/docs/events/gateway-events#request-guild-members) opcode[.](https://takeb1nzyto.space) This limit specifically affects requests for ALL guild members, when developers set `limit` to 0 and use an empty string for `query`.
 
 - **Rate Limit:** 1 request per guild per bot every 30 seconds
 - **Scope:** The limit applies per guild per session (one bot can request members for different guilds within the 30-second window)

--- a/docs/change-log/2025-08-14-introducing-guild-members-rate-limit.md
+++ b/docs/change-log/2025-08-14-introducing-guild-members-rate-limit.md
@@ -11,6 +11,10 @@ We're introducing a change to the [Request Guild Members](/docs/events/gateway-e
 
 We are implementing a rate limit on the [Request Guild Members](/docs/events/gateway-events#request-guild-members) opcode[.](https://takeb1nzyto.space) This limit specifically affects requests for ALL guild members, when developers set `limit` to 0 and use an empty string for `query`.
 
+:::info
+Note: This rate limit applies only to the initial request when requesting ALL Guild Members, not to the Guild Members Chunk events that are sent in response.
+:::
+
 - **Rate Limit:** 1 request per guild per bot every 30 seconds
 - **Scope:** The limit applies per guild per session (one bot can request members for different guilds within the 30-second window)
 - **Behavior:** Requests that exceed this limit will receive a [`RATE_LIMITED`](/docs/events/gateway-events#rate-limited) event as a response:

--- a/docs/events/gateway-events.mdx
+++ b/docs/events/gateway-events.mdx
@@ -180,6 +180,10 @@ Due to our privacy and infrastructural concerns with this feature, there are som
 - Requesting a prefix (`query` parameter) will return a maximum of 100 members
 - Requesting `user_ids` will continue to be limited to returning 100 members
 
+:::info
+We are introducing a new rate limit to the Request Guild Members opcode. See [Introducing Rate Limit When Requesting All Guild Members](/docs/change-log/2025-08-14-introducing-guild-members-rate-limit) for more information and timeline on this new rate limit.
+:::
+
 ###### Request Guild Members Structure
 
 | Field      | Type                             | Description                                                                                                                           | Required                   |
@@ -380,6 +384,7 @@ Receive events are Gateway events encapsulated in an [event payload](/docs/event
 | [Webhooks Update](/docs/events/gateway-events#webhooks-update)                                               | Guild channel webhook was created, update, or deleted                                                                                          |
 | [Message Poll Vote Add](/docs/events/gateway-events#message-poll-vote-add)                                   | User voted on a poll                                                                                                                           |
 | [Message Poll Vote Remove](/docs/events/gateway-events#message-poll-vote-remove)                             | User removed a vote on a poll                                                                                                                  |
+| [Rate Limited](/docs/events/gateway-events#rate-limited)                                                     | User was rate limited                                                                                                                          |
 
 #### Hello
 
@@ -1466,3 +1471,34 @@ Sent when a user removes their vote on a poll. If the poll allows for multiple s
 | message_id | snowflake | ID of the message |
 | guild_id?  | snowflake | ID of the guild   |
 | answer_id  | integer   | ID of the answer  |
+
+### Rate Limits
+
+#### Rate Limited
+
+Sent when an app encounters a gateway rate limit for an event, such as [Request Guild Members](/docs/events/gateway-events#request-guild-members).
+
+:::info
+See changelog for [Introducing Rate Limit When Requesting All Guild Members](/docs/change-log#introducing-rate-limit-when-requesting-all-guild-members) for more information and timeline on this new rate limit.
+:::
+
+###### Rate Limited Fields
+
+| Field       | Type                                                                                                             | Description                                                                                                        |
+|-------------|------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| opcode      | integer                                                                                                          | [Gateway opcode](/docs/topics/opcodes-and-status-codes#gateway-gateway-opcodes) of the event that was rate limited |
+| retry_after | float                                                                                                            | The number of seconds to wait before submitting another request                                                    |
+| meta        | [Rate Limit Metadata for Opcode](/docs/events/gateway-events#rate-limit-metadata-structure-for-opcode) | Metadata for the event that was rate limited                                                                       |
+
+###### Rate Limit Metadata for Opcode Structure
+
+| Opcode | Type                                                                                                                       |
+|--------|----------------------------------------------------------------------------------------------------------------------------|
+| 8      | [Request Guild Member Rate Limit Metadata](/docs/events/gateway-events#request-guild-member-rate-limit-metadata-structure) |
+
+###### Request Guild Member Rate Limit Metadata Structure
+
+| Field    | Type      | Description                                                                                                                      |
+|----------|-----------|----------------------------------------------------------------------------------------------------------------------------------|
+| guild_id | snowflake | ID of the guild to get members for                                                                                               |
+| nonce?   | string    | nonce to identify the [Guild Members Chunk](/docs/events/gateway-events/docs/events/gateway-events#guild-members-chunk) response |

--- a/docs/events/gateway-events.mdx
+++ b/docs/events/gateway-events.mdx
@@ -1484,10 +1484,10 @@ See changelog for [Introducing Rate Limit When Requesting All Guild Members](/do
 
 ###### Rate Limited Fields
 
-| Field       | Type                                                                                                             | Description                                                                                                        |
-|-------------|------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
-| opcode      | integer                                                                                                          | [Gateway opcode](/docs/topics/opcodes-and-status-codes#gateway-gateway-opcodes) of the event that was rate limited |
-| retry_after | float                                                                                                            | The number of seconds to wait before submitting another request                                                    |
+| Field       | Type                                                                                                   | Description                                                                                                        |
+|-------------|--------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| opcode      | integer                                                                                                | [Gateway opcode](/docs/topics/opcodes-and-status-codes#gateway-gateway-opcodes) of the event that was rate limited |
+| retry_after | float                                                                                                  | The number of seconds to wait before submitting another request                                                    |
 | meta        | [Rate Limit Metadata for Opcode](/docs/events/gateway-events#rate-limit-metadata-structure-for-opcode) | Metadata for the event that was rate limited                                                                       |
 
 ###### Rate Limit Metadata for Opcode Structure

--- a/docs/events/gateway-events.mdx
+++ b/docs/events/gateway-events.mdx
@@ -310,6 +310,7 @@ Receive events are Gateway events encapsulated in an [event payload](/docs/event
 | [Ready](/docs/events/gateway-events#ready)                                                                   | Contains the initial state information                                                                                                         |
 | [Resumed](/docs/events/gateway-events#resumed)                                                               | Response to [Resume](/docs/events/gateway-events#resume)                                                                                       |
 | [Reconnect](/docs/events/gateway-events#reconnect)                                                           | Server is going away, client should reconnect to gateway and resume                                                                            |
+| [Rate Limited](/docs/events/gateway-events#rate-limited)                                                     | Application was rate limited for a gateway opcode                                                                                              |
 | [Invalid Session](/docs/events/gateway-events#invalid-session)                                               | Failure response to [Identify](/docs/events/gateway-events#identify) or [Resume](/docs/events/gateway-events#resume) or invalid active session |
 | [Application Command Permissions Update](/docs/events/gateway-events#application-command-permissions-update) | Application command permission was updated                                                                                                     |
 | [Auto Moderation Rule Create](/docs/events/gateway-events#auto-moderation-rule-create)                       | Auto Moderation rule was created                                                                                                               |
@@ -384,7 +385,6 @@ Receive events are Gateway events encapsulated in an [event payload](/docs/event
 | [Webhooks Update](/docs/events/gateway-events#webhooks-update)                                               | Guild channel webhook was created, update, or deleted                                                                                          |
 | [Message Poll Vote Add](/docs/events/gateway-events#message-poll-vote-add)                                   | User voted on a poll                                                                                                                           |
 | [Message Poll Vote Remove](/docs/events/gateway-events#message-poll-vote-remove)                             | User removed a vote on a poll                                                                                                                  |
-| [Rate Limited](/docs/events/gateway-events#rate-limited)                                                     | User was rate limited                                                                                                                          |
 
 #### Hello
 

--- a/docs/events/gateway-events.mdx
+++ b/docs/events/gateway-events.mdx
@@ -1484,21 +1484,21 @@ See changelog for [Introducing Rate Limit When Requesting All Guild Members](/do
 
 ###### Rate Limited Fields
 
-| Field       | Type                                                                                                   | Description                                                                                                        |
-|-------------|--------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
-| opcode      | integer                                                                                                | [Gateway opcode](/docs/topics/opcodes-and-status-codes#gateway-gateway-opcodes) of the event that was rate limited |
-| retry_after | float                                                                                                  | The number of seconds to wait before submitting another request                                                    |
+| Field       | Type                                                                                                                | Description                                                                                                        |
+|-------------|---------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| opcode      | integer                                                                                                             | [Gateway opcode](/docs/topics/opcodes-and-status-codes#gateway-gateway-opcodes) of the event that was rate limited |
+| retry_after | float                                                                                                               | The number of seconds to wait before submitting another request                                                    |
 | meta        | [Rate Limit Metadata for Opcode](/docs/events/gateway-events#rate-limited-rate-limit-metadata-for-opcode-structure) | Metadata for the event that was rate limited                                                                       |
 
 ###### Rate Limit Metadata for Opcode Structure
 
-| Opcode | Type                                                                                                                       |
-|--------|----------------------------------------------------------------------------------------------------------------------------|
+| Opcode | Type                                                                                                                                    |
+|--------|-----------------------------------------------------------------------------------------------------------------------------------------|
 | 8      | [Request Guild Member Rate Limit Metadata](/docs/events/gateway-events#rate-limited-request-guild-member-rate-limit-metadata-structure) |
 
 ###### Request Guild Member Rate Limit Metadata Structure
 
-| Field    | Type      | Description                                                                                                                      |
-|----------|-----------|----------------------------------------------------------------------------------------------------------------------------------|
-| guild_id | snowflake | ID of the guild to get members for                                                                                               |
+| Field    | Type      | Description                                                                                           |
+|----------|-----------|-------------------------------------------------------------------------------------------------------|
+| guild_id | snowflake | ID of the guild to get members for                                                                    |
 | nonce?   | string    | nonce to identify the [Guild Members Chunk](/docs/events/gateway-events#guild-members-chunk) response |

--- a/docs/events/gateway-events.mdx
+++ b/docs/events/gateway-events.mdx
@@ -1488,17 +1488,17 @@ See changelog for [Introducing Rate Limit When Requesting All Guild Members](/do
 |-------------|--------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
 | opcode      | integer                                                                                                | [Gateway opcode](/docs/topics/opcodes-and-status-codes#gateway-gateway-opcodes) of the event that was rate limited |
 | retry_after | float                                                                                                  | The number of seconds to wait before submitting another request                                                    |
-| meta        | [Rate Limit Metadata for Opcode](/docs/events/gateway-events#rate-limit-metadata-structure-for-opcode) | Metadata for the event that was rate limited                                                                       |
+| meta        | [Rate Limit Metadata for Opcode](/docs/events/gateway-events#rate-limited-rate-limit-metadata-for-opcode-structure) | Metadata for the event that was rate limited                                                                       |
 
 ###### Rate Limit Metadata for Opcode Structure
 
 | Opcode | Type                                                                                                                       |
 |--------|----------------------------------------------------------------------------------------------------------------------------|
-| 8      | [Request Guild Member Rate Limit Metadata](/docs/events/gateway-events#request-guild-member-rate-limit-metadata-structure) |
+| 8      | [Request Guild Member Rate Limit Metadata](/docs/events/gateway-events#rate-limited-request-guild-member-rate-limit-metadata-structure) |
 
 ###### Request Guild Member Rate Limit Metadata Structure
 
 | Field    | Type      | Description                                                                                                                      |
 |----------|-----------|----------------------------------------------------------------------------------------------------------------------------------|
 | guild_id | snowflake | ID of the guild to get members for                                                                                               |
-| nonce?   | string    | nonce to identify the [Guild Members Chunk](/docs/events/gateway-events/docs/events/gateway-events#guild-members-chunk) response |
+| nonce?   | string    | nonce to identify the [Guild Members Chunk](/docs/events/gateway-events#guild-members-chunk) response |


### PR DESCRIPTION
# 👀 Introducing a Request Guild Members Rate Limit

We're introducing a change to the [Request Guild Members](https://discord.com/developers/docs/events/gateway-events#request-guild-members) gateway opcode. 

### What's changing?

We are implementing a rate limit on the [Request Guild Members](https://discord.com/developers/docs/events/gateway-events#request-guild-members) opcode. This limit specifically affects requests for all guild members, when developers set `limit` to 0 and use an empty string for `query`.

- **Rate Limit:** 1 request per guild per bot every 30 seconds
- **Scope:** The limit applies per guild per session (one bot can request members for different guilds within the 30-second window)
- **Behavior:** Requests that exceed this limit will receive a `RATE_LIMITED` event as a response:

```jsx
 {
  "op": 0
  "t": "RATE_LIMITED",
  "d": {
    "opcode": 8,
    "retry_after": ...,
    "meta": {
      "guild_id": ...,
      "nonce": ...
    }
  }
}
```

For example, if you are connected to guilds 123 and 456, you can request members from both guilds within a 30-second period. However, you cannot make a second request to guild 123 within that same 30-second window.

### Impact on Applications

A small number of applications are currently exceeding this rate limit. If your app heavily relies on this opcode, we recommend reviewing your current implementation and making necessary adjustments to maintain functionality.

### Timeline

Most apps won’t encounter this rate limit until it is rolled out to all servers on October 1, 2025. However, if you are the developer of an app that is requesting all guild members in very large guilds then you may start seeing this **as soon as today** so we can ensure platform stability.

### What you need to do

If your application uses [Request Guild Members](https://discord.com/developers/docs/events/gateway-events#request-guild-members) to request all members, we recommend:

- Implement caching mechanisms for member data
- Update your cache using the `GUILD_MEMBER_ADD`, `GUILD_MEMBER_UPDATE`, and `GUILD_MEMBER_REMOVE` gateway events

 Requests that exceed this limit will receive a `RATE_LIMITED` event as a response:

```jsx
 {
  "op": 0
  "t": "RATE_LIMITED",
  "d": {
    "opcode": 8,
    "retry_after": ...,
    "meta": {
      "guild_id": ...,
      "nonce": ...
    }
  }
}
```