### PR TITLE
Wording fix and clarification

### DIFF
--- a/docs/interactions/receiving-and-responding.mdx
+++ b/docs/interactions/receiving-and-responding.mdx
@@ -135,6 +135,8 @@ Sent in `APPLICATION_COMMAND` and `APPLICATION_COMMAND_AUTOCOMPLETE` interaction
 
 ###### Component Interaction Response Structures
 
+Response structures for both modal and message component interactions.
+
 | Component                                                                                                             |
 |-----------------------------------------------------------------------------------------------------------------------|
 | [String Select](/docs/components/reference#string-select-string-select-interaction-response-structure)                |

--- a/docs/resources/guild-scheduled-event.mdx
+++ b/docs/resources/guild-scheduled-event.mdx
@@ -410,7 +410,7 @@ Any event with `'status': SCHEDULED` after a certain time interval (on the order
 NOTE: `entity_type` is expressed by name rather than value for readability
 
 :::info
-A user must be a member of the guild in order to access events for that guild unless the guild is lurkable. If a guild is lurkable, events in that guild may be visible to lurkers depending on the event type and the permissions of any channels associated with the event.
+A user must be a member of the guild in order to access events for that guild unless the guild is public. If a guild is public, events in that guild may be visible depending on the event type and the permissions of any channels associated with the event.
 :::
 
 ### Permissions for events with entity_type: STAGE_INSTANCE

--- a/docs/resources/message.mdx
+++ b/docs/resources/message.mdx
@@ -61,7 +61,7 @@ An app will receive empty values in the `content`, `embeds`, `attachments`, and 
 
 \[2\] An app will receive empty values in the `content`, `embeds`, `attachments`, and `components` fields while `poll` will be omitted if they have not configured (or been approved for) the [`MESSAGE_CONTENT` privileged intent (`1 << 15`)](/docs/events/gateway#message-content-intent).
 
-\[3\] Not all channel mentions in a message will appear in `mention_channels`. Only textual channels that are visible to everyone in a lurkable guild will ever be included. Only crossposted messages (via Channel Following) currently include `mention_channels` at all. If no mentions in the message meet these requirements, this field will not be sent.
+\[3\] Not all channel mentions in a message will appear in `mention_channels`. Only textual channels that are visible to everyone in a public guild will ever be included. Only crossposted messages (via Channel Following) currently include `mention_channels` at all. If no mentions in the message meet these requirements, this field will not be sent.
 
 \[4\] This field is only returned for messages with a `type` of `19` (REPLY), `21` (THREAD_STARTER_MESSAGE), or `23` (CONTEXT_MENU_COMMAND). If the message is one of these but the `referenced_message` field is not present, the backend did not attempt to fetch the message that was being replied to, so its state is unknown. If the field exists but is null, the referenced message was deleted.
 


### PR DESCRIPTION
Closes https://github.com/discord/discord-api-docs/issues/8042
Lurkable is an old term to describe public guilds so this cleans up the last mentions of it

Closes https://github.com/discord/discord-api-docs/issues/8032
That section of the docs is meant for both message and modal interaction responses. It does come after the modal section so I added a clarifying note