### PR TITLE
fix: mark custom_id field in button component as optional

### DIFF
--- a/developers/components/reference.mdx
+++ b/developers/components/reference.mdx
@@ -167,17 +167,17 @@ Buttons must be placed inside an [Action Row](/developers/components/reference#a
 <ManualAnchor id="button-button-structure" />
 ###### Button Structure
 
-| Field     | Type                                                      | Description                                                                                                               |
-|-----------|-----------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| type      | integer                                                   | `2` for a button                                                                                                          |
-| id?       | integer                                                   | Optional identifier for component                                                                                         |
-| style     | integer                                                   | A [button style](/developers/components/reference#button-button-styles)                                                   |
-| label?    | string                                                    | Text that appears on the button; max 80 characters                                                                        |
-| emoji?    | partial [emoji](/developers/resources/emoji#emoji-object) | `name`, `id`, and `animated`                                                                                              |
-| custom_id | string                                                    | Developer-defined identifier for the button; 1-100 characters                                                             |
-| sku_id?   | snowflake                                                 | Identifier for a purchasable [SKU](/developers/resources/sku#sku-object), only available when using premium-style buttons |
-| url?      | string                                                    | URL for link-style buttons; max 512 characters                                                                            |
-| disabled? | boolean                                                   | Whether the button is disabled (defaults to `false`)                                                                      |
+| Field      | Type                                                      | Description                                                                                                               |
+|------------|-----------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| type       | integer                                                   | `2` for a button                                                                                                          |
+| id?        | integer                                                   | Optional identifier for component                                                                                         |
+| style      | integer                                                   | A [button style](/developers/components/reference#button-button-styles)                                                   |
+| label?     | string                                                    | Text that appears on the button; max 80 characters                                                                        |
+| emoji?     | partial [emoji](/developers/resources/emoji#emoji-object) | `name`, `id`, and `animated`                                                                                              |
+| custom_id? | string                                                    | Developer-defined identifier for the button; 1-100 characters                                                             |
+| sku_id?    | snowflake                                                 | Identifier for a purchasable [SKU](/developers/resources/sku#sku-object), only available when using premium-style buttons |
+| url?       | string                                                    | URL for link-style buttons; max 512 characters                                                                            |
+| disabled?  | boolean                                                   | Whether the button is disabled (defaults to `false`)                                                                      |
 
 Buttons come in various styles to convey different types of actions. These styles also define what fields are valid for a button.
 


### PR DESCRIPTION
In button component docs, it says `custom_id` field is not optional, even though it cannot have that field when the type is `link` or `premium`.

I was confused by this and wanted to prevent further confusion