### PR TITLE
Add missing field resolved to modal submit data structure

### DIFF
--- a/docs/interactions/receiving-and-responding.mdx
+++ b/docs/interactions/receiving-and-responding.mdx
@@ -127,10 +127,11 @@ Sent in `APPLICATION_COMMAND` and `APPLICATION_COMMAND_AUTOCOMPLETE` interaction
 
 ###### Modal Submit Data Structure
 
-| Field      | Type                                                                                                                                                | Description                          |
-|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
-| custom_id  | string                                                                                                                                              | The custom ID provided for the modal |
-| components | array of [component interaction response](/docs/interactions/receiving-and-responding#interaction-object-component-interaction-response-structures) | Values submitted by the user         |
+| Field      | Type                                                                                                                                                | Description                             |
+|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------|
+| custom_id  | string                                                                                                                                              | The custom ID provided for the modal    |
+| components | array of [component interaction response](/docs/interactions/receiving-and-responding#interaction-object-component-interaction-response-structures) | Values submitted by the user            |
+| resolved?  | [resolved data](/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure)                                             | Resolved entities from selected options |
 
 ###### Component Interaction Response Structures
 


### PR DESCRIPTION
In the update of modal components, they forgot to add a new field "resolved"