### PR TITLE
docs: minimum supported versions to Social SDK platform compatibility

### DIFF
--- a/docs/discord-social-sdk/core-concepts/platform-compatibility.mdx
+++ b/docs/discord-social-sdk/core-concepts/platform-compatibility.mdx
@@ -14,21 +14,22 @@ You can find instructions on how to download the SDK for each platform in the [G
 
 The Discord Social SDK is available for the following platforms:
 
-| Platform               | Support Level       | Standalone C++ | Unreal Engine | Unity |
-|------------------------|---------------------|----------------|---------------|-------|
-| **Desktop**            |                     |                |               |       |
-| Windows (x64)          | Generally Available | ✅              | ✅             | ✅     |
-| Windows (ARM64)        | Generally Available | ✅              | ❌             | ❌     |
-| macOS                  | Generally Available | ✅              | ❌             | ✅     |
-| Linux* (glibc >= 2.31) | Experimental        | ✅              | ✅             | ✅     |
-| **Mobile**             |                     |                |               |       |
-| Android                | Experimental        | ✅              | ❌             | ✅     |
-| iOS                    | Experimental        | ✅              | ❌             | ✅     |
-| **Console**            |                     |                |               |       |
-| Xbox One               | Experimental        | ✅              | ✅             | ❌     |
-| Xbox Series X\|S       | Experimental        | ✅              | ✅             | ✅     |
-| PlayStation 4          | Experimental        | ✅              | ✅             | ❌     |
-| PlayStation 5          | Experimental        | ✅              | ✅             | ✅     |
+| Platform         | Minimum Supported Version | Support Level       | Standalone C++ | Unreal Engine | Unity |
+|------------------|---------------------------|---------------------|----------------|---------------|-------|
+| **Desktop**      |                           |                     |                |               |       |
+| Windows (x64)    | 10                        | Generally Available | ✅              | ✅             | ✅     |
+| Windows (ARM64)  | 11                        | Generally Available | ✅              | ❌             | ❌     |
+| macOS (x64)      | 10.5                      | Generally Available | ✅              | ❌             | ✅     |
+| macOS (ARM64)    | 11                        | Generally Available | ✅              | ❌             | ✅     |
+| Linux            | glibc 2.31*               | Experimental        | ✅              | ✅             | ✅     |
+| **Mobile**       |                           |                     |                |               |       |
+| Android          |                           | Experimental        | ✅              | ❌             | ✅     |
+| iOS              |                           | Experimental        | ✅              | ❌             | ✅     |
+| **Console**      |                           |                     |                |               |       |
+| Xbox One         |                           | Experimental        | ✅              | ✅             | ❌     |
+| Xbox Series X\|S |                           | Experimental        | ✅              | ✅             | ✅     |
+| PlayStation 4    |                           | Experimental        | ✅              | ✅             | ❌     |
+| PlayStation 5    |                           | Experimental        | ✅              | ✅             | ✅     |
 
 :::info
 \* There are too many Linux distributions to test, but most distros with glibc 2.31, e.g. Ubuntu 20.04,


### PR DESCRIPTION
Update platform compatibility table to include minimum supported versions for each platform. Notable additions:
- macOS split into separate rows for Intel (10.15+) and Apple Silicon (11.0+)
- Windows minimum versions (10 for x64, 11 for ARM64)
- Clarified Linux glibc 2.31 minimum requirement