### PR TITLE
Game SDK: Fix Archive Warning

### DIFF
--- a/docs/developer-tools/game-sdk.mdx
+++ b/docs/developer-tools/game-sdk.mdx
@@ -3,10 +3,8 @@
 # Game SDK
 
 :::warn
-**The Game SDK has been archived.**
-
-We recommend using the [Discord Social SDK](/docs/discord-social-sdk/overview) for new projects.
-
+**The Game SDK has been archived.**<br/><br/>
+We recommend using the [Discord Social SDK](/docs/discord-social-sdk/overview) for new projects.<br/><br/>
 Existing projects using the Game SDK will continue to work, but we encourage you to migrate to the [Discord Social SDK](/docs/discord-social-sdk/overview) for new features and updates.
 :::
 

--- a/docs/rich-presence/overview.mdx
+++ b/docs/rich-presence/overview.mdx
@@ -43,10 +43,8 @@ After a user joins an Activity, Rich Presence can be used to dynamically show da
 ### Game SDK
 
 :::warn
-**The Game SDK has been archived.**
-
-We recommend using the [Discord Social SDK](/docs/discord-social-sdk/overview) for new projects.
-
+**The Game SDK has been archived.**<br/><br/>
+We recommend using the [Discord Social SDK](/docs/discord-social-sdk/overview) for new projects.<br/><br/>
 Existing projects using the Game SDK will continue to work, but we encourage you to migrate to the [Discord Social SDK](/docs/discord-social-sdk/overview) for new features and updates.
 :::
 

--- a/docs/rich-presence/using-with-the-game-sdk.mdx
+++ b/docs/rich-presence/using-with-the-game-sdk.mdx
@@ -5,10 +5,8 @@ sidebar_label: Using with the Game SDK
 # Using Rich Presence with the Game SDK
 
 :::warn
-**The Game SDK has been archived.**
-
-We recommend using the [Discord Social SDK](/docs/discord-social-sdk/overview) for new projects.
-
+**The Game SDK has been archived.**<br/><br/>
+We recommend using the [Discord Social SDK](/docs/discord-social-sdk/overview) for new projects.<br/><br/>
 Existing projects using the Game SDK will continue to work, but we encourage you to migrate to the [Discord Social SDK](/docs/discord-social-sdk/overview) for new features and updates.
 :::
 


### PR DESCRIPTION
The full warning about the game sdk was being truncated, so the call to action to use the Social SDK was not being displayed.

This fixes that!

