### PR TITLE
fix: Add `ManualAnchor` for `interaction-object-application-command-interaction-data-option-structure`

### DIFF
--- a/discord/developers/docs/interactions/receiving-and-responding.mdx
+++ b/discord/developers/docs/interactions/receiving-and-responding.mdx
@@ -178,6 +178,7 @@ If data for a Member is included, data for its corresponding User will also be i
 
 \*\* Partial `Channel` objects only have `id`, `name`, `type`, `permissions`, `last_message_id`, `last_pin_timestamp`, `nsfw`, `parent_id`, `guild_id`, `flags`, `rate_limit_per_user`, `topic` and `position` fields. Threads will also have the `thread_metadata` field.
 
+<ManualAnchor id="interaction-object-application-command-interaction-data-option-structure" />
 ###### Application Command Interaction Data Option Structure
 
 All options have names, and an option can either be a parameter and input value--in which case `value` will be set--or it can denote a subcommand or group--in which case it will contain a top-level key and another array of `options`.


### PR DESCRIPTION
Without the `ManualAnchor`, hyperlinks linking to `/developers/docs/interactions/receiving-and-responding#interaction-object-application-command-interaction-data-option-structure` would scroll back to the top of the page.