### PR TITLE
Remove warning about Gateway connection from Cloudflare Workers

### DIFF
--- a/docs/events/gateway.mdx
+++ b/docs/events/gateway.mdx
@@ -103,10 +103,6 @@ When connecting to the URL, it's a good idea to explicitly pass the API version 
 `wss://gateway.discord.gg/?v=10&encoding=json` is an example of a WSS URL an app may use to connect to the Gateway.
 :::
 
-:::warn
-For security reasons, the Gateway cannot be accessed directly from a Cloudflare Worker. Attempts will result in a 401 Unauthorized status code.
-:::
-
 ###### Gateway URL Query String Params
 
 | Field     | Type    | Description                                                                                         | Accepted Values                                            |


### PR DESCRIPTION
Cloudflare Workers were allowed based on the comment https://github.com/discord/discord-api-docs/issues/6145#issuecomment-3618601748