### PR TITLE
Deprecate non-E2EE voice calls with March 2026 deadline

### DIFF
--- a/docs/change-log/2025-09-02-deprecating-non-e2ee-calls.md
+++ b/docs/change-log/2025-09-02-deprecating-non-e2ee-calls.md
@@ -1,0 +1,29 @@
+---
+title: "Deprecating Non-E2EE Voice Calls"
+date: "2025-09-02"
+topics:
+- "Voice"
+---
+
+We started work on end-to-end encryption for Discord over two years ago to enhance our user privacy and security. With
+DAVE now supported across all platforms, we’re very close to making every call fully end-to-end encrypted.
+
+### Developer Impact
+
+To support our long-term privacy goals, we will **only support E2EE calls starting on March 1st, 2026** for all audio 
+and video conversations in direct messages (DMs), group messages (GDMs), voice channels, and Go Live streams on 
+Discord. After that date, any client or application not updated for DAVE support will no longer be able to 
+participate in Discord calls.
+
+### Implementing E2EE Voice
+
+For developers working with Discord's voice APIs, you can consult 
+[the updated voice documentation](/docs/topics/voice-connections)
+and the implementation examples available in our [open-source repository](https://github.com/discord/libdave) as 
+well as [the protocol whitepaper](https://github.com/discord/dave-protocol). 
+
+The [Discord Developers community](https://discord.gg/discord-developers) is also a
+great place to find assistance and answers to any integration questions you may have.
+
+We're committed to making this transition as smooth as possible while delivering the enhanced privacy and security that 
+DAVE provides to all Discord users.

--- a/docs/topics/voice-connections.mdx
+++ b/docs/topics/voice-connections.mdx
@@ -210,8 +210,11 @@ First, we open a UDP connection to the IP and port provided in the Ready payload
 
 Since September 2024, Discord is migrating voice and video in DMs, Group DMs, voice channels, and Go Live streams to use end-to-end encryption (E2EE).
 
-:::info
-You are not immediately required to support the E2EE protocol, as calls will automatically upgrade/downgrade to/from E2EE depending on the support of clients in the call. Non-E2EE connections to voice in DMs, Group DMs, voice channels, and Go Live streams will soon be deprecated and will be discontinued (after at least a six month deprecation window).
+:::warn
+To support our long-term privacy goals, we will **only support E2EE calls starting on March 1st, 2026** for all audio
+and video conversations in direct messages (DMs), group messages (GDMs), voice channels, and Go Live streams on
+Discord.<br/><br/>
+We highly recommend you implement DAVE support as soon as possible to ensure a smooth transition.
 :::
 
 This section is a high-level overview of how to support Discord's audio & video end-to-end encryption (DAVE) protocol, centered around the voice gateway opcodes necessary for the protocol. The most thorough documentation on the DAVE protocol is found in the [Protocol Whitepaper](https://daveprotocol.com). You may additionally be able to leverage or refer to our open-source library [libdave](https://github.com/discord/libdave) to assist your implementation. The exact format of the DAVE protocol opcodes is detailed in the [Voice Gateway Opcodes section of the protocol whitepaper](https://daveprotocol.com/#voice-gateway-opcodes).


### PR DESCRIPTION
Add changelog entry and update voice connections documentation to announce that only end-to-end encrypted calls will be supported starting March 1st, 2026. Emphasizes the need for developers to implement DAVE protocol support before the deadline.