### PR TITLE
Rich Presence Activity Invite Cover Image: Update docs around how to add an invite cover image

### DIFF
--- a/docs/discord-social-sdk/development-guides/managing-game-invites.mdx
+++ b/docs/discord-social-sdk/development-guides/managing-game-invites.mdx
@@ -158,6 +158,18 @@ Now your game supports rich presence with game invites! The Discord client will 
 
 ---
 
+## Setting a Cover Image for the Invite (Optional)
+
+You can set a cover image for an invite via rich presence activity. This image displays as the banner on the invite and helps draw attention to it. Setting a cover image via rich presence allows you to dynamically customize invites per rich presence activity; for example, showing different images based on game mode, map, etc. rather than using the same static image for all invites. If not set, the banner falls back to the "Rich Presence Invite Image" configured in the Developer Portal under the "Rich Presence" tab. Setting an invite cover image is entirely optional.
+
+```cpp
+discordpp::ActivityAssets assets;
+assets.SetInviteCoverImage("invite-cover-image");
+activity.SetAssets(assets);
+```
+
+---
+
 ## Registering a Launch Command
 
 Before we send a game invite, let's make sure that the Discord client knows about your game and how to launch it.

--- a/docs/discord-social-sdk/development-guides/managing-game-invites.mdx
+++ b/docs/discord-social-sdk/development-guides/managing-game-invites.mdx
@@ -158,18 +158,6 @@ Now your game supports rich presence with game invites! The Discord client will 
 
 ---
 
-## Setting a Cover Image for the Invite (Optional)
-
-You can set a cover image for an invite via rich presence activity. This image displays as the banner on the invite and helps draw attention to it. Setting a cover image via rich presence allows you to dynamically customize invites per rich presence activity; for example, showing different images based on game mode, map, etc. rather than using the same static image for all invites. If not set, the banner falls back to the "Rich Presence Invite Image" configured in the Developer Portal under the "Rich Presence" tab. Setting an invite cover image is entirely optional.
-
-```cpp
-discordpp::ActivityAssets assets;
-assets.SetInviteCoverImage("invite-cover-image");
-activity.SetAssets(assets);
-```
-
----
-
 ## Registering a Launch Command
 
 Before we send a game invite, let's make sure that the Discord client knows about your game and how to launch it.
@@ -465,6 +453,18 @@ yourgame://_discord/join?secret=the_join_secret_you_set
    ```
 3. Your game receives the URL and extracts the join secret
 4. Use the secret to connect the player to the session
+
+---
+
+## Setting a Cover Image for the Invite (Optional)
+
+You can set a cover image for an invite via rich presence activity. This image displays as the banner on the invite and helps draw attention to it. Setting a cover image via rich presence allows you to dynamically customize invites per rich presence activity; for example, showing different images based on game mode, map, etc. rather than using the same static image for all invites. If not set, the banner falls back to the "Rich Presence Invite Image" configured in the Developer Portal under the "Rich Presence" tab. Setting an invite cover image is entirely optional.
+
+```cpp
+discordpp::ActivityAssets assets;
+assets.SetInviteCoverImage("invite-cover-image"); // This example uses an asset key, but you can use an external URL asset for more dynamic cover images.
+activity.SetAssets(assets);
+```
 
 ---
 

--- a/docs/discord-social-sdk/development-guides/setting-rich-presence.mdx
+++ b/docs/discord-social-sdk/development-guides/setting-rich-presence.mdx
@@ -146,7 +146,7 @@ activity.SetTimestamps(timestamps);
 
 ## Setting Assets
 
-Once you've uploaded assets to your app, you can reference them using their **asset key** in your code to set custom artwork in Rich Presence. Here's an example of an asset with the key of "map-mainframe" and "tank-avatar":
+Once you've uploaded assets to your app, you can reference them using their **asset key** in your code to set custom artwork in Rich Presence. Here's an example of an asset with the key of "map-mainframe", "tank-avatar", and "invite-cover-image":
 
 ```cpp
 // Setting Activity Assets

--- a/docs/discord-social-sdk/development-guides/setting-rich-presence.mdx
+++ b/docs/discord-social-sdk/development-guides/setting-rich-presence.mdx
@@ -155,6 +155,7 @@ assets.SetLargeImage("map-mainframe");
 assets.SetLargeText("Mainframe");
 assets.SetSmallImage("tank-avatar");
 assets.SetSmallText("Tank");
+assets.SetInviteCoverImage("invite-cover-image"); // Used for Game Invites
 activity.SetAssets(assets);
 ```
 

--- a/docs/events/gateway-events.mdx
+++ b/docs/events/gateway-events.mdx
@@ -1219,14 +1219,15 @@ For Listening and Watching activities, you can include both start and end timest
 
 ###### Activity Assets
 
-| Field        | Type   | Description                                                                                  |
-|--------------|--------|----------------------------------------------------------------------------------------------|
-| large_image? | string | See [Activity Asset Image](/docs/events/gateway-events#activity-object-activity-asset-image) |
-| large_text?  | string | Text displayed when hovering over the large image of the activity                            |
-| large_url?   | string | URL that is opened when clicking on the large image                                          |
-| small_image? | string | See [Activity Asset Image](/docs/events/gateway-events#activity-object-activity-asset-image) |
-| small_text?  | string | Text displayed when hovering over the small image of the activity                            |
-| small_url?   | string | URL that is opened when clicking on the small image                                          |
+| Field               | Type   | Description                                                                                                                              |
+|---------------------|--------|------------------------------------------------------------------------------------------------------------------------------------------|
+| large_image?        | string | See [Activity Asset Image](/docs/events/gateway-events#activity-object-activity-asset-image)                                             |
+| large_text?         | string | Text displayed when hovering over the large image of the activity                                                                        |
+| large_url?          | string | URL that is opened when clicking on the large image                                                                                      |
+| small_image?        | string | See [Activity Asset Image](/docs/events/gateway-events#activity-object-activity-asset-image)                                             |
+| small_text?         | string | Text displayed when hovering over the small image of the activity                                                                        |
+| small_url?          | string | URL that is opened when clicking on the small image                                                                                      |
+| invite_cover_image? | string | See [Activity Asset Image](/docs/events/gateway-events#activity-object-activity-asset-image). Displayed as a banner on a [Game Invite](/docs/discord-social-sdk/development-guides/managing-game-invites). Currently only supported via Social SDK. |
 
 ###### Activity Asset Image
 

--- a/docs/events/gateway-events.mdx
+++ b/docs/events/gateway-events.mdx
@@ -1219,15 +1219,15 @@ For Listening and Watching activities, you can include both start and end timest
 
 ###### Activity Assets
 
-| Field               | Type   | Description                                                                                                                              |
-|---------------------|--------|------------------------------------------------------------------------------------------------------------------------------------------|
-| large_image?        | string | See [Activity Asset Image](/docs/events/gateway-events#activity-object-activity-asset-image)                                             |
-| large_text?         | string | Text displayed when hovering over the large image of the activity                                                                        |
-| large_url?          | string | URL that is opened when clicking on the large image                                                                                      |
-| small_image?        | string | See [Activity Asset Image](/docs/events/gateway-events#activity-object-activity-asset-image)                                             |
-| small_text?         | string | Text displayed when hovering over the small image of the activity                                                                        |
-| small_url?          | string | URL that is opened when clicking on the small image                                                                                      |
-| invite_cover_image? | string | See [Activity Asset Image](/docs/events/gateway-events#activity-object-activity-asset-image). Displayed as a banner on a [Game Invite](/docs/discord-social-sdk/development-guides/managing-game-invites). Currently only supported via Social SDK. |
+| Field               | Type   | Description                                                                                                                                                                                                |
+|---------------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| large_image?        | string | See [Activity Asset Image](/docs/events/gateway-events#activity-object-activity-asset-image)                                                                                                               |
+| large_text?         | string | Text displayed when hovering over the large image of the activity                                                                                                                                          |
+| large_url?          | string | URL that is opened when clicking on the large image                                                                                                                                                        |
+| small_image?        | string | See [Activity Asset Image](/docs/events/gateway-events#activity-object-activity-asset-image)                                                                                                               |
+| small_text?         | string | Text displayed when hovering over the small image of the activity                                                                                                                                          |
+| small_url?          | string | URL that is opened when clicking on the small image                                                                                                                                                        |
+| invite_cover_image? | string | See [Activity Asset Image](/docs/events/gateway-events#activity-object-activity-asset-image). Displayed as a banner on a [Game Invite](/docs/discord-social-sdk/development-guides/managing-game-invites). |
 
 ###### Activity Asset Image
 


### PR DESCRIPTION
# Links
- Asana task https://app.asana.com/1/236888843494340/project/1211140002354531/task/1211412412977046?focus=true

# Visuals

<img width="2139" height="585" alt="Screenshot 2025-10-15 at 15 39 16" src="https://github.com/user-attachments/assets/b08bf4b8-32f4-4ca1-b734-9c0b574c898e" />
<img width="2016" height="589" alt="Screenshot 2025-10-15 at 15 34 14" src="https://github.com/user-attachments/assets/9813e29f-1c6a-4886-a88b-63c481b3ef49" />
<img width="2274" height="1166" alt="Screenshot 2025-10-15 at 15 33 31" src="https://github.com/user-attachments/assets/1916a4de-038d-4186-a9f7-d97864e884b2" />
