### PR TITLE
Update checkBuild.ts

### DIFF
--- a/tools/checkBuild.ts
+++ b/tools/checkBuild.ts
@@ -1,31 +1,47 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { compile } from "@mdx-js/mdx";
 
-const args = process.argv.slice(2);
-const bail = args.includes("--bail");
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
-const ROOT_DIR = path.join(import.meta.dirname, "..");
+const args = process.argv.slice(2);
+const exitOnError = args.includes("--bail");
+
+const ROOT_DIR = path.join(__dirname, "..");
 const DOCS_DIR = path.join(ROOT_DIR, "discord", "developers", "docs");
 
 const extensions = [".mdx", ".md"];
 let hasErrors = false;
 
-for (const docsRelativePath of await fs.readdir(DOCS_DIR, { recursive: true })) {
-  const filePath = path.join(DOCS_DIR, docsRelativePath);
-  const rootRelPath = path.relative(ROOT_DIR, filePath);
+async function* walk(dir) {
+  for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(fullPath);
+    } else {
+      yield fullPath;
+    }
+  }
+}
 
+for await (const filePath of walk(DOCS_DIR)) {
   if (extensions.includes(path.extname(filePath))) {
+    const rootRelPath = path.relative(ROOT_DIR, filePath);
+
     try {
       console.error(`Compiling ${rootRelPath}`);
-      await compile(await fs.readFile(filePath), {
+      const content = await fs.readFile(filePath, "utf8");
+      await compile(content, {
         format: path.extname(filePath) === ".mdx" ? "mdx" : "md",
       });
     } catch (error) {
       console.error(`Error compiling ${rootRelPath}:`);
       console.error(error);
       hasErrors = true;
-      if (bail) {
+
+      if (exitOnError) {
         process.exit(1);
       }
     }


### PR DESCRIPTION
Issue: import.meta.dirname does not exist

import.meta.dirname is not a standard Node.js feature.

Issue: fs.readdir does not support { recursive: true }

Node’s standard fs.readdir does not support recursive listing

Unclear variable name: bail

bail likely means “exit on first error,” but the variable name is not immediately clear. Consider renaming to something clearer:

Missing: Filter out directories before path.extname

If recursive directory walking is implemented, directories will be returned and passed into path.extname, which can cause incorrect behavior.