### PR TITLE
Document invite profile

### DIFF
--- a/docs/resources/guild.mdx
+++ b/docs/resources/guild.mdx
@@ -65,7 +65,6 @@ Fields specific to the `GUILD_CREATE` event are listed in the [Gateway Events do
 
 \*\* This field is deprecated and is replaced by [channel.rtc_region](/docs/resources/channel#channel-object-channel-structure)
 
-
 ###### Default Message Notification Level
 
 | Key           | Value | Description                                                                        |
@@ -421,7 +420,7 @@ BYPASSES_VERIFICATION allows a member who does not meet verification requirement
 ### Guild Profile Object
 
 :::info
-This object can be retrieved using `profile` field using the [GET Invite](docs/resources/invite#get-invite) endpoint.
+This object can only be retrieved through the `profile` field of the [GET Invite](/docs/resources/invite#get-invite) endpoint.
 :::
 
 ###### Guild Profile Structure

--- a/docs/resources/guild.mdx
+++ b/docs/resources/guild.mdx
@@ -425,28 +425,39 @@ This object can only be retrieved through the `profile` field of the [GET Invite
 
 ###### Guild Profile Structure
 
-| Field                      | Type                                                                                | Description                                                                                    |
-|----------------------------|-------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
-| badge                      | integer                                                                             | guild badge                                                                                    |
-| badge_color_primary        | string                                                                              | primary color for the guild badge                                                              |
-| badge_color_secondary      | string                                                                              | secondary color for the guild badge                                                            |
-| badge_hash                 | ?string                                                                             | [guild tag badge hash](/docs/reference#image-formatting)                                       |
-| banner_hash                | ?string                                                                             | [server tag badge hash](/docs/reference#image-formatting)                                      |
-| custom_banner_hash         | ?string                                                                             | [custom banner hash](/docs/reference#image-formatting)                                         |
-| description                | ?string                                                                             | the description for the guild                                                                  |
-| features                   | array of [guild feature](/docs/resources/guild#guild-object-guild-features) strings | enabled guild features                                                                         |
-| game_activity              | object                                                                              | game activity data for the guild                                                               |
-| game_application_ids       | array of snowflakes                                                                 | application ids for games associated with the guild                                            |
-| icon_hash                  | ?string                                                                             | [icon hash](/docs/reference#image-formatting)                                                  |
-| id                         | snowflake                                                                           | guild id                                                                                       |
-| member_count               | integer                                                                             | total number of members in the guild                                                           |
-| name                       | string                                                                              | guild name                                                                                     |
-| online_count               | integer                                                                             | number of online members in the guild                                                          |
-| premium_subscription_count | integer                                                                             | the number of boosts this guild currently has                                                  |
-| premium_tier               | integer                                                                             | [premium tier](/docs/resources/guild#guild-object-premium-tier) (Server Boost level)           |
-| tag                        | ?string                                                                             | tag of the guild                                                                               |
-| traits                     | array of strings                                                                    | traits associated with the guild                                                               |
-| visibility                 | integer                                                                             | visibility level of the guild                                                                  |
+| Field                      | Type                                                                                 | Description                                                                          |
+|----------------------------|--------------------------------------------------------------------------------------|------------------------------------------------------------------------------------- |
+| badge                      | integer                                                                              | guild badge                                                                          |
+| badge_color_primary        | string                                                                               | primary color for the guild badge                                                    |
+| badge_color_secondary      | string                                                                               | secondary color for the guild badge                                                  |
+| badge_hash                 | ?string                                                                              | [guild tag badge hash](/docs/reference#image-formatting)                             |
+| banner_hash                | ?string                                                                              | [server tag badge hash](/docs/reference#image-formatting)                            |
+| custom_banner_hash         | ?string                                                                              | [custom banner hash](/docs/reference#image-formatting)                               |
+| description                | ?string                                                                              | the description for the guild                                                        |
+| features                   | array of [guild feature](/docs/resources/guild#guild-object-guild-features) strings  | enabled guild features                                                               |
+| game_activity              | object                                                                               | game activity data for the guild                                                     |
+| game_application_ids       | array of snowflakes                                                                  | application ids for games associated with the guild                                  |
+| icon_hash                  | ?string                                                                              | [icon hash](/docs/reference#image-formatting)                                        |
+| id                         | snowflake                                                                            | guild id                                                                             |
+| member_count               | integer                                                                              | total number of members in the guild                                                 |
+| name                       | string                                                                               | guild name                                                                           |
+| online_count               | integer                                                                              | number of online members in the guild                                                |
+| premium_subscription_count | integer                                                                              | the number of boosts this guild currently has                                        |
+| premium_tier               | integer                                                                              | [premium tier](/docs/resources/guild#guild-object-premium-tier) (Server Boost level) |
+| tag                        | ?string                                                                              | tag of the guild                                                                     |
+| traits                     | array of [guild trait object](/docs/resources/guild#guild-object-guild-trait-object) | traits of the guild                                                                  |
+| visibility                 | integer                                                                              | visibility level of the guild                                                        |
+
+
+###### Guild Trait Object
+
+| Field          | Type       | Description                        |
+|----------------|------------|------------------------------------|
+| emoji_id       | ?snowflake | the id of a guild's custom emoji   |
+| emoji_name     | string     | the unicode character of the emoji |
+| emoji_animated | boolean    | Whether the emoji is animated      |
+| label          | string     | The label of the trait             |
+| position       | integer    | The position of the trait          |
 
 ### Integration Object
 

--- a/docs/resources/guild.mdx
+++ b/docs/resources/guild.mdx
@@ -60,10 +60,13 @@ Fields specific to the `GUILD_CREATE` event are listed in the [Gateway Events do
 | premium_progress_bar_enabled   | boolean                                                                             | whether the guild has the boost progress bar enabled                                                                                                                                        |
 | safety_alerts_channel_id       | ?snowflake                                                                          | the id of the channel where admins and moderators of Community guilds receive safety alerts from Discord                                                                                    |
 | incidents_data                 | ?[incidents data](/docs/resources/guild#incidents-data-object) object               | the incidents data for this guild                                                                                                                                                           |
+| profile? \*\*\*                | [guild profile](/docs/resources/guild#guild-profile-object) object                  | the profile of this guild                                                                                                                                                                   |
 
 \* These fields are only sent when using the [GET Current User Guilds](/docs/resources/user#get-current-user-guilds) endpoint and are relative to the requested user
 
 \*\* This field is deprecated and is replaced by [channel.rtc_region](/docs/resources/channel#channel-object-channel-structure)
+
+\*\*\* This field is only sent when using the [GET Invite](docs/resources/invite#get-invite) endpoint.
 
 ###### Default Message Notification Level
 
@@ -416,6 +419,33 @@ Member objects retrieved from `VOICE_STATE_UPDATE` events will have `joined_at` 
 :::info
 BYPASSES_VERIFICATION allows a member who does not meet verification requirements to participate in a server.
 :::
+
+### Guild Profile Object
+
+###### Guild Profile Structure
+
+| Field                      | Type                                                                                | Description                                                                                    |
+|----------------------------|-------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
+| badge                      | integer                                                                             | guild badge                                                                                    |
+| badge_color_primary        | string                                                                              | primary color for the guild badge                                                              |
+| badge_color_secondary      | string                                                                              | secondary color for the guild badge                                                            |
+| badge_hash                 | ?string                                                                             | [guild tag badge hash](/docs/reference#image-formatting)                                       |
+| banner_hash                | ?string                                                                             | [server tag badge hash](/docs/reference#image-formatting)                                      |
+| custom_banner_hash         | ?string                                                                             | [custom banner hash](/docs/reference#image-formatting)                                         |
+| description                | ?string                                                                             | the description for the guild                                                                  |
+| features                   | array of [guild feature](/docs/resources/guild#guild-object-guild-features) strings | enabled guild features                                                                         |
+| game_activity              | object                                                                              | game activity data for the guild                                                               |
+| game_application_ids       | array of snowflakes                                                                 | application ids for games associated with the guild                                            |
+| icon_hash                  | ?string                                                                             | [icon hash](/docs/reference#image-formatting)                                                  |
+| id                         | snowflake                                                                           | guild id                                                                                       |
+| member_count               | integer                                                                             | total number of members in the guild                                                           |
+| name                       | string                                                                              | guild name                                                                                     |
+| online_count               | integer                                                                             | number of online members in the guild                                                          |
+| premium_subscription_count | integer                                                                             | the number of boosts this guild currently has                                                  |
+| premium_tier               | integer                                                                             | [premium tier](/docs/resources/guild#guild-object-premium-tier) (Server Boost level)           |
+| tag                        | ?string                                                                             | tag of the guild                                                                               |
+| traits                     | array of strings                                                                    | traits associated with the guild                                                               |
+| visibility                 | integer                                                                             | visibility level of the guild                                                                  |
 
 ### Integration Object
 

--- a/docs/resources/guild.mdx
+++ b/docs/resources/guild.mdx
@@ -448,7 +448,6 @@ This object can only be retrieved through the `profile` field of the [GET Invite
 | traits                     | array of [guild trait object](/docs/resources/guild#guild-object-guild-trait-object) | traits of the guild                                                                  |
 | visibility                 | integer                                                                              | visibility level of the guild                                                        |
 
-
 ###### Guild Trait Object
 
 | Field          | Type       | Description                        |

--- a/docs/resources/guild.mdx
+++ b/docs/resources/guild.mdx
@@ -60,13 +60,11 @@ Fields specific to the `GUILD_CREATE` event are listed in the [Gateway Events do
 | premium_progress_bar_enabled   | boolean                                                                             | whether the guild has the boost progress bar enabled                                                                                                                                        |
 | safety_alerts_channel_id       | ?snowflake                                                                          | the id of the channel where admins and moderators of Community guilds receive safety alerts from Discord                                                                                    |
 | incidents_data                 | ?[incidents data](/docs/resources/guild#incidents-data-object) object               | the incidents data for this guild                                                                                                                                                           |
-| profile? \*\*\*                | [guild profile](/docs/resources/guild#guild-profile-object) object                  | the profile of this guild                                                                                                                                                                   |
 
 \* These fields are only sent when using the [GET Current User Guilds](/docs/resources/user#get-current-user-guilds) endpoint and are relative to the requested user
 
 \*\* This field is deprecated and is replaced by [channel.rtc_region](/docs/resources/channel#channel-object-channel-structure)
 
-\*\*\* This field is only sent when using the [GET Invite](docs/resources/invite#get-invite) endpoint.
 
 ###### Default Message Notification Level
 
@@ -421,6 +419,10 @@ BYPASSES_VERIFICATION allows a member who does not meet verification requirement
 :::
 
 ### Guild Profile Object
+
+:::info
+This object can be retrieved using `profile` field using the [GET Invite](docs/resources/invite#get-invite) endpoint.
+:::
 
 ###### Guild Profile Structure
 

--- a/docs/resources/invite.mdx
+++ b/docs/resources/invite.mdx
@@ -25,7 +25,7 @@ Represents a code that when used, adds a user to a guild or group DM channel.
 | expires_at                  | ?ISO8601 timestamp                                                                                 | the expiration date of this invite                                                                                 |
 | guild_scheduled_event?      | [guild scheduled event](/docs/resources/guild-scheduled-event#guild-scheduled-event-object) object | guild scheduled event data, only included if `guild_scheduled_event_id` contains a valid guild scheduled event id  |
 | flags?                      | integer                                                                                            | [guild invite flags](/docs/resources/invite#invite-object-guild-invite-flags) for guild invites                    |
-| profile                     | [guild profile](/docs/resources/guild#guild-profile-object) object                                 | the profile of this guild                                                                                          |
+| profile                     | [guild profile](/docs/resources/guild#guild-profile-object) object                                 | the guild profile                                                                                                  |
 
 ###### Invite Types
 

--- a/docs/resources/invite.mdx
+++ b/docs/resources/invite.mdx
@@ -25,6 +25,7 @@ Represents a code that when used, adds a user to a guild or group DM channel.
 | expires_at                  | ?ISO8601 timestamp                                                                                 | the expiration date of this invite                                                                                 |
 | guild_scheduled_event?      | [guild scheduled event](/docs/resources/guild-scheduled-event#guild-scheduled-event-object) object | guild scheduled event data, only included if `guild_scheduled_event_id` contains a valid guild scheduled event id  |
 | flags?                      | integer                                                                                            | [guild invite flags](/docs/resources/invite#invite-object-guild-invite-flags) for guild invites                    |
+| profile                     | [guild profile](/docs/resources/guild#guild-profile-object) object                                 | the profile of this guild                                                                                          |
 
 ###### Invite Types
 


### PR DESCRIPTION
I noticed that the [GET /invites/{code}](https://discord.com/developers/docs/resources/invite#get-invite) endpoint has included a profile field for a while now, but it hasn’t been documented yet. This PR does exactly that.

Additionally, there’s an endpoint not accessible to bots: `guilds/{id}/profile`. I assume it returns the same information, which is why I think the seperate object belongs under guild rather than invite.

This is my first contribution here, so any feedback or guidance would be greatly appreciated.


Maybe relevant:
- https://github.com/discord/discord-api-docs/discussions/7846