### PR TITLE
Add OAuth verification requirement

### DIFF
--- a/docs/discord-social-sdk/development-guides/account-linking-on-consoles.mdx
+++ b/docs/discord-social-sdk/development-guides/account-linking-on-consoles.mdx
@@ -50,7 +50,7 @@ Console users cannot authenticate via a web browser. Instead, they follow these 
 The SDK can manage this process automatically or allow manual token handling.
 
 :::info
-The OAuth2 flow requires a [user's account to be verified](https://support.discord.com/hc/en-us/articles/6181726888215-How-to-Verify-Your-Discord-Account)
+The OAuth2 flow requires a user's account to be verified
 :::
 
 ![Authorization screen from using OpenAuthorizeDeviceScreen and GetTokenFromDevice](images/social-sdk/development-guides/authorize_device.webp)

--- a/docs/discord-social-sdk/development-guides/account-linking-on-consoles.mdx
+++ b/docs/discord-social-sdk/development-guides/account-linking-on-consoles.mdx
@@ -49,6 +49,10 @@ Console users cannot authenticate via a web browser. Instead, they follow these 
 
 The SDK can manage this process automatically or allow manual token handling.
 
+:::info
+The OAuth2 flow requires a [user's account to be verified](https://support.discord.com/hc/en-us/articles/6181726888215-How-to-Verify-Your-Discord-Account)
+:::
+
 ![Authorization screen from using OpenAuthorizeDeviceScreen and GetTokenFromDevice](images/social-sdk/development-guides/authorize_device.webp)
 
 ---

--- a/docs/discord-social-sdk/development-guides/account-linking-with-discord.mdx
+++ b/docs/discord-social-sdk/development-guides/account-linking-with-discord.mdx
@@ -44,7 +44,7 @@ OAuth2 is the standard authentication flow that allows users to sign in using th
    - Refresh Token, used to obtain a new access token
 
 :::info
-The OAuth2 flow requires a [user's account to be verified](https://support.discord.com/hc/en-us/articles/6181726888215-How-to-Verify-Your-Discord-Account)
+The OAuth2 flow requires a user's account to be verified
 :::
 
 ### OAuth2 using the Discord Social SDK

--- a/docs/discord-social-sdk/development-guides/account-linking-with-discord.mdx
+++ b/docs/discord-social-sdk/development-guides/account-linking-with-discord.mdx
@@ -43,6 +43,10 @@ OAuth2 is the standard authentication flow that allows users to sign in using th
    - Access Token, which is valid for ~7 days
    - Refresh Token, used to obtain a new access token
 
+:::info
+The OAuth2 flow requires a [user's account to be verified](https://support.discord.com/hc/en-us/articles/6181726888215-How-to-Verify-Your-Discord-Account)
+:::
+
 ### OAuth2 using the Discord Social SDK
 
 - If the Discord client has [overlay support](https://support.discord.com/hc/en-us/articles/217659737-Game-Overlay-101) (Windows only), the OAuth2 login modal appears in your game instead of opening a browser.


### PR DESCRIPTION
OAuth2 now requires a user's account to be verified before they can allow it. This adds a note about it with a link to how to verify!
<img width="1121" height="557" alt="Screenshot 2025-09-17 at 1 27 18 PM" src="https://github.com/user-attachments/assets/c764c9f7-9b6c-4ef3-81f0-8671cb331745" />
<img width="1130" height="744" alt="Screenshot 2025-09-17 at 1 30 23 PM" src="https://github.com/user-attachments/assets/c0e31a11-4170-4a2d-aad0-edb28a8eac62" />
