### PR TITLE
Document banner, avatar, and bio on modify current member

### DIFF
--- a/docs/change-log/2025-09-10-modify-current-member.md
+++ b/docs/change-log/2025-09-10-modify-current-member.md
@@ -1,0 +1,8 @@
+---
+title: "Banner, avatar, and bio can be set on modify current member"
+date: "2025-09-10"
+topics:
+- "HTTP API"
+---
+
+As of September 10, 2025, bots can set `banner`, `avatar`, and `bio` fields using the [modify current member](/docs/resources/guild#modify-current-member) route.

--- a/docs/resources/guild.mdx
+++ b/docs/resources/guild.mdx
@@ -1015,9 +1015,12 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 
 ###### JSON Params
 
-| Field | Type    | Description                     | Permission      |
-|-------|---------|---------------------------------|-----------------|
-| nick? | ?string | value to set user's nickname to | CHANGE_NICKNAME |
+| Field   | Type    | Description                          | Permission      |
+|---------|---------|--------------------------------------|-----------------|
+| nick?   | ?string | value to set user's nickname to      | CHANGE_NICKNAME |
+| banner? | ?string | data URI base64 encoded banner image |                 |
+| avatar? | ?string | data URL base64 encoded avatar image |                 |
+| bio?    | ?string | guild member bio                     |                 |
 
 ## Modify Current User Nick
 <Route method="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members/@me/nick</Route>

--- a/docs/resources/guild.mdx
+++ b/docs/resources/guild.mdx
@@ -1019,7 +1019,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 |---------|---------|--------------------------------------|-----------------|
 | nick?   | ?string | value to set user's nickname to      | CHANGE_NICKNAME |
 | banner? | ?string | data URI base64 encoded banner image |                 |
-| avatar? | ?string | data URL base64 encoded avatar image |                 |
+| avatar? | ?string | data URI base64 encoded avatar image |                 |
 | bio?    | ?string | guild member bio                     |                 |
 
 ## Modify Current User Nick

--- a/docs/resources/guild.mdx
+++ b/docs/resources/guild.mdx
@@ -1015,12 +1015,12 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 
 ###### JSON Params
 
-| Field   | Type    | Description                          | Permission      |
-|---------|---------|--------------------------------------|-----------------|
-| nick?   | ?string | value to set user's nickname to      | CHANGE_NICKNAME |
-| banner? | ?string | data URI base64 encoded banner image |                 |
-| avatar? | ?string | data URI base64 encoded avatar image |                 |
-| bio?    | ?string | guild member bio                     |                 |
+| Field   | Type    | Description                                                        | Permission      |
+|---------|---------|--------------------------------------------------------------------|-----------------|
+| nick?   | ?string | value to set user's nickname to                                    | CHANGE_NICKNAME |
+| banner? | ?string | [data URI base64 encoded](/docs/reference#image-data) banner image |                 |
+| avatar? | ?string | [data URI base64 encoded](/docs/reference#image-data) avatar image |                 |
+| bio?    | ?string | guild member bio                                                   |                 |
 
 ## Modify Current User Nick
 <Route method="PATCH">/guilds/[\{guild.id\}](/docs/resources/guild#guild-object)/members/@me/nick</Route>


### PR DESCRIPTION
Modify current member endpoint supports `banner`, `avatar`, and `bio` being set for bots.