### PR TITLE
docs: add Apple and PSN external account providers

### DIFF
--- a/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
+++ b/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
@@ -94,6 +94,8 @@ We currently support the following provider types:
 - Steam Session Tickets
 - Epic Online Services (EOS)
 - Unity
+- Apple
+- PlayStation Network (PSN)
 
 Providers are represented in Discord's systems by the following types:
 
@@ -106,6 +108,8 @@ Providers are represented in Discord's systems by the following types:
 | EPIC_ONLINE_SERVICES_ACCESS_TOKEN | Access token for Epic Online Services. Supports EOS Auth access tokens        |
 | EPIC_ONLINE_SERVICES_ID_TOKEN     | ID token for Epic Online Services. Supports both EOS Auth + Connect ID tokens |
 | UNITY_SERVICES_ID_TOKEN           | Unity Services authentication ID token                                        |
+| APPLE_ID_TOKEN                    | Apple sign-in authentication ID token                                         |
+| PLAYSTATION_NETWORK_ID_TOKEN      | PlayStation Network account authentication ID token                           |
 | DISCORD_BOT_ISSUED_ACCESS_TOKEN   | An access token for a user authenticated via the Bot Token Endpoint           |
 
 ---


### PR DESCRIPTION
Add documentation for Apple ID Token and PlayStation Network ID Token as supported provider types for provisional accounts in the Discord Social SDK.

