### PR TITLE
Introduce provisional bot API + blanket improvements on docs

### DIFF
--- a/docs/discord-social-sdk/development-guides/account-linking-with-discord.mdx
+++ b/docs/discord-social-sdk/development-guides/account-linking-with-discord.mdx
@@ -61,7 +61,7 @@ For OAuth2 to work correctly, you must **register the correct redirect URIs** fo
 | **Desktop** | `http://127.0.0.1/callback`                                                                |
 | **Mobile**  | `discord-APP_ID:/authorize/callback` _(replace `APP_ID` with your Discord application ID)_ |
 
-### Step 1: Request Authorization 
+### Step 1: Request Authorization
 
 The SDK provides helper methods to simplify OAuth2 login.
 
@@ -277,6 +277,13 @@ def revoke_token(access_or_refresh_token):
     r.raise_for_status()
 ```
 
+### Handling User Initiated Revocation
+
+Users can unlink their account by removing access to your application on their Discord `User Settings -> Authorized Apps` page.
+
+If you would like to be notified when a user unlinks this way, you can [configure you application to listen for the `APPLICATION_DEAUTHORIZED` webhook event](/docs/events/webhook-events#application-deauthorized).
+Otherwise, you will know that the user has unlinked because their access token and refresh token (if you have one) will be invalidated.
+
 ---
 
 ## Next Steps
@@ -292,7 +299,7 @@ Now that you've successfully implemented account linking with Discord, you can i
   </Card>
   <Card title="Setting Rich Presence" link="/docs/discord-social-sdk/development-guides/setting-rich-presence" icon="UserStatusIcon">
     Display game status and information to Discord friends.
-  </Card>  
+  </Card>
 </Container>
 
 <SupportCallout />

--- a/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
+++ b/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
@@ -236,24 +236,24 @@ It is suggested that these provisional tokens are not stored and instead invoke 
 
 Common error codes and solutions for the server token exchange methods:
 
-| Code   | Meaning                           | Solution                                                                    |
-|--------|-----------------------------------|-----------------------------------------------------------------------------|
-| 530000 | Application not configured        | Contact Discord support to enable provisional accounts for your application |
-| 530001 | Expired ID token                  | Request a new token from your identity provider                             |
-| 530004 | Token too old                     | Request a new token (tokens over 1 week old are rejected)                   |
-| 530006 | Username generation failed        | Retry the operation (temporary error)                                       |
-| 530007 | Invalid client secret             | Verify or regenerate your client secret in the Developer Portal             |
-| 530010 | User account non-provisional      | User already linked to Discord account - use standard OAuth2 flow           |
+| Code   | Meaning                      | Solution                                                                    |
+|--------|------------------------------|-----------------------------------------------------------------------------|
+| 530000 | Application not configured   | Contact Discord support to enable provisional accounts for your application |
+| 530001 | Expired ID token             | Request a new token from your identity provider                             |
+| 530004 | Token too old                | Request a new token (tokens over 1 week old are rejected)                   |
+| 530006 | Username generation failed   | Retry the operation (temporary error)                                       |
+| 530007 | Invalid client secret        | Verify or regenerate your client secret in the Developer Portal             |
+| 530010 | User account non-provisional | User already linked to Discord account - use standard OAuth2 flow           |
 
 If you are using OIDC, you may encounter more specific errors:
 
-| Code   | Meaning                           | Solution                                                                    |
-|--------|-----------------------------------|-----------------------------------------------------------------------------|
-| 530002 | Invalid issuer                    | Verify the issuer in your ID token matches your configuration               |
-| 530003 | Invalid audience                  | Check that the audience in your ID token matches your OIDC configuration    |
-| 530008 | OIDC configuration not found      | Verify your OIDC issuer URL is configured and accessible                    |
-| 530009 | OIDC JWKS not found               | Check that your OIDC provider's JWKS endpoint is accessible                 |
-| 530020 | Invalid OIDC JWT token            | Ensure your OIDC ID token is properly signed and formatted                  |
+| Code   | Meaning                      | Solution                                                                 |
+|--------|------------------------------|--------------------------------------------------------------------------|
+| 530002 | Invalid issuer               | Verify the issuer in your ID token matches your configuration            |
+| 530003 | Invalid audience             | Check that the audience in your ID token matches your OIDC configuration |
+| 530008 | OIDC configuration not found | Verify your OIDC issuer URL is configured and accessible                 |
+| 530009 | OIDC JWKS not found          | Check that your OIDC provider's JWKS endpoint is accessible              |
+| 530020 | Invalid OIDC JWT token       | Ensure your OIDC ID token is properly signed and formatted               |
 
  You can find you OIDC configuration by visiting the [Developer Portal](https://discord.com/developers/applications), selecting your application, and opening the `External Auth` page under the `Discord Social SDK` section in the sidebar.
 
@@ -434,13 +434,13 @@ This migration ensures users don't lose their social connections built while usi
 
 You may receive a merge specific error code while attempting this operation:
 
-| Code   | HTTP Status | Meaning                                    | Solution                                                                   |
-|--------|-------------|--------------------------------------------|--------------------------------------------------------------------------- |
-| 530014 | 400         | Invalid merge source                       | The source account is not provisional                                      |
-| 530016 | 400         | Invalid merge destination                  | The destination account is provisional                                     |
-| 530017 | 400         | Merge source user banned                   | The provisional account being merged is banned from platform               |
-| 530023 | 400         | Too many application identities            | User already has an associated external identity for this application      |
-| -      | 423         | Resource locked                            | Transient error, wait and retry                                            |
+| Code   | HTTP Status | Meaning                         | Solution                                                              |
+|--------|-------------|---------------------------------|-----------------------------------------------------------------------|
+| 530014 | 400         | Invalid merge source            | The source account is not provisional                                 |
+| 530016 | 400         | Invalid merge destination       | The destination account is provisional                                |
+| 530017 | 400         | Merge source user banned        | The provisional account being merged is banned from platform          |
+| 530023 | 400         | Too many application identities | User already has an associated external identity for this application |
+| -      | 423         | Resource locked                 | Transient error, wait and retry                                       |
 
 ---
 

--- a/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
+++ b/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
@@ -67,6 +67,16 @@ For existing Discord users who have added a provisional account as a game friend
 
 ---
 
+## Choosing an Authentication Method
+
+Discord offers a number of authentication methods tailored to different games:
+
+1. Use the [**Bot Token Endpoint**](/docs/discord-social-sdk/development-guides/using-provisional-acounts#bot-token-endpoint#) if your game has an account system which uniquely identifies users. This is the recommended approach when possible.
+2. Use the [**External Credentials Exchange Endpoint**](/docs/discord-social-sdk/development-guides/using-provisional-acounts#external-credentials-exchange-endpoint) if you have an existing OIDC provider, or do not have an account system.
+3. Use the [**Client Side Token Exchange Method**](/docs/discord-social-sdk/development-guides/using-provisional-acounts#provisional-account-authentication-for-public-clients) if you are using a Public Client.
+
+If you are using the **External Credentials Exchange Endpoint** or **Client Side Token Exchange Method**, you must [configure you identity provider](/docs/discord-social-sdk/development-guides/using-provisional-acounts#configuring-your-identity-provider) before proceeding.
+
 ## Configuring Your Identity Provider
 
 Open the Discord app for your game in the [Developer Portal](https://discord.com/developers/applications). Find the `External Auth` page under the `Discord Social SDK` section in the sidebar.
@@ -80,59 +90,9 @@ We currently support the following provider types:
 - Epic Online Services (EOS)
 - Unity
 
----
+If you are using the bot token endpoint, no configuration is required.
 
-## Implementing Provisional Accounts
-
-### Provisional Account Authentication for Public Clients
-
-<PublicClient />
-
-If you have `Public Client` enabled on your Discord app, you can use the following code to authenticate your players with the external provider.
-
-```cpp
-// filepath: your_game/auth_manager.cpp
-void AuthenticateUser(std::shared_ptr<discordpp::Client> client) {
-    // Get your external auth token (Steam, OIDC, etc.)
-    std::string externalToken = GetExternalAuthToken();
-
-    // Get provisional token from Discord
-    client->GetProvisionalToken(DISCORD_APPLICATION_ID,
-        discordpp::AuthenticationExternalAuthType::OIDC,
-        externalToken,
-        [client](discordpp::ClientResult result, std::string accessToken, std::string refreshToken, discordpp::AuthorizationTokenType tokenType, int32_t expiresIn, std::string scope) {
-        if (result.Successful()) {
-            std::cout << "🔓 Provisional token received! Establishing connection...\n";
-            client->UpdateToken(discordpp::AuthorizationTokenType::Bearer, accessToken, [client](discordpp::ClientResult result) {
-                client->Connect();
-            });
-        } else {
-            std::cerr << "❌ Provisional token request failed: " << result.Error() << std::endl;
-        }
-    });
-}
-```
-
-
-#### Provisional Account Access Tokens
-
-This function generates a Discord access token. You pass in the user's identity, and it generates a new Discord account tied to that identity. There are multiple ways of specifying that identity, including using Steam/Epic services or your own identity system.
-
-The callback function will be invoked with an access token that expires in 1 hour. Refresh tokens are not supported for provisional accounts, so that will be an empty string. When the old one expires, you must call this function again to get a new access token.
-
-You can use [`Client::SetTokenExpirationCallback`] to receive a callback when the current token is about to expire or expires.
-
-:::info
-When the token expires, the SDK will still receive updates, such as new messages sent in a lobby, and any voice calls will continue to be active. However, any new actions, such as sending a message or adding a friend, will fail. You can get a new token and pass it to UpdateToken without interrupting the user's experience.
-:::
-
-#### Provisional Account Access Token Storage
-
-It is suggested that these provisional tokens are not stored and instead invoke this function each time the game is launched and when these tokens are about to expire. However, should you choose to store it, it is recommended that these provisional account tokens be differentiated from "full" Discord account tokens.
-
-### Provisional Account Authentication for Servers
-
-If you are not using the [`Client::GetProvisionalToken`] method, you'll need to make a request to the Discord API provisional account token endpoint.
+Which are represented in Discord's systems by the following types:
 
 #### External Auth Types
 
@@ -143,8 +103,57 @@ If you are not using the [`Client::GetProvisionalToken`] method, you'll need to 
 | EPIC_ONLINE_SERVICES_ACCESS_TOKEN | Access token for Epic Online Services. Supports EOS Auth access tokens        |
 | EPIC_ONLINE_SERVICES_ID_TOKEN     | ID token for Epic Online Services. Supports both EOS Auth + Connect ID tokens |
 | UNITY_SERVICES_ID_TOKEN           | Unity Services authentication ID token                                        |
+| DISCORD_BOT_ISSUED_ACCESS_TOKEN   | An access token for a user authenticated via the Bot Token Endpoint           |
+
+---
+
+## Implementing Provisional Accounts
+
+Creating a Provisional Account and requesting an Access Token for the account always happens in a single step.
+
+You provide external authentication and uniquely identifies the user, and Discord finds a user associated with that identifier.
+
+- If there is no account associated with the identity, a new provisional account is created along with a new access token for the user.
+- If there is a provisional account associated with the identity, an access token is returned.
+- If there is an existing _full Discord account_ associated with the identity, the request is aborted (See [Error Handling](/docs/discord-social-sdk/development-guides/using-provisional-acounts#error-handling)).
+
+Once authentication is complete, you can use the access token as you would a full Discord user's access token.
 
 
+### Provisional Account Authentication for Servers
+
+If you are not using the [`Client::GetProvisionalToken`] method, you'll need to make a request to the Discord API provisional account token endpoint.
+
+#### Bot Token Endpoint
+```python
+# filepath: your_game/server/auth.py
+import requests
+from models import GameAccount
+
+def get_provisional_token(game_account: GameAccount):
+  response = requests.post(
+    'https://discord.com/api/v10/partner-sdk/token/bot',
+    json={
+      'external_user_id': game_account.id,
+      'preferred_global_name': game_account.display_name,
+    }
+  )
+  return response.json()
+```
+
+#### Bot Token Endpoint Response
+
+```python
+{
+  "access_token": "<access token>",
+  "id_token": "<id token>",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "sdk.social_layer"
+}
+```
+
+#### External Credentials Exchange Endpoint
 ```python
 # filepath: your_game/server/auth.py
 import requests
@@ -175,19 +184,76 @@ def get_provisional_token(external_token: str):
 }
 ```
 
+### Provisional Account Authentication for Public Clients
+
+<PublicClient />
+
+If you have `Public Client` enabled on your Discord app, you can use the following code to authenticate your players with the external provider.
+
+```cpp
+// filepath: your_game/auth_manager.cpp
+void AuthenticateUser(std::shared_ptr<discordpp::Client> client) {
+    // Get your external auth token (Steam, OIDC, etc.)
+    std::string externalToken = GetExternalAuthToken();
+
+    // Get provisional token from Discord
+    client->GetProvisionalToken(DISCORD_APPLICATION_ID,
+        discordpp::AuthenticationExternalAuthType::OIDC,
+        externalToken,
+        [client](discordpp::ClientResult result, std::string accessToken, std::string refreshToken, discordpp::AuthorizationTokenType tokenType, int32_t expiresIn, std::string scope) {
+        if (result.Successful()) {
+            std::cout << "🔓 Provisional token received! Establishing connection...\n";
+            client->UpdateToken(discordpp::AuthorizationTokenType::Bearer, accessToken, [client](discordpp::ClientResult result) {
+                client->Connect();
+            });
+        } else {
+            std::cerr << "❌ Provisional token request failed: " << result.Error() << std::endl;
+        }
+    });
+}
+```
+
+### Provisional Account Access Tokens
+
+These methods generate a Discord access token. You pass in the user's identity, and it generates a new Discord account tied to that identity. There are multiple ways of specifying that identity, including using Steam/Epic services or your own identity system.
+
+The callback function will be invoked with an access token that expires in 1 hour. Refresh tokens are not supported for provisional accounts, so that will be an empty string. When the old one expires, you must call this function again to get a new access token.
+
+You can use [`Client::SetTokenExpirationCallback`] to receive a callback when the current token is about to expire or expires.
+
+:::info
+When the token expires, the SDK will still receive updates, such as new messages sent in a lobby, and any voice calls will continue to be active. However, any new actions, such as sending a message or adding a friend, will fail. You can get a new token and pass it to UpdateToken without interrupting the user's experience.
+:::
+
+#### Provisional Account Access Token Storage
+
+It is suggested that these provisional tokens are not stored and instead invoke this function each time the game is launched and when these tokens are about to expire. However, should you choose to store it, it is recommended that these provisional account tokens be differentiated from "full" Discord account tokens.
+
 ### Error Handling
 
-Common error codes and solutions for the GetProvisionalToken method:
+Common error codes and solutions for the server token exchange methods:
 
-| Code   | Meaning                    | Solution                                                                    |
-|--------|----------------------------|-----------------------------------------------------------------------------|
-| 530000 | Permission not granted     | Contact Discord support to enable provisional accounts for your application |
-| 530001 | Expired ID token           | Request a new token from your identity provider                             |
-| 530002 | Invalid issuer             | Verify the issuer in your ID token matches your configuration               |
-| 530003 | Invalid audience           | Check that the audience in your ID token matches your OIDC configuration    |
-| 530004 | Token too old              | Request a new token (tokens over 1 week old are rejected)                   |
-| 530006 | Username generation failed | Retry the operation (temporary error)                                       |
-| 530007 | Invalid client secret      | Verify or regenerate your client secret in the Developer Portal             |
+| Code   | Meaning                           | Solution                                                                    |
+|--------|-----------------------------------|-----------------------------------------------------------------------------|
+| 530000 | Application not configured        | Contact Discord support to enable provisional accounts for your application |
+| 530001 | Expired ID token                  | Request a new token from your identity provider                             |
+| 530004 | Token too old                     | Request a new token (tokens over 1 week old are rejected)                   |
+| 530006 | Username generation failed        | Retry the operation (temporary error)                                       |
+| 530007 | Invalid client secret             | Verify or regenerate your client secret in the Developer Portal             |
+| 530010 | User account non-provisional      | User already linked to Discord account - use standard OAuth2 flow           |
+
+If you are using OIDC, you may encounter more specific errors:
+
+| Code   | Meaning                           | Solution                                                                    |
+| 530002 | Invalid issuer                    | Verify the issuer in your ID token matches your configuration               |
+| 530003 | Invalid audience                  | Check that the audience in your ID token matches your OIDC configuration    |
+| 530008 | OIDC configuration not found      | Verify your OIDC issuer URL is configured and accessible                    |
+| 530009 | OIDC JWKS not found               | Check that your OIDC provider's JWKS endpoint is accessible                 |
+| 530020 | Invalid OIDC JWT token            | Ensure your OIDC ID token is properly signed and formatted                  |
+
+:::info
+ You can find you OIDC configuration by visiting the [Developer Portal](https://discord.com/developers/applications), selecting your application, and opening the `External Auth` page under the `Discord Social SDK` section in the sidebar.
+:::
 
 ---
 
@@ -195,6 +261,7 @@ Common error codes and solutions for the GetProvisionalToken method:
 
 Using these credentials, we'll create a limited Discord account just for your game and try to set the username for you according to the following:
 
+- For Bot issued tokens, the `preferred_global_name` you specified will be used.
 - For OIDC, a provisional account's display name will be the value of the `preferred_username` claim, if specified in
   the ID token. This field is optional and should be between 1 and 32 characters. If not specified, the user's display
   name will default to the user's unique username, which Discord generates on creation.
@@ -222,71 +289,14 @@ client->UpdateProvisionalAccountDisplayName("CoolPlayer123", [](discordpp::Clien
 
 ## Merging Provisional Accounts
 
-When a player wants to convert their provisional account to a full Discord account.
+When a player wants to convert their provisional account to a full Discord account, we start a special version of the [access token request flow](/docs/discord-social-sdk/development-guides/account-linking-with-discord#requesting-access-tokens) where the provisional users external identity is included.
 
-### Merging Provisional Accounts for Public Clients
-
-<PublicClient />
-
-The easiest way to merge accounts is to leverage the [`Client::GetTokenFromProvisionalMerge`] (Desktop & Mobile) or [`Client::GetTokenFromDeviceProvisionalMerge`] (Console) method, which will handle the entire process for you. You'll want to first enable Public Client on your Discord application's OAuth2 tab on the Discord developer portal. You can then leverage the [`Client::GetTokenFromProvisionalMerge`] or [`Client::GetTokenFromDeviceProvisionalMerge`] method using just the client.
-
-This function should be used with the Client::Authorize function whenever a user with a provisional account wants to link to an existing Discord account or "upgrade" their provisional account into a "full" Discord account.
-
-In this case, data from the provisional account should be "migrated" to the Discord account, a process we call "account merging". Specifically, relationships, DMs, and lobby memberships are transferred to the Discord account.
-
-The provisional account will be deleted once this merging process is completed. If the user unlinks later, a new provisional account with a new unique ID is created.
-
-The account merging process starts like the normal login flow, invoking the [`Client::Authorize`] method to get an authorization code back. Instead of calling `GetToken`, call this function and pass on the provisional user's identity.
-
-Discord can then find the provisional account with that identity and the new Discord account and merge any data as necessary.
-
-See the documentation for [`Client::GetToken`] for more details on the callback. Note that the callback will be invoked when the token exchange is complete, but merging accounts happens asynchronously and will not be complete yet.
-
-```cpp
-// Create a code verifier and challenge if using GetToken
-auto codeVerifier = client->CreateAuthorizationCodeVerifier();
-discordpp::AuthorizationArgs args{};
-args.SetClientId(YOUR_DISCORD_APPLICATION_ID);
-args.SetScopes(discordpp::Client::GetDefaultPresenceScopes());
-args.SetCodeChallenge(codeVerifier.Challenge());
-
-client->Authorize(args, [client, codeVerifier](discordpp::ClientResult result, std::string code, std::string redirectUri) {
-  if (!result.Successful()) {
-    std::cerr << "❌ Authorization Error: " << result.Error() << std::endl;
-  } else {
-    std::cout << "✅ Authorization successful! Next step: GetTokenFromProvisionalMerge \n";
-
-    // Retrieve your external auth token
-    std::string externalAuthToken = GetExternalAuthToken();
-
-    client->GetTokenFromProvisionalMerge(YOUR_DISCORD_APPLICATION_ID, code, codeVerifier, redirectUri, discordpp::AuthenticationExternalAuthType::OIDC, externalAuthToken,[client](
-      discordpp::ClientResult result,
-      std::string accessToken,
-      std::string refreshToken,
-      discordpp::AuthorizationTokenType tokenType,
-      int32_t expiresIn,
-      std::string scope) {
-        if (result.Successful()) {
-          std::cout << "🔓 Token received! Establishing connection...\n";
-          client->UpdateToken(discordpp::AuthorizationTokenType::Bearer, accessToken, [client](discordpp::ClientResult result) {
-            client->Connect();
-          });
-        } else {
-          std::cerr << "❌ Token request failed: " << result.Error() << std::endl;
-        }
-    });
-
-  }
-});
-```
-
-You'll want to use your game backend for the merge operation if you have one.
+- If you have a backend, follow [Merging Provisional Accounts for Servers](/docs/discord-social-sdk/development-guides/using-provisional-acounts#merging-provisional-accounts-for-servers)
+- If you do not have a backend, follow [Merging Provisional Accounts for Public Clients ](/docs/discord-social-sdk/development-guides/using-provisional-acounts#merging-provisional-accounts-for-public-clients)
 
 ### Merging Provisional Accounts for Servers
 
 #### Desktop & Mobile
-
-If you are not using the [`Client::GetTokenFromProvisionalMerge`] or [`Client::GetTokenFromDeviceProvisionalMerge`] method, you'll need to make a request to our API's OAuth2 token endpoint from your server.
 
 ```python
 import requests
@@ -349,6 +359,62 @@ def exchange_device_code_with_merge(device_code):
 }
 ```
 
+### Merging Provisional Accounts for Public Clients
+
+<PublicClient />
+
+If you do not have a backend, leverage the [`Client::GetTokenFromProvisionalMerge`] (Desktop & Mobile) or [`Client::GetTokenFromDeviceProvisionalMerge`] (Console) method, which will handle the entire process for you. You'll want to first enable Public Client on your Discord application's OAuth2 tab on the Discord developer portal. You can then leverage the [`Client::GetTokenFromProvisionalMerge`] or [`Client::GetTokenFromDeviceProvisionalMerge`] method using just the client.
+
+This function should be used with the Client::Authorize function whenever a user with a provisional account wants to link to an existing Discord account or "upgrade" their provisional account into a "full" Discord account.
+
+In this case, data from the provisional account should be "migrated" to the Discord account, a process we call "account merging". Specifically, relationships, DMs, and lobby memberships are transferred to the Discord account.
+
+The provisional account will be deleted once this merging process is completed. If the user unlinks later, a new provisional account with a new unique ID is created.
+
+The account merging process starts like the normal login flow, invoking the [`Client::Authorize`] method to get an authorization code back. Instead of calling `GetToken`, call this function and pass on the provisional user's identity.
+
+Discord can then find the provisional account with that identity and the new Discord account and merge any data as necessary.
+
+See the documentation for [`Client::GetToken`] for more details on the callback. Note that the callback will be invoked when the token exchange is complete, but merging accounts happens asynchronously and will not be complete yet.
+
+```cpp
+// Create a code verifier and challenge if using GetToken
+auto codeVerifier = client->CreateAuthorizationCodeVerifier();
+discordpp::AuthorizationArgs args{};
+args.SetClientId(YOUR_DISCORD_APPLICATION_ID);
+args.SetScopes(discordpp::Client::GetDefaultPresenceScopes());
+args.SetCodeChallenge(codeVerifier.Challenge());
+
+client->Authorize(args, [client, codeVerifier](discordpp::ClientResult result, std::string code, std::string redirectUri) {
+  if (!result.Successful()) {
+    std::cerr << "❌ Authorization Error: " << result.Error() << std::endl;
+  } else {
+    std::cout << "✅ Authorization successful! Next step: GetTokenFromProvisionalMerge \n";
+
+    // Retrieve your external auth token
+    std::string externalAuthToken = GetExternalAuthToken();
+
+    client->GetTokenFromProvisionalMerge(YOUR_DISCORD_APPLICATION_ID, code, codeVerifier, redirectUri, discordpp::AuthenticationExternalAuthType::OIDC, externalAuthToken,[client](
+      discordpp::ClientResult result,
+      std::string accessToken,
+      std::string refreshToken,
+      discordpp::AuthorizationTokenType tokenType,
+      int32_t expiresIn,
+      std::string scope) {
+        if (result.Successful()) {
+          std::cout << "🔓 Token received! Establishing connection...\n";
+          client->UpdateToken(discordpp::AuthorizationTokenType::Bearer, accessToken, [client](discordpp::ClientResult result) {
+            client->Connect();
+          });
+        } else {
+          std::cerr << "❌ Token request failed: " << result.Error() << std::endl;
+        }
+    });
+
+  }
+});
+```
+
 ### Data Migration During Merging
 
 When a user merges their provisional account with a Discord account, the following data is automatically transferred:
@@ -366,11 +432,11 @@ This migration ensures users don't lose their social connections built while usi
 When a player wants to unlink their Discord account from their provisional account, there are three options:
 
 1. The user can unmerge their account from the Discord client
-2. A developer can use the SDK helper method for public clients
-3. A developer can unmerge the account using the unmerge endpoint on the Discord API
+2. A developer can unmerge the account using the unmerge endpoint on the Discord API
+3. A developer can use the SDK helper method for public clients
 
 :::warn
-Unmerging invalidates all access/refresh tokens for the user. They cannot be used again after the unmerge operation completes.
+Unmerging invalidates all access/refresh tokens for the user. They cannot be used again after the unmerge operation completes. Any connected game sessions will be disconnected.
 :::
 
 ### Discord Users
@@ -380,7 +446,38 @@ Users can unmerge their account by removing access to your application on their 
 This method doesn't require any code changes from developers, but we recommend providing unmerging functionality through
 one of the options below for a better user experience.
 
-### Using the SDK Helper Method
+If you would like to be notified when a user unlinks this way, you can [configure you application to listen for the `APPLICATION_DEAUTHORIZED` webhook event](/docs/events/webhook-events#application-deauthorized).
+Otherwise, you will know that the user has unlinked because their access token and refresh token (if you have one) will be invalidated.
+
+### Unmerging Provisional Accounts for Servers
+
+A developer can unmerge a user's account by sending a request to the unmerge endpoint on the Discord API.
+
+
+```python
+import requests
+
+API_ENDPOINT = 'https://discord.com/api/v10'
+CLIENT_ID = '332269999912132097'
+CLIENT_SECRET = '937it3ow87i4ery69876wqire'
+EXTERNAL_AUTH_TYPE = 'OIDC'
+
+def unmerge_provisional_account(external_auth_token):
+  data = {
+    'client_id': CLIENT_ID,
+    'client_secret': CLIENT_SECRET,
+    'external_auth_type': EXTERNAL_AUTH_TYPE,
+    'external_auth_token': external_auth_token
+  }
+  r = requests.post('%s/partner-sdk/provisional-accounts/unmerge' % API_ENDPOINT, json=data, headers=headers)
+  r.raise_for_status()
+```
+
+:::info
+If you have a server backend, you'll want to use the server-to-server unmerge endpoint rather than the SDK helper method to maintain better security and control over the unmerge process.
+:::
+
+### Unmerging Provisional Accounts for Public Clients
 
 <PublicClient />
 
@@ -441,34 +538,6 @@ void UnmergeUserAccount(const std::shared_ptr<discordpp::Client>& client) {
     );
 }
 ```
-
-### Unmerging using the unmerge endpoint
-
-A developer can unmerge a user's account by sending a request to the unmerge endpoint on the Discord API.
-
-
-```python
-import requests
-
-API_ENDPOINT = 'https://discord.com/api/v10'
-CLIENT_ID = '332269999912132097'
-CLIENT_SECRET = '937it3ow87i4ery69876wqire'
-EXTERNAL_AUTH_TYPE = 'OIDC'
-
-def unmerge_provisional_account(external_auth_token):
-  data = {
-    'client_id': CLIENT_ID,
-    'client_secret': CLIENT_SECRET,
-    'external_auth_type': EXTERNAL_AUTH_TYPE,
-    'external_auth_token': external_auth_token
-  }
-  r = requests.post('%s/partner-sdk/provisional-accounts/unmerge' % API_ENDPOINT, json=data, headers=headers)
-  r.raise_for_status()
-```
-
-:::info
-If you have a server backend, you'll want to use the server-to-server unmerge endpoint rather than the SDK helper method to maintain better security and control over the unmerge process.
-:::
 
 ### Data Migration During Unmerging
 

--- a/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
+++ b/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
@@ -137,12 +137,11 @@ def get_provisional_token(game_account: GameAccount):
   response = requests.post(
     'https://discord.com/api/v10/partner-sdk/token/bot',
     json={
-      'external_user_id': game_account.id,
-      'preferred_global_name': game_account.display_name,
+      'external_user_id': game_account.id,       # your account system's unique id
+      'preferred_global_name': game_account.display_name, # your account system's display name for the user
     }
   )
   return response.json()
-```
 
 #### Bot Token Endpoint Response
 

--- a/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
+++ b/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
@@ -76,7 +76,7 @@ Discord offers a number of authentication methods, the one you use depends on ho
 2. Use the [External Credentials Exchange Endpoint](/docs/discord-social-sdk/development-guides/using-provisional-accounts#external-credentials-exchange-endpoint) if you have an existing OIDC provider, or do not have an account system.
 3. Use the [Client Side Token Exchange Method](/docs/discord-social-sdk/development-guides/using-provisional-accounts#provisional-account-authentication-for-public-clients) if you are using a Public Client.
 
-If you are using (2) or (3), you must configure you identity provider before proceeding.
+If you are using (2) or (3), you must configure you identity provider before being able to create provisional accounts.
 
 ### Configuring Your Identity Provider
 

--- a/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
+++ b/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
@@ -297,7 +297,7 @@ When a player wants to convert their provisional account to a full Discord accou
 
 ### Merging Provisional Accounts for Servers
 
-Merging is as simple as including `external_auth_type` and `external_auth_token` in a request to `/oauth2/token`. Discord will look up the Provisional User associated with the provided identity and attempt to merge it in to the full Discord account that generated the provided `code`.
+To merge provisional accounts, include `external_auth_type` and `external_auth_token` values with a request to `/oauth2/token`. Discord will look up the Provisional User associated with the provided identity and attempt to merge it in to the full Discord account that generated the provided `code`.
 
 #### Desktop & Mobile
 
@@ -368,7 +368,7 @@ def exchange_device_code_with_merge(device_code):
 
 If you do not have a backend, leverage the [`Client::GetTokenFromProvisionalMerge`] (Desktop & Mobile) or [`Client::GetTokenFromDeviceProvisionalMerge`] (Console) method, which will handle the entire process for you. You'll want to first enable Public Client on your Discord application's OAuth2 tab on the Discord developer portal. You can then leverage the [`Client::GetTokenFromProvisionalMerge`] or [`Client::GetTokenFromDeviceProvisionalMerge`] method using just the client.
 
-This function should be used with the Client::Authorize function whenever a user with a provisional account wants to link to an existing Discord account or "upgrade" their provisional account into a "full" Discord account.
+This function should be used with the [`Client::Authorize`] function whenever a user with a provisional account wants to link to an existing Discord account or "upgrade" their provisional account into a "full" Discord account.
 
 In this case, data from the provisional account should be "migrated" to the Discord account, a process we call "account merging". Specifically, relationships, DMs, and lobby memberships are transferred to the Discord account.
 

--- a/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
+++ b/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
@@ -81,7 +81,7 @@ If you are using (2) or (3), you must configure you identity provider before bei
 ### Configuring Your Identity Provider
 
 :::warn
-If you are using the bot token endpoint, no configuration is required.
+If you are using the bot token endpoint, no Identity Provider configuration is required.
 :::
 
 Open the Discord app for your game in the [Developer Portal](https://discord.com/developers/applications). Find the `External Auth` page under the `Discord Social SDK` section in the sidebar.

--- a/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
+++ b/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
@@ -72,9 +72,9 @@ For existing Discord users who have added a provisional account as a game friend
 
 Discord offers a number of authentication methods, the one you use depends on how you game and account system is set up:
 
-1. Use the [Bot Token Endpoint](/docs/discord-social-sdk/development-guides/using-provisional-accounts#bot-token-endpoint#) if your game has an account system which uniquely identifies users. This is the recommended approach when possible.
-2. Use the [External Credentials Exchange Endpoint](/docs/discord-social-sdk/development-guides/using-provisional-accounts#external-credentials-exchange-endpoint) if you have an existing OIDC provider, or do not have an account system.
-3. Use the [Client Side Token Exchange Method](/docs/discord-social-sdk/development-guides/using-provisional-accounts#provisional-account-authentication-for-public-clients) if you are using a Public Client.
+1. Use the [Bot Token Endpoint](/docs/discord-social-sdk/development-guides/using-provisional-accounts#server-authentication-with-bot-token-endpoint) if your game has an account system which uniquely identifies users. This is the recommended approach when possible.
+2. Use the [Server Authentication with External Credentials Exchange](/docs/discord-social-sdk/development-guides/using-provisional-accounts#server-authentication-with-external-credentials-exchange) if you have an existing OIDC provider, or do not have an account system.
+3. Use the [Client Side Token Exchange Method](/docs/discord-social-sdk/development-guides/using-provisional-accounts#authentication-for-public-clients) if you are using a Public Client.
 
 If you are using (2) or (3), you must configure you identity provider before being able to create provisional accounts.
 
@@ -122,12 +122,12 @@ You provide external authentication and uniquely identifies the user, and Discor
 
 Once authentication is complete, you can use the access token as you would a full Discord user's access token.
 
+### Server Authentication with Bot Token Endpoint
 
-### Provisional Account Authentication for Servers
+:::info
+This is the preferred method of authentication. It ends up being the simplest choice for most provisional account integrations.
+:::
 
-If you are not using the [`Client::GetProvisionalToken`] method, you'll need to make a request to the Discord API provisional account token endpoint.
-
-#### Bot Token Endpoint
 ```python
 # filepath: your_game/server/auth.py
 import requests
@@ -142,6 +142,7 @@ def get_provisional_token(game_account: GameAccount):
     }
   )
   return response.json()
+```
 
 #### Bot Token Endpoint Response
 
@@ -155,7 +156,7 @@ def get_provisional_token(game_account: GameAccount):
 }
 ```
 
-#### External Credentials Exchange Endpoint
+### Server Authentication with External Credentials Exchange
 ```python
 # filepath: your_game/server/auth.py
 import requests
@@ -186,7 +187,7 @@ def get_provisional_token(external_token: str):
 }
 ```
 
-### Provisional Account Authentication for Public Clients
+### Authentication for Public Clients
 
 <PublicClient />
 

--- a/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
+++ b/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
@@ -67,17 +67,22 @@ For existing Discord users who have added a provisional account as a game friend
 
 ---
 
-## Choosing an Authentication Method
+## Getting Set Up
+### Choosing an Authentication Method
 
-Discord offers a number of authentication methods tailored to different games:
+Discord offers a number of authentication methods, the one you use depends on how you game and account system is set up:
 
-1. Use the [**Bot Token Endpoint**](/docs/discord-social-sdk/development-guides/using-provisional-acounts#bot-token-endpoint#) if your game has an account system which uniquely identifies users. This is the recommended approach when possible.
-2. Use the [**External Credentials Exchange Endpoint**](/docs/discord-social-sdk/development-guides/using-provisional-acounts#external-credentials-exchange-endpoint) if you have an existing OIDC provider, or do not have an account system.
-3. Use the [**Client Side Token Exchange Method**](/docs/discord-social-sdk/development-guides/using-provisional-acounts#provisional-account-authentication-for-public-clients) if you are using a Public Client.
+1. Use the [Bot Token Endpoint](/docs/discord-social-sdk/development-guides/using-provisional-accounts#bot-token-endpoint#) if your game has an account system which uniquely identifies users. This is the recommended approach when possible.
+2. Use the [External Credentials Exchange Endpoint](/docs/discord-social-sdk/development-guides/using-provisional-accounts#external-credentials-exchange-endpoint) if you have an existing OIDC provider, or do not have an account system.
+3. Use the [Client Side Token Exchange Method](/docs/discord-social-sdk/development-guides/using-provisional-accounts#provisional-account-authentication-for-public-clients) if you are using a Public Client.
 
-If you are using the **External Credentials Exchange Endpoint** or **Client Side Token Exchange Method**, you must [configure you identity provider](/docs/discord-social-sdk/development-guides/using-provisional-acounts#configuring-your-identity-provider) before proceeding.
+If you are using (2) or (3), you must configure you identity provider before proceeding.
 
-## Configuring Your Identity Provider
+### Configuring Your Identity Provider
+
+:::warn
+If you are using the bot token endpoint, no configuration is required.
+:::
 
 Open the Discord app for your game in the [Developer Portal](https://discord.com/developers/applications). Find the `External Auth` page under the `Discord Social SDK` section in the sidebar.
 
@@ -90,9 +95,7 @@ We currently support the following provider types:
 - Epic Online Services (EOS)
 - Unity
 
-If you are using the bot token endpoint, no configuration is required.
-
-Which are represented in Discord's systems by the following types:
+Providers are represented in Discord's systems by the following types:
 
 #### External Auth Types
 
@@ -115,7 +118,7 @@ You provide external authentication and uniquely identifies the user, and Discor
 
 - If there is no account associated with the identity, a new provisional account is created along with a new access token for the user.
 - If there is a provisional account associated with the identity, an access token is returned.
-- If there is an existing _full Discord account_ associated with the identity, the request is aborted (See [Error Handling](/docs/discord-social-sdk/development-guides/using-provisional-acounts#error-handling)).
+- If there is an existing _full Discord account_ associated with the identity, the request is aborted (See [Error Handling](/docs/discord-social-sdk/development-guides/using-provisional-accounts#error-handling)).
 
 Once authentication is complete, you can use the access token as you would a full Discord user's access token.
 
@@ -245,15 +248,14 @@ Common error codes and solutions for the server token exchange methods:
 If you are using OIDC, you may encounter more specific errors:
 
 | Code   | Meaning                           | Solution                                                                    |
+|--------|-----------------------------------|-----------------------------------------------------------------------------|
 | 530002 | Invalid issuer                    | Verify the issuer in your ID token matches your configuration               |
 | 530003 | Invalid audience                  | Check that the audience in your ID token matches your OIDC configuration    |
 | 530008 | OIDC configuration not found      | Verify your OIDC issuer URL is configured and accessible                    |
 | 530009 | OIDC JWKS not found               | Check that your OIDC provider's JWKS endpoint is accessible                 |
 | 530020 | Invalid OIDC JWT token            | Ensure your OIDC ID token is properly signed and formatted                  |
 
-:::info
  You can find you OIDC configuration by visiting the [Developer Portal](https://discord.com/developers/applications), selecting your application, and opening the `External Auth` page under the `Discord Social SDK` section in the sidebar.
-:::
 
 ---
 
@@ -291,10 +293,12 @@ client->UpdateProvisionalAccountDisplayName("CoolPlayer123", [](discordpp::Clien
 
 When a player wants to convert their provisional account to a full Discord account, we start a special version of the [access token request flow](/docs/discord-social-sdk/development-guides/account-linking-with-discord#requesting-access-tokens) where the provisional users external identity is included.
 
-- If you have a backend, follow [Merging Provisional Accounts for Servers](/docs/discord-social-sdk/development-guides/using-provisional-acounts#merging-provisional-accounts-for-servers)
-- If you do not have a backend, follow [Merging Provisional Accounts for Public Clients ](/docs/discord-social-sdk/development-guides/using-provisional-acounts#merging-provisional-accounts-for-public-clients)
+- If you have a backend, follow [Merging Provisional Accounts for Servers](/docs/discord-social-sdk/development-guides/using-provisional-accounts#merging-provisional-accounts-for-servers)
+- If you do not have a backend, follow [Merging Provisional Accounts for Public Clients ](/docs/discord-social-sdk/development-guides/using-provisional-accounts#merging-provisional-accounts-for-public-clients)
 
 ### Merging Provisional Accounts for Servers
+
+Merging is as simple as including `external_auth_type` and `external_auth_token` in a request to `/oauth2/token`. Discord will look up the Provisional User associated with the provided identity and attempt to merge it in to the full Discord account that generated the provided `code`.
 
 #### Desktop & Mobile
 
@@ -304,7 +308,7 @@ import requests
 API_ENDPOINT = 'https://discord.com/api/v10'
 CLIENT_ID = '332269999912132097'
 CLIENT_SECRET = '937it3ow87i4ery69876wqire'
-EXTERNAL_AUTH_TYPE = 'OIDC'
+EXTERNAL_AUTH_TYPE = 'OIDC' # See External Auth Types above
 
 def exchange_code_with_merge(code, redirect_uri, external_auth_token):
   data = {
@@ -424,6 +428,19 @@ When a user merges their provisional account with a Discord account, the followi
 * **✅ DM Messages**: Direct messages and history
 
 This migration ensures users don't lose their social connections built while using the provisional account.
+
+
+### Merge Request Failures
+
+You may receive a merge specific error code while attempting this operation:
+
+| Code   | HTTP Status | Meaning                                    | Solution                                                                   |
+|--------|-------------|--------------------------------------------|--------------------------------------------------------------------------- |
+| 530014 | 400         | Invalid merge source                       | The source account is not provisional                                      |
+| 530016 | 400         | Invalid merge destination                  | The destination account is provisional                                     |
+| 530017 | 400         | Merge source user banned                   | The provisional account being merged is banned from platform               |
+| 530023 | 400         | Too many application identities            | User already has an associated external identity for this application      |
+| -      | 423         | Resource locked                            | Transient error, wait and retry                                            |
 
 ---
 
@@ -551,6 +568,16 @@ When a user unmerges their account, a new provisional account is created with a 
 :::info
 Provisional accounts can have Discord friends, but can only message these friends when actively playing the game.
 :::
+
+### Unmerge Request Failures
+
+You may receive an unmerge specific error code while attempting this operation:
+
+Code   | HTTP Status | Meaning                                    | Solution                                                                   |
+|--------|-------------|--------------------------------------------|--------------------------------------------------------------------------|
+| 50229  | 400         | Invalid user type                          | User account is provisional and cannot be unmerged                       |
+| -      | 404         | Unknown user                               | No user identity found for the provided external identity                |
+
 
 ---
 


### PR DESCRIPTION
In no particular order this PR:
- Introduces the `/partner-sdk/token/bot` endpoint
- provides more opinionated guidance on which external auth method to use (bot vs external auth vs SDK public client method)
- re-orders the guide to de-emphasize public client methods
- expands error handling guide to cover more common errors
- breaks out OIDC errors into separate table with more guidance
- calls out the APPLICATION_DEAUTHORIZED webhook when discussing unlink / unmerging
- adds error handling guides for merge and unmerge operations