### PR TITLE
Fix result check

### DIFF
--- a/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
+++ b/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
@@ -284,7 +284,7 @@ If you'd like to set the display name for a provisional account, you can use the
 
 ```cpp
 client->UpdateProvisionalAccountDisplayName("CoolPlayer123", [](discordpp::ClientResult result) {
-    if (!result.Successful()) {
+    if (result.Successful()) {
       std::cout << "✅ Display name updated\n";
     }
   }


### PR DESCRIPTION
This spot should check for success since it's printing a success message. Checked all the other spots in our documentation and they check correctly.