### PR TITLE
Fix markdown: Remove backslash in field names "chunk_index" and "chunk_count"

### DIFF
--- a/docs/events/gateway-events.mdx
+++ b/docs/events/gateway-events.mdx
@@ -803,7 +803,7 @@ You can use the `chunk_index` and `chunk_count` to calculate how many chunks are
 |-------------|----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
 | guild_id    | snowflake                                                                  | ID of the guild                                                                                |
 | members     | array of [guild member](/docs/resources/guild#guild-member-object) objects | Set of guild members                                                                           |
-| chunk_index | integer                                                                    | Chunk index in the expected chunks for this response (`0 <= chunk\_index < chunk\_count`)      |
+| chunk_index | integer                                                                    | Chunk index in the expected chunks for this response (`0 <= chunk_index < chunk_count`)        |
 | chunk_count | integer                                                                    | Total number of expected chunks for this response                                              |
 | not_found?  | array                                                                      | When passing an invalid ID to `REQUEST_GUILD_MEMBERS`, it will be returned here                |
 | presences?  | array of [presence](/docs/events/gateway-events#presence) objects          | When passing `true` to `REQUEST_GUILD_MEMBERS`, presences of the returned members will be here |


### PR DESCRIPTION
https://discord.com/developers/docs/events/gateway-events#guild-members-chunk-guild-members-chunk-event-fields

<img width="1054" height="444" alt="image" src="https://github.com/user-attachments/assets/68db68d8-4f11-499a-8d36-063876554c8d" />