### PR TITLE
[social sdk]  Add provisional account error codes to opcodes

### DIFF
--- a/docs/topics/opcodes-and-status-codes.md
+++ b/docs/topics/opcodes-and-status-codes.md
@@ -123,232 +123,239 @@ Along with the HTTP error code, our API can also return more detailed error code
 
 ###### JSON Error Codes
 
-| Code   | Meaning                                                                                                                       |
-|--------|-------------------------------------------------------------------------------------------------------------------------------|
-| 0      | General error (such as a malformed request body, amongst other things)                                                        |
-| 10001  | Unknown account                                                                                                               |
-| 10002  | Unknown application                                                                                                           |
-| 10003  | Unknown channel                                                                                                               |
-| 10004  | Unknown guild                                                                                                                 |
-| 10005  | Unknown integration                                                                                                           |
-| 10006  | Unknown invite                                                                                                                |
-| 10007  | Unknown member                                                                                                                |
-| 10008  | Unknown message                                                                                                               |
-| 10009  | Unknown permission overwrite                                                                                                  |
-| 10010  | Unknown provider                                                                                                              |
-| 10011  | Unknown role                                                                                                                  |
-| 10012  | Unknown token                                                                                                                 |
-| 10013  | Unknown user                                                                                                                  |
-| 10014  | Unknown emoji                                                                                                                 |
-| 10015  | Unknown webhook                                                                                                               |
-| 10016  | Unknown webhook service                                                                                                       |
-| 10020  | Unknown session                                                                                                               |
-| 10021  | Unknown Asset                                                                                                                 |
-| 10026  | Unknown ban                                                                                                                   |
-| 10027  | Unknown SKU                                                                                                                   |
-| 10028  | Unknown Store Listing                                                                                                         |
-| 10029  | Unknown entitlement                                                                                                           |
-| 10030  | Unknown build                                                                                                                 |
-| 10031  | Unknown lobby                                                                                                                 |
-| 10032  | Unknown branch                                                                                                                |
-| 10033  | Unknown store directory layout                                                                                                |
-| 10036  | Unknown redistributable                                                                                                       |
-| 10038  | Unknown gift code                                                                                                             |
-| 10049  | Unknown stream                                                                                                                |
-| 10050  | Unknown premium server subscribe cooldown                                                                                     |
-| 10057  | Unknown guild template                                                                                                        |
-| 10059  | Unknown discoverable server category                                                                                          |
-| 10060  | Unknown sticker                                                                                                               |
-| 10061  | Unknown sticker pack                                                                                                          |
-| 10062  | Unknown interaction                                                                                                           |
-| 10063  | Unknown application command                                                                                                   |
-| 10065  | Unknown voice state                                                                                                           |
-| 10066  | Unknown application command permissions                                                                                       |
-| 10067  | Unknown Stage Instance                                                                                                        |
-| 10068  | Unknown Guild Member Verification Form                                                                                        |
-| 10069  | Unknown Guild Welcome Screen                                                                                                  |
-| 10070  | Unknown Guild Scheduled Event                                                                                                 |
-| 10071  | Unknown Guild Scheduled Event User                                                                                            |
-| 10087  | Unknown Tag                                                                                                                   |
-| 10097  | Unknown sound                                                                                                                 |
-| 20001  | Bots cannot use this endpoint                                                                                                 |
-| 20002  | Only bots can use this endpoint                                                                                               |
-| 20009  | Explicit content cannot be sent to the desired recipient(s)                                                                   |
-| 20012  | You are not authorized to perform this action on this application                                                             |
-| 20016  | This action cannot be performed due to slowmode rate limit                                                                    |
-| 20018  | Only the owner of this account can perform this action                                                                        |
-| 20022  | This message cannot be edited due to announcement rate limits                                                                 |
-| 20024  | Under minimum age                                                                                                             |
-| 20028  | The channel you are writing has hit the write rate limit                                                                      |
-| 20029  | The write action you are performing on the server has hit the write rate limit                                                |
-| 20031  | Your Stage topic, server name, server description, or channel names contain words that are not allowed                        |
-| 20035  | Guild premium subscription level too low                                                                                      |
-| 30001  | Maximum number of guilds reached (100)                                                                                        |
-| 30002  | Maximum number of friends reached (1000)                                                                                      |
-| 30003  | Maximum number of pins reached for the channel (50)                                                                           |
-| 30004  | Maximum number of recipients reached (10)                                                                                     |
-| 30005  | Maximum number of guild roles reached (250)                                                                                   |
-| 30007  | Maximum number of webhooks reached (15)                                                                                       |
-| 30008  | Maximum number of emojis reached                                                                                              |
-| 30010  | Maximum number of reactions reached (20)                                                                                      |
-| 30011  | Maximum number of group DMs reached (10)                                                                                      |
-| 30013  | Maximum number of guild channels reached (500)                                                                                |
-| 30015  | Maximum number of attachments in a message reached (10)                                                                       |
-| 30016  | Maximum number of invites reached (1000)                                                                                      |
-| 30018  | Maximum number of animated emojis reached                                                                                     |
-| 30019  | Maximum number of server members reached                                                                                      |
-| 30030  | Maximum number of server categories has been reached (5)                                                                      |
-| 30031  | Guild already has a template                                                                                                  |
-| 30032  | Maximum number of application commands reached                                                                                |
-| 30033  | Maximum number of thread participants has been reached (1000)                                                                 |
-| 30034  | Maximum number of daily application command creates has been reached (200)                                                    |
-| 30035  | Maximum number of bans for non-guild members have been exceeded                                                               |
-| 30037  | Maximum number of bans fetches has been reached                                                                               |
-| 30038  | Maximum number of uncompleted guild scheduled events reached (100)                                                            |
-| 30039  | Maximum number of stickers reached                                                                                            |
-| 30040  | Maximum number of prune requests has been reached. Try again later                                                            |
-| 30042  | Maximum number of guild widget settings updates has been reached. Try again later                                             |
-| 30045  | Maximum number of soundboard sounds reached                                                                                   |
-| 30046  | Maximum number of edits to messages older than 1 hour reached. Try again later                                                |
-| 30047  | Maximum number of pinned threads in a forum channel has been reached                                                          |
-| 30048  | Maximum number of tags in a forum channel has been reached                                                                    |
-| 30052  | Bitrate is too high for channel of this type                                                                                  |
-| 30056  | Maximum number of premium emojis reached (25)                                                                                 |
-| 30058  | Maximum number of webhooks per guild reached (1000)                                                                           |
-| 30060  | Maximum number of channel permission overwrites reached (1000)                                                                |
-| 30061  | The channels for this guild are too large                                                                                     |
-| 40001  | Unauthorized. Provide a valid token and try again                                                                             |
-| 40002  | You need to verify your account in order to perform this action                                                               |
-| 40003  | You are opening direct messages too fast                                                                                      |
-| 40004  | Send messages has been temporarily disabled                                                                                   |
-| 40005  | Request entity too large. Try sending something smaller in size                                                               |
-| 40006  | This feature has been temporarily disabled server-side                                                                        |
-| 40007  | The user is banned from this guild                                                                                            |
-| 40012  | Connection has been revoked                                                                                                   |
-| 40018  | Only consumable SKUs can be consumed                                                                                          |
-| 40019  | You can only delete sandbox entitlements.                                                                                     |
-| 40032  | Target user is not connected to voice                                                                                         |
-| 40033  | This message has already been crossposted                                                                                     |
-| 40041  | An application command with that name already exists                                                                          |
-| 40043  | Application interaction failed to send                                                                                        |
-| 40058  | Cannot send a message in a forum channel                                                                                      |
-| 40060  | Interaction has already been acknowledged                                                                                     |
-| 40061  | Tag names must be unique                                                                                                      |
-| 40062  | Service resource is being rate limited                                                                                        |
-| 40066  | There are no tags available that can be set by non-moderators                                                                 |
-| 40067  | A tag is required to create a forum post in this channel                                                                      |
-| 40074  | An entitlement has already been granted for this resource                                                                     |
-| 40094  | This interaction has hit the maximum number of follow up messages                                                             |
-| 40333  | Cloudflare is blocking your request. This can often be resolved by setting a proper [User Agent](/docs/reference#user-agent)  |
-| 50001  | Missing access                                                                                                                |
-| 50002  | Invalid account type                                                                                                          |
-| 50003  | Cannot execute action on a DM channel                                                                                         |
-| 50004  | Guild widget disabled                                                                                                         |
-| 50005  | Cannot edit a message authored by another user                                                                                |
-| 50006  | Cannot send an empty message                                                                                                  |
-| 50007  | Cannot send messages to this user                                                                                             |
-| 50008  | Cannot send messages in a non-text channel                                                                                    |
-| 50009  | Channel verification level is too high for you to gain access                                                                 |
-| 50010  | OAuth2 application does not have a bot                                                                                        |
-| 50011  | OAuth2 application limit reached                                                                                              |
-| 50012  | Invalid OAuth2 state                                                                                                          |
-| 50013  | You lack permissions to perform that action                                                                                   |
-| 50014  | Invalid authentication token provided                                                                                         |
-| 50015  | Note was too long                                                                                                             |
-| 50016  | Provided too few or too many messages to delete. Must provide at least 2 and fewer than 100 messages to delete                |
-| 50017  | Invalid MFA Level                                                                                                             |
-| 50019  | A message can only be pinned to the channel it was sent in                                                                    |
-| 50020  | Invite code was either invalid or taken                                                                                       |
-| 50021  | Cannot execute action on a system message                                                                                     |
-| 50024  | Cannot execute action on this channel type                                                                                    |
-| 50025  | Invalid OAuth2 access token provided                                                                                          |
-| 50026  | Missing required OAuth2 scope                                                                                                 |
-| 50027  | Invalid webhook token provided                                                                                                |
-| 50028  | Invalid role                                                                                                                  |
-| 50033  | Invalid Recipient(s)                                                                                                          |
-| 50034  | A message provided was too old to bulk delete                                                                                 |
-| 50035  | Invalid form body (returned for both `application/json` and `multipart/form-data` bodies), or invalid `Content-Type` provided |
-| 50036  | An invite was accepted to a guild the application's bot is not in                                                             |
-| 50039  | Invalid Activity Action                                                                                                       |
-| 50041  | Invalid API version provided                                                                                                  |
-| 50045  | File uploaded exceeds the maximum size                                                                                        |
-| 50046  | Invalid file uploaded                                                                                                         |
-| 50054  | Cannot self-redeem this gift                                                                                                  |
-| 50055  | Invalid Guild                                                                                                                 |
-| 50057  | Invalid SKU                                                                                                                   |
-| 50067  | Invalid request origin                                                                                                        |
-| 50068  | Invalid message type                                                                                                          |
-| 50070  | Payment source required to redeem gift                                                                                        |
-| 50073  | Cannot modify a system webhook                                                                                                |
-| 50074  | Cannot delete a channel required for Community guilds                                                                         |
-| 50080  | Cannot edit stickers within a message                                                                                         |
-| 50081  | Invalid sticker sent                                                                                                          |
-| 50083  | Tried to perform an operation on an archived thread, such as editing a message or adding a user to the thread                 |
-| 50084  | Invalid thread notification settings                                                                                          |
-| 50085  | `before` value is earlier than the thread creation date                                                                       |
-| 50086  | Community server channels must be text channels                                                                               |
-| 50091  | The entity type of the event is different from the entity you are trying to start the event for                               |
-| 50095  | This server is not available in your location                                                                                 |
-| 50097  | This server needs monetization enabled in order to perform this action                                                        |
-| 50101  | This server needs more boosts to perform this action                                                                          |
-| 50109  | The request body contains invalid JSON.                                                                                       |
-| 50110  | The provided file is invalid.                                                                                                 |
-| 50123  | The provided file type is invalid.                                                                                            |
-| 50124  | The provided file duration exceeds maximum of 5.2 seconds.                                                                    |
-| 50131  | Owner cannot be pending member                                                                                                |
-| 50132  | Ownership cannot be transferred to a bot user                                                                                 |
-| 50138  | Failed to resize asset below the maximum size: 262144                                                                         |
-| 50144  | Cannot mix subscription and non subscription roles for an emoji                                                               |
-| 50145  | Cannot convert between premium emoji and normal emoji                                                                         |
-| 50146  | Uploaded file not found.                                                                                                      |
-| 50151  | The specified emoji is invalid                                                                                                |
-| 50159  | Voice messages do not support additional content.                                                                             |
-| 50160  | Voice messages must have a single audio attachment.                                                                           |
-| 50161  | Voice messages must have supporting metadata.                                                                                 |
-| 50162  | Voice messages cannot be edited.                                                                                              |
-| 50163  | Cannot delete guild subscription integration                                                                                  |
-| 50173  | You cannot send voice messages in this channel.                                                                               |
-| 50178  | The user account must first be verified                                                                                       |
-| 50192  | The provided file does not have a valid duration.                                                                             |
-| 50600  | You do not have permission to send this sticker.                                                                              |
-| 60003  | Two factor is required for this operation                                                                                     |
-| 80004  | No users with DiscordTag exist                                                                                                |
-| 90001  | Reaction was blocked                                                                                                          |
-| 90002  | User cannot use burst reactions                                                                                               |
-| 110001 | Application not yet available. Try again later                                                                                |
-| 130000 | API resource is currently overloaded. Try again a little later                                                                |
-| 150006 | The Stage is already open                                                                                                     |
-| 160002 | Cannot reply without permission to read message history                                                                       |
-| 160004 | A thread has already been created for this message                                                                            |
-| 160005 | Thread is locked                                                                                                              |
-| 160006 | Maximum number of active threads reached                                                                                      |
-| 160007 | Maximum number of active announcement threads reached                                                                         |
-| 170001 | Invalid JSON for uploaded Lottie file                                                                                         |
-| 170002 | Uploaded Lotties cannot contain rasterized images such as PNG or JPEG                                                         |
-| 170003 | Sticker maximum framerate exceeded                                                                                            |
-| 170004 | Sticker frame count exceeds maximum of 1000 frames                                                                            |
-| 170005 | Lottie animation maximum dimensions exceeded                                                                                  |
-| 170006 | Sticker frame rate is either too small or too large                                                                           |
-| 170007 | Sticker animation duration exceeds maximum of 5 seconds                                                                       |
-| 180000 | Cannot update a finished event                                                                                                |
-| 180002 | Failed to create stage needed for stage event                                                                                 |
-| 200000 | Message was blocked by automatic moderation                                                                                   |
-| 200001 | Title was blocked by automatic moderation                                                                                     |
-| 220001 | Webhooks posted to forum channels must have a thread_name or thread_id                                                        |
-| 220002 | Webhooks posted to forum channels cannot have both a thread_name and thread_id                                                |
-| 220003 | Webhooks can only create threads in forum channels                                                                            |
-| 220004 | Webhook services cannot be used in forum channels                                                                             |
-| 240000 | Message blocked by harmful links filter                                                                                       |
-| 350000 | Cannot enable onboarding, requirements are not met                                                                            |
-| 350001 | Cannot update onboarding while below requirements                                                                             |
-| 400001 | Access to file uploads has been limited for this guild                                                                        |
-| 500000 | Failed to ban users                                                                                                           |
-| 520000 | Poll voting blocked                                                                                                           |
-| 520001 | Poll expired                                                                                                                  |
-| 520002 | Invalid channel type for poll creation                                                                                        |
-| 520003 | Cannot edit a poll message                                                                                                    |
-| 520004 | Cannot use an emoji included with the poll                                                                                    |
-| 520006 | Cannot expire a non-poll message                                                                                              |
+| Code   | Meaning                                                                                                                                                                                                               |
+|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0      | General error (such as a malformed request body, amongst other things)                                                                                                                                                |
+| 10001  | Unknown account                                                                                                                                                                                                       |
+| 10002  | Unknown application                                                                                                                                                                                                   |
+| 10003  | Unknown channel                                                                                                                                                                                                       |
+| 10004  | Unknown guild                                                                                                                                                                                                         |
+| 10005  | Unknown integration                                                                                                                                                                                                   |
+| 10006  | Unknown invite                                                                                                                                                                                                        |
+| 10007  | Unknown member                                                                                                                                                                                                        |
+| 10008  | Unknown message                                                                                                                                                                                                       |
+| 10009  | Unknown permission overwrite                                                                                                                                                                                          |
+| 10010  | Unknown provider                                                                                                                                                                                                      |
+| 10011  | Unknown role                                                                                                                                                                                                          |
+| 10012  | Unknown token                                                                                                                                                                                                         |
+| 10013  | Unknown user                                                                                                                                                                                                          |
+| 10014  | Unknown emoji                                                                                                                                                                                                         |
+| 10015  | Unknown webhook                                                                                                                                                                                                       |
+| 10016  | Unknown webhook service                                                                                                                                                                                               |
+| 10020  | Unknown session                                                                                                                                                                                                       |
+| 10021  | Unknown Asset                                                                                                                                                                                                         |
+| 10026  | Unknown ban                                                                                                                                                                                                           |
+| 10027  | Unknown SKU                                                                                                                                                                                                           |
+| 10028  | Unknown Store Listing                                                                                                                                                                                                 |
+| 10029  | Unknown entitlement                                                                                                                                                                                                   |
+| 10030  | Unknown build                                                                                                                                                                                                         |
+| 10031  | Unknown lobby                                                                                                                                                                                                         |
+| 10032  | Unknown branch                                                                                                                                                                                                        |
+| 10033  | Unknown store directory layout                                                                                                                                                                                        |
+| 10036  | Unknown redistributable                                                                                                                                                                                               |
+| 10038  | Unknown gift code                                                                                                                                                                                                     |
+| 10049  | Unknown stream                                                                                                                                                                                                        |
+| 10050  | Unknown premium server subscribe cooldown                                                                                                                                                                             |
+| 10057  | Unknown guild template                                                                                                                                                                                                |
+| 10059  | Unknown discoverable server category                                                                                                                                                                                  |
+| 10060  | Unknown sticker                                                                                                                                                                                                       |
+| 10061  | Unknown sticker pack                                                                                                                                                                                                  |
+| 10062  | Unknown interaction                                                                                                                                                                                                   |
+| 10063  | Unknown application command                                                                                                                                                                                           |
+| 10065  | Unknown voice state                                                                                                                                                                                                   |
+| 10066  | Unknown application command permissions                                                                                                                                                                               |
+| 10067  | Unknown Stage Instance                                                                                                                                                                                                |
+| 10068  | Unknown Guild Member Verification Form                                                                                                                                                                                |
+| 10069  | Unknown Guild Welcome Screen                                                                                                                                                                                          |
+| 10070  | Unknown Guild Scheduled Event                                                                                                                                                                                         |
+| 10071  | Unknown Guild Scheduled Event User                                                                                                                                                                                    |
+| 10087  | Unknown Tag                                                                                                                                                                                                           |
+| 10097  | Unknown sound                                                                                                                                                                                                         |
+| 20001  | Bots cannot use this endpoint                                                                                                                                                                                         |
+| 20002  | Only bots can use this endpoint                                                                                                                                                                                       |
+| 20009  | Explicit content cannot be sent to the desired recipient(s)                                                                                                                                                           |
+| 20012  | You are not authorized to perform this action on this application                                                                                                                                                     |
+| 20016  | This action cannot be performed due to slowmode rate limit                                                                                                                                                            |
+| 20018  | Only the owner of this account can perform this action                                                                                                                                                                |
+| 20022  | This message cannot be edited due to announcement rate limits                                                                                                                                                         |
+| 20024  | Under minimum age                                                                                                                                                                                                     |
+| 20028  | The channel you are writing has hit the write rate limit                                                                                                                                                              |
+| 20029  | The write action you are performing on the server has hit the write rate limit                                                                                                                                        |
+| 20031  | Your Stage topic, server name, server description, or channel names contain words that are not allowed                                                                                                                |
+| 20035  | Guild premium subscription level too low                                                                                                                                                                              |
+| 30001  | Maximum number of guilds reached (100)                                                                                                                                                                                |
+| 30002  | Maximum number of friends reached (1000)                                                                                                                                                                              |
+| 30003  | Maximum number of pins reached for the channel (50)                                                                                                                                                                   |
+| 30004  | Maximum number of recipients reached (10)                                                                                                                                                                             |
+| 30005  | Maximum number of guild roles reached (250)                                                                                                                                                                           |
+| 30007  | Maximum number of webhooks reached (15)                                                                                                                                                                               |
+| 30008  | Maximum number of emojis reached                                                                                                                                                                                      |
+| 30010  | Maximum number of reactions reached (20)                                                                                                                                                                              |
+| 30011  | Maximum number of group DMs reached (10)                                                                                                                                                                              |
+| 30013  | Maximum number of guild channels reached (500)                                                                                                                                                                        |
+| 30015  | Maximum number of attachments in a message reached (10)                                                                                                                                                               |
+| 30016  | Maximum number of invites reached (1000)                                                                                                                                                                              |
+| 30018  | Maximum number of animated emojis reached                                                                                                                                                                             |
+| 30019  | Maximum number of server members reached                                                                                                                                                                              |
+| 30030  | Maximum number of server categories has been reached (5)                                                                                                                                                              |
+| 30031  | Guild already has a template                                                                                                                                                                                          |
+| 30032  | Maximum number of application commands reached                                                                                                                                                                        |
+| 30033  | Maximum number of thread participants has been reached (1000)                                                                                                                                                         |
+| 30034  | Maximum number of daily application command creates has been reached (200)                                                                                                                                            |
+| 30035  | Maximum number of bans for non-guild members have been exceeded                                                                                                                                                       |
+| 30037  | Maximum number of bans fetches has been reached                                                                                                                                                                       |
+| 30038  | Maximum number of uncompleted guild scheduled events reached (100)                                                                                                                                                    |
+| 30039  | Maximum number of stickers reached                                                                                                                                                                                    |
+| 30040  | Maximum number of prune requests has been reached. Try again later                                                                                                                                                    |
+| 30042  | Maximum number of guild widget settings updates has been reached. Try again later                                                                                                                                     |
+| 30045  | Maximum number of soundboard sounds reached                                                                                                                                                                           |
+| 30046  | Maximum number of edits to messages older than 1 hour reached. Try again later                                                                                                                                        |
+| 30047  | Maximum number of pinned threads in a forum channel has been reached                                                                                                                                                  |
+| 30048  | Maximum number of tags in a forum channel has been reached                                                                                                                                                            |
+| 30052  | Bitrate is too high for channel of this type                                                                                                                                                                          |
+| 30056  | Maximum number of premium emojis reached (25)                                                                                                                                                                         |
+| 30058  | Maximum number of webhooks per guild reached (1000)                                                                                                                                                                   |
+| 30060  | Maximum number of channel permission overwrites reached (1000)                                                                                                                                                        |
+| 30061  | The channels for this guild are too large                                                                                                                                                                             |
+| 40001  | Unauthorized. Provide a valid token and try again                                                                                                                                                                     |
+| 40002  | You need to verify your account in order to perform this action                                                                                                                                                       |
+| 40003  | You are opening direct messages too fast                                                                                                                                                                              |
+| 40004  | Send messages has been temporarily disabled                                                                                                                                                                           |
+| 40005  | Request entity too large. Try sending something smaller in size                                                                                                                                                       |
+| 40006  | This feature has been temporarily disabled server-side                                                                                                                                                                |
+| 40007  | The user is banned from this guild                                                                                                                                                                                    |
+| 40012  | Connection has been revoked                                                                                                                                                                                           |
+| 40018  | Only consumable SKUs can be consumed                                                                                                                                                                                  |
+| 40019  | You can only delete sandbox entitlements.                                                                                                                                                                             |
+| 40032  | Target user is not connected to voice                                                                                                                                                                                 |
+| 40033  | This message has already been crossposted                                                                                                                                                                             |
+| 40041  | An application command with that name already exists                                                                                                                                                                  |
+| 40043  | Application interaction failed to send                                                                                                                                                                                |
+| 40058  | Cannot send a message in a forum channel                                                                                                                                                                              |
+| 40060  | Interaction has already been acknowledged                                                                                                                                                                             |
+| 40061  | Tag names must be unique                                                                                                                                                                                              |
+| 40062  | Service resource is being rate limited                                                                                                                                                                                |
+| 40066  | There are no tags available that can be set by non-moderators                                                                                                                                                         |
+| 40067  | A tag is required to create a forum post in this channel                                                                                                                                                              |
+| 40074  | An entitlement has already been granted for this resource                                                                                                                                                             |
+| 40094  | This interaction has hit the maximum number of follow up messages                                                                                                                                                     |
+| 40333  | Cloudflare is blocking your request. This can often be resolved by setting a proper [User Agent](/docs/reference#user-agent)                                                                                          |
+| 50001  | Missing access                                                                                                                                                                                                        |
+| 50002  | Invalid account type                                                                                                                                                                                                  |
+| 50003  | Cannot execute action on a DM channel                                                                                                                                                                                 |
+| 50004  | Guild widget disabled                                                                                                                                                                                                 |
+| 50005  | Cannot edit a message authored by another user                                                                                                                                                                        |
+| 50006  | Cannot send an empty message                                                                                                                                                                                          |
+| 50007  | Cannot send messages to this user                                                                                                                                                                                     |
+| 50008  | Cannot send messages in a non-text channel                                                                                                                                                                            |
+| 50009  | Channel verification level is too high for you to gain access                                                                                                                                                         |
+| 50010  | OAuth2 application does not have a bot                                                                                                                                                                                |
+| 50011  | OAuth2 application limit reached                                                                                                                                                                                      |
+| 50012  | Invalid OAuth2 state                                                                                                                                                                                                  |
+| 50013  | You lack permissions to perform that action                                                                                                                                                                           |
+| 50014  | Invalid authentication token provided                                                                                                                                                                                 |
+| 50015  | Note was too long                                                                                                                                                                                                     |
+| 50016  | Provided too few or too many messages to delete. Must provide at least 2 and fewer than 100 messages to delete                                                                                                        |
+| 50017  | Invalid MFA Level                                                                                                                                                                                                     |
+| 50019  | A message can only be pinned to the channel it was sent in                                                                                                                                                            |
+| 50020  | Invite code was either invalid or taken                                                                                                                                                                               |
+| 50021  | Cannot execute action on a system message                                                                                                                                                                             |
+| 50024  | Cannot execute action on this channel type                                                                                                                                                                            |
+| 50025  | Invalid OAuth2 access token provided                                                                                                                                                                                  |
+| 50026  | Missing required OAuth2 scope                                                                                                                                                                                         |
+| 50027  | Invalid webhook token provided                                                                                                                                                                                        |
+| 50028  | Invalid role                                                                                                                                                                                                          |
+| 50033  | Invalid Recipient(s)                                                                                                                                                                                                  |
+| 50034  | A message provided was too old to bulk delete                                                                                                                                                                         |
+| 50035  | Invalid form body (returned for both `application/json` and `multipart/form-data` bodies), or invalid `Content-Type` provided                                                                                         |
+| 50036  | An invite was accepted to a guild the application's bot is not in                                                                                                                                                     |
+| 50039  | Invalid Activity Action                                                                                                                                                                                               |
+| 50041  | Invalid API version provided                                                                                                                                                                                          |
+| 50045  | File uploaded exceeds the maximum size                                                                                                                                                                                |
+| 50046  | Invalid file uploaded                                                                                                                                                                                                 |
+| 50054  | Cannot self-redeem this gift                                                                                                                                                                                          |
+| 50055  | Invalid Guild                                                                                                                                                                                                         |
+| 50057  | Invalid SKU                                                                                                                                                                                                           |
+| 50067  | Invalid request origin                                                                                                                                                                                                |
+| 50068  | Invalid message type                                                                                                                                                                                                  |
+| 50070  | Payment source required to redeem gift                                                                                                                                                                                |
+| 50073  | Cannot modify a system webhook                                                                                                                                                                                        |
+| 50074  | Cannot delete a channel required for Community guilds                                                                                                                                                                 |
+| 50080  | Cannot edit stickers within a message                                                                                                                                                                                 |
+| 50081  | Invalid sticker sent                                                                                                                                                                                                  |
+| 50083  | Tried to perform an operation on an archived thread, such as editing a message or adding a user to the thread                                                                                                         |
+| 50084  | Invalid thread notification settings                                                                                                                                                                                  |
+| 50085  | `before` value is earlier than the thread creation date                                                                                                                                                               |
+| 50086  | Community server channels must be text channels                                                                                                                                                                       |
+| 50091  | The entity type of the event is different from the entity you are trying to start the event for                                                                                                                       |
+| 50095  | This server is not available in your location                                                                                                                                                                         |
+| 50097  | This server needs monetization enabled in order to perform this action                                                                                                                                                |
+| 50101  | This server needs more boosts to perform this action                                                                                                                                                                  |
+| 50109  | The request body contains invalid JSON.                                                                                                                                                                               |
+| 50110  | The provided file is invalid.                                                                                                                                                                                         |
+| 50123  | The provided file type is invalid.                                                                                                                                                                                    |
+| 50124  | The provided file duration exceeds maximum of 5.2 seconds.                                                                                                                                                            |
+| 50131  | Owner cannot be pending member                                                                                                                                                                                        |
+| 50132  | Ownership cannot be transferred to a bot user                                                                                                                                                                         |
+| 50138  | Failed to resize asset below the maximum size: 262144                                                                                                                                                                 |
+| 50144  | Cannot mix subscription and non subscription roles for an emoji                                                                                                                                                       |
+| 50145  | Cannot convert between premium emoji and normal emoji                                                                                                                                                                 |
+| 50146  | Uploaded file not found.                                                                                                                                                                                              |
+| 50151  | The specified emoji is invalid                                                                                                                                                                                        |
+| 50159  | Voice messages do not support additional content.                                                                                                                                                                     |
+| 50160  | Voice messages must have a single audio attachment.                                                                                                                                                                   |
+| 50161  | Voice messages must have supporting metadata.                                                                                                                                                                         |
+| 50162  | Voice messages cannot be edited.                                                                                                                                                                                      |
+| 50163  | Cannot delete guild subscription integration                                                                                                                                                                          |
+| 50173  | You cannot send voice messages in this channel.                                                                                                                                                                       |
+| 50178  | The user account must first be verified                                                                                                                                                                               |
+| 50192  | The provided file does not have a valid duration.                                                                                                                                                                     |
+| 50600  | You do not have permission to send this sticker.                                                                                                                                                                      |
+| 60003  | Two factor is required for this operation                                                                                                                                                                             |
+| 80004  | No users with DiscordTag exist                                                                                                                                                                                        |
+| 90001  | Reaction was blocked                                                                                                                                                                                                  |
+| 90002  | User cannot use burst reactions                                                                                                                                                                                       |
+| 110001 | Application not yet available. Try again later                                                                                                                                                                        |
+| 130000 | API resource is currently overloaded. Try again a little later                                                                                                                                                        |
+| 150006 | The Stage is already open                                                                                                                                                                                             |
+| 160002 | Cannot reply without permission to read message history                                                                                                                                                               |
+| 160004 | A thread has already been created for this message                                                                                                                                                                    |
+| 160005 | Thread is locked                                                                                                                                                                                                      |
+| 160006 | Maximum number of active threads reached                                                                                                                                                                              |
+| 160007 | Maximum number of active announcement threads reached                                                                                                                                                                 |
+| 170001 | Invalid JSON for uploaded Lottie file                                                                                                                                                                                 |
+| 170002 | Uploaded Lotties cannot contain rasterized images such as PNG or JPEG                                                                                                                                                 |
+| 170003 | Sticker maximum framerate exceeded                                                                                                                                                                                    |
+| 170004 | Sticker frame count exceeds maximum of 1000 frames                                                                                                                                                                    |
+| 170005 | Lottie animation maximum dimensions exceeded                                                                                                                                                                          |
+| 170006 | Sticker frame rate is either too small or too large                                                                                                                                                                   |
+| 170007 | Sticker animation duration exceeds maximum of 5 seconds                                                                                                                                                               |
+| 180000 | Cannot update a finished event                                                                                                                                                                                        |
+| 180002 | Failed to create stage needed for stage event                                                                                                                                                                         |
+| 200000 | Message was blocked by automatic moderation                                                                                                                                                                           |
+| 200001 | Title was blocked by automatic moderation                                                                                                                                                                             |
+| 220001 | Webhooks posted to forum channels must have a thread_name or thread_id                                                                                                                                                |
+| 220002 | Webhooks posted to forum channels cannot have both a thread_name and thread_id                                                                                                                                        |
+| 220003 | Webhooks can only create threads in forum channels                                                                                                                                                                    |
+| 220004 | Webhook services cannot be used in forum channels                                                                                                                                                                     |
+| 240000 | Message blocked by harmful links filter                                                                                                                                                                               |
+| 350000 | Cannot enable onboarding, requirements are not met                                                                                                                                                                    |
+| 350001 | Cannot update onboarding while below requirements                                                                                                                                                                     |
+| 400001 | Access to file uploads has been limited for this guild                                                                                                                                                                |
+| 500000 | Failed to ban users                                                                                                                                                                                                   |
+| 520000 | Poll voting blocked                                                                                                                                                                                                   |
+| 520001 | Poll expired                                                                                                                                                                                                          |
+| 520002 | Invalid channel type for poll creation                                                                                                                                                                                |
+| 520003 | Cannot edit a poll message                                                                                                                                                                                            |
+| 520004 | Cannot use an emoji included with the poll                                                                                                                                                                            |
+| 520006 | Cannot expire a non-poll message                                                                                                                                                                                      |
+| 530000 | Your Discord application has not been granted the permission to use provisional accounts.                                                                                                                             |
+| 530001 | The ID token JWT you have provided is expired. You will need to get another one issued from the identity provider.                                                                                                    |
+| 530002 | The issuer in the ID token JWT you have provided does not match what you have configured.                                                                                                                             |
+| 530003 | The audience in the ID token JWT you have provided does not match the audience you specified in your OIDC configuration. Either update your configuration or pass in an ID token that was issued to your application. |
+| 530004 | The ID token you provided was issued too long ago. Discord will not accept ID tokens issued beyond a week ago. You will need to get a new ID token issued from the identity provider.                                 |
+| 530006 | Discord failed to generate a unique username within the allotted time. This is not a terminal error, and should resolve itself upon a retry.                                                                          |
+| 530007 | Your client secret is invalid. Double check what you are sending or regenerate your client secret.                                                                                                                    |
 
 ###### Example JSON Error Response
 


### PR DESCRIPTION
Add codes from [Social SDK](https://discord.com/developers/docs/social-sdk/authentication.html#autotoc_md56) to [Opcodes and Status Codes](http://localhost:3336/developers/docs/topics/opcodes-and-status-codes).