### PR TITLE
Add clarification for the permission needed for GUILD_BAN_ADD and GUILD_BAN_REMOVE.

### DIFF
--- a/developers/events/gateway-events.mdx
+++ b/developers/events/gateway-events.mdx
@@ -713,7 +713,7 @@ Sent when a guild audit log entry is created. The inner payload is an [Audit Log
 
 #### Guild Ban Add
 
-Sent when a user is banned from a guild.
+Sent when a user is banned from a guild. This event is only sent to bots with the `BAN_MEMBERS` permission.
 
 <ManualAnchor id="guild-ban-add-guild-ban-add-event-fields" />
 ###### Guild Ban Add Event Fields
@@ -725,7 +725,7 @@ Sent when a user is banned from a guild.
 
 #### Guild Ban Remove
 
-Sent when a user is unbanned from a guild.
+Sent when a user is unbanned from a guild. This event is only sent to bots with the `BAN_MEMBERS` permission.
 
 <ManualAnchor id="guild-ban-remove-guild-ban-remove-event-fields" />
 ###### Guild Ban Remove Event Fields

--- a/developers/events/gateway-events.mdx
+++ b/developers/events/gateway-events.mdx
@@ -713,7 +713,7 @@ Sent when a guild audit log entry is created. The inner payload is an [Audit Log
 
 #### Guild Ban Add
 
-Sent when a user is banned from a guild. This event is only sent to bots with the `BAN_MEMBERS` permission.
+Sent when a user is banned from a guild. This event is only sent to bots with the `BAN_MEMBERS` or `VIEW_AUDIT_LOG` permission.
 
 <ManualAnchor id="guild-ban-add-guild-ban-add-event-fields" />
 ###### Guild Ban Add Event Fields
@@ -725,7 +725,7 @@ Sent when a user is banned from a guild. This event is only sent to bots with th
 
 #### Guild Ban Remove
 
-Sent when a user is unbanned from a guild. This event is only sent to bots with the `BAN_MEMBERS` permission.
+Sent when a user is unbanned from a guild. This event is only sent to bots with the `BAN_MEMBERS` or `VIEW_AUDIT_LOG` permission.
 
 <ManualAnchor id="guild-ban-remove-guild-ban-remove-event-fields" />
 ###### Guild Ban Remove Event Fields


### PR DESCRIPTION
This pr adds clarification for the GUILD_BAN_ADD and GUILD_BAN_REMOVE gateway events that those events will only get sent to bots with the BAN_MEMBERS permission.