### PR TITLE
Document BYPASS_SLOWMODE permission + permission split

### DIFF
--- a/docs/change-log/2025-11-24-bypass-slow-mode-permission.md
+++ b/docs/change-log/2025-11-24-bypass-slow-mode-permission.md
@@ -1,5 +1,5 @@
 ---
-title: "New BYPASS_SLOWMODE Permission"
+title: "New BYPASS_SLOWMODE Permission & Permission Split"
 date: "2025-11-24"
 ---
 

--- a/docs/change-log/2025-11-24-bypass-slow-mode-permission.md
+++ b/docs/change-log/2025-11-24-bypass-slow-mode-permission.md
@@ -3,7 +3,7 @@ title: "New BYPASS_SLOWMODE Permission & Permission Split"
 date: "2025-11-24"
 ---
 
-We have introduced a new permission: `BYPASS_SLOWMODE`. This permission allows designated roles or users to bypass slow mode restrictions in channels.
+We have introduced a new permission: `BYPASS_SLOWMODE`. This permission allows designated roles or users to bypass slowmode restrictions in channels.
 
 - The `BYPASS_SLOWMODE` permission (`1 << 52`) is being split from `MANAGE_MESSAGES`, `MANAGE_CHANNEL` and `MANAGE_THREADS`.
 - Note: This primarily affects users, as bots are not affected by slowmode restrictions.

--- a/docs/change-log/2025-11-24-bypass-slow-mode-permission.md
+++ b/docs/change-log/2025-11-24-bypass-slow-mode-permission.md
@@ -1,0 +1,10 @@
+---
+title: "New BYPASS_SLOWMODE Permission"
+date: "2025-11-24"
+---
+
+We have introduced a new permission: `BYPASS_SLOWMODE`. This permission allows designated roles or users to bypass slow mode restrictions in channels.
+
+- The `BYPASS_SLOWMODE` permission (`1 << 52`) is being split from `MANAGE_MESSAGES`, `MANAGE_CHANNEL` and `MANAGE_THREADS`.
+- Note: This primarily affects users, as bots are not affected by slowmode restrictions.
+- Starting on February 23, 2026, users will need the `BYPASS_SLOWMODE` permission to not be affected by slowmode restrictions.

--- a/docs/change-log/2025-11-24-bypass-slow-mode-permission.md
+++ b/docs/change-log/2025-11-24-bypass-slow-mode-permission.md
@@ -5,6 +5,6 @@ date: "2025-11-24"
 
 We have introduced a new permission: `BYPASS_SLOWMODE`. This permission allows designated roles or users to bypass slowmode restrictions in channels.
 
-- The `BYPASS_SLOWMODE` permission (`1 << 52`) is being split from `MANAGE_MESSAGES`, `MANAGE_CHANNEL` and `MANAGE_THREADS`.
+- The `BYPASS_SLOWMODE` permission (`1 << 52`) is being split from `MANAGE_MESSAGES`, `MANAGE_CHANNEL`, and `MANAGE_THREADS`.
 - Note: This primarily affects users, as bots are not affected by slowmode restrictions.
 - Starting on February 23, 2026, users will need the `BYPASS_SLOWMODE` permission to not be affected by slowmode restrictions.

--- a/docs/topics/permissions.md
+++ b/docs/topics/permissions.md
@@ -84,6 +84,7 @@ Below is a table of all current permissions, their integer values in hexadecimal
 | SEND_POLLS                             | `0x0002000000000000` `(1 << 49)` | Allows sending polls                                                                                                                                                                                               | T, V, S                    |
 | USE_EXTERNAL_APPS                      | `0x0004000000000000` `(1 << 50)` | Allows user-installed apps to send public responses. When disabled, users will still be allowed to use their apps but the responses will be ephemeral. This only applies to apps not also installed to the server. | T, V, S                    |
 | PIN_MESSAGES                           | `0x0008000000000000` `(1 << 51)` | Allows pinning and unpinning messages                                                                                                                                                                              | T                          |
+| BYPASS_SLOWMODE                        | `0x0010000000000000` `(1 << 52)` | Allows bypassing slowmode restrictions                                                                                                                                                                             | T, V, S                    |
 
 | Channel Type (Abbreviated) | Description | Channel Types                                            |
 |----------------------------|-------------|----------------------------------------------------------|


### PR DESCRIPTION
We have introduced a new permission: `BYPASS_SLOWMODE`. This permission allows designated roles or users to bypass slow mode restrictions in channels.

- The `BYPASS_SLOWMODE` permission (`1 << 52`) is being split from `MANAGE_MESSAGES`, `MANAGE_CHANNEL` and, `MANAGE_THREADS`.
- Note: This primarily affects users, as bots are not affected by slowmode restrictions.
- Starting on February 23, 2026, users will need the `BYPASS_SLOWMODE` permission to not be affected by slowmode restrictions.