### PR TITLE
Fix broken alert box in guild resource docs

### DIFF
--- a/docs/resources/guild.mdx
+++ b/docs/resources/guild.mdx
@@ -379,8 +379,9 @@ The field `user` won't be included in the member object attached to `MESSAGE_CRE
 In `GUILD_` events, `pending` will always be included as true or false. In non `GUILD_` events which can only be triggered by non-`pending` users, `pending` will not be included.
 :::
 
-> info
-> Member objects retrieved from `VOICE_STATE_UPDATE` events will have `joined_at` set as `null` if the member was invited as a guest.
+:::info
+Member objects retrieved from `VOICE_STATE_UPDATE` events will have `joined_at` set as `null` if the member was invited as a guest.
+:::
 
 ###### Example Guild Member
 


### PR DESCRIPTION
This PR fixes an alert box which never got updated to the newer formatting
<img width="2355" height="713" alt="image" src="https://github.com/user-attachments/assets/9f2898b0-a937-4e6d-8506-a94c0bdf9bc9" />

I checked the rest of the docs and didn't find any other instances of this, looks like this was the only one