### PR TITLE
Add new s/S formats to timestamp styles

### DIFF
--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -287,15 +287,17 @@ Using the markdown for either users, roles, or channels will usually mention the
 
 ###### Timestamp Styles
 
-| Style | Example Output               | Description     |
-|-------|------------------------------|-----------------|
-| t     | 16:20                        | Short Time      |
-| T     | 16:20:30                     | Long Time       |
-| d     | 20/04/2021                   | Short Date      |
-| D     | 20 April 2021                | Long Date       |
-| f \*  | 20 April 2021 16:20          | Short Date/Time |
-| F     | Tuesday, 20 April 2021 16:20 | Long Date/Time  |
-| R     | 2 months ago                 | Relative Time   |
+| Style | Example Output                   | Description            |
+|-------|----------------------------------|------------------------|
+| t     | 16:20                            | Short Time             |
+| T     | 16:20:30                         | Medium Time            |
+| d     | 20/04/2021                       | Short Date             |
+| D     | April 20, 2021                   | Long Date              |
+| f \*  | April 20, 2021 at 16:20          | Long Date/Short Time   |
+| F     | Tuesday, April 20, 2021 at 16:20 | Full Date/Short Time   |
+| s     | 20/04/2021, 16:20                | Short Date/Short Time  |
+| S     | 20/04/2021, 16:20:30             | Short Date/Medium Time |
+| R     | 2 months ago                     | Relative Time          |
 
 \* Default style used when no style is specified.
 

--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -287,17 +287,17 @@ Using the markdown for either users, roles, or channels will usually mention the
 
 ###### Timestamp Styles
 
-| Style | Example Output                   | Description            |
-|-------|----------------------------------|------------------------|
-| t     | 16:20                            | Short Time             |
-| T     | 16:20:30                         | Medium Time            |
-| d     | 20/04/2021                       | Short Date             |
-| D     | April 20, 2021                   | Long Date              |
-| f \*  | April 20, 2021 at 16:20          | Long Date/Short Time   |
-| F     | Tuesday, April 20, 2021 at 16:20 | Full Date/Short Time   |
-| s     | 20/04/2021, 16:20                | Short Date/Short Time  |
-| S     | 20/04/2021, 16:20:30             | Short Date/Medium Time |
-| R     | 2 months ago                     | Relative Time          |
+| Style | Example Output                   | Description             |
+|-------|----------------------------------|-------------------------|
+| t     | 16:20                            | Short Time              |
+| T     | 16:20:30                         | Medium Time             |
+| d     | 20/04/2021                       | Short Date              |
+| D     | April 20, 2021                   | Long Date               |
+| f \*  | April 20, 2021 at 16:20          | Long Date, Short Time   |
+| F     | Tuesday, April 20, 2021 at 16:20 | Full Date, Short Time   |
+| s     | 20/04/2021, 16:20                | Short Date, Short Time  |
+| S     | 20/04/2021, 16:20:30             | Short Date, Medium Time |
+| R     | 2 months ago                     | Relative Time           |
 
 \* Default style used when no style is specified.
 


### PR DESCRIPTION
Also cleans up the existing examples to match actual current behavior better, and adjusts the descriptions to use the standard CLDR names for these styles.