### PR TITLE
Add deep-links for App Verification, Discovery, and Activities sections

### DIFF
--- a/docs/activities/building-an-activity.mdx
+++ b/docs/activities/building-an-activity.mdx
@@ -117,7 +117,7 @@ Enter a name for your app, select a development team, then press **Create**.
 Launching a non-distributed Activity is limited to you or members of the developer team, so if you're collaborating with others during development, create a [developer team](https://discord.com/developers/teams) and set it to the owner when you create the app.
 :::
 
-After you create your app, you'll land on the **General Overview** page of the app's settings, where you can update basic information about your app like its description and icon.
+After you create your app, you'll land on the **General Information** page of the app's settings, where you can update basic information about your app like its description and icon.
 
 ### Choose installation contexts
 
@@ -135,7 +135,7 @@ As mentioned, installation contexts determine where your app can be installed. T
 Details about installation contexts is in the [Application documentation](/docs/resources/application#installation-context) and the [Developing a User-Installable App tutorial](/docs/tutorials/developing-a-user-installable-app).
 </Collapsible>
 
-Click on **Installation** in the left sidebar, then under **Installation Contexts** make sure both "User Install" and "Guild Install" are selected. This will make sure users can launch our app's Activity across Discord servers, DMs, and Group DMs.
+Click on [**Installation**](https://discord.com/developers/applications/select/installation) in the left sidebar, then under **Installation Contexts** make sure both "User Install" and "Guild Install" are selected. This will make sure users can launch our app's Activity across Discord servers, DMs, and Group DMs.
 
 ### Add a Redirect URI
 
@@ -143,7 +143,7 @@ Next, we'll add a Redirect URI, which is where a user is typically redirected to
 
 You can learn more about the OAuth flow and redirect URIs in the [OAuth2 documentation](/docs/topics/oauth2), but since we're only authorizing in an Activity, we'll just use a placeholder value (`https://127.0.0.1`) and let the Embedded App SDK handle the rest.
 
-Click on **OAuth2** on the sidebar in your app's settings. Under **Redirects**, enter `https://127.0.0.1` as a placeholder value then click **Save Changes**.
+Click on [**OAuth2**](https://discord.com/developers/applications/select/oauth2) in your app's settings. Under **Redirects**, enter `https://127.0.0.1` as a placeholder value then click **Save Changes**.
 
 ![Redirect URI in Activity Settings](images/activities/oauth2-redirect.webp)
 
@@ -167,7 +167,7 @@ cp example.env .env
 Your `DISCORD_CLIENT_SECRET` and `DISCORD_BOT_TOKEN` are *highly* sensitive secrets. Never share either secrets or check them into any kind of version control.
 :::
 
-Back in your app's settings, click on **OAuth2** on the sidebar:
+Back in your app's settings, click on [**OAuth2**](https://discord.com/developers/applications/select/oauth2):
 1. **Client ID**: Copy the value for Client ID and add it to your `.env` file as **`VITE_CLIENT_ID`**. This is the public ID that Discord associates with your app, and is almost always the same as your App ID.
 2. **Client Secret**: Copy the value for Client Secret and add it to your `.env` as **`DISCORD_CLIENT_SECRET`**. This is a private, sensitive identifier that your app will use to grant an OAuth2 `access_token`, and should never be shared or checked into version control.
 
@@ -308,7 +308,7 @@ Copy the URL from the output, as we'll need to add it to our app's settings.
 
 Because Activities are in a sandbox enviornment and go through the Discord proxy, you'll need to add a public URL mapping to serve your application and make external requests in your Activity. Since we're developing locally, we'll use the public endpoint we just set up.
 
-Back in your app's settings, click on the **URL Mappings** page under **Activities** on the left-hand sidebar. Enter the URL you generated from `cloudflared` in the previous step.
+Back in your app's settings, click on the [**URL Mappings** page](https://discord.com/developers/applications/select/embedded/url-mappings) under **Activities** on the left-hand sidebar. Enter the URL you generated from `cloudflared` in the previous step.
 
 ![Configuring your URL Mapping](images/activities/url-mapping-tutorial.webp)
 
@@ -320,7 +320,7 @@ Read details about URL Mapping [in the development guide](/docs/activities/devel
 
 ### Enable Activities
 
-Next, we'll need to enable Activities for your app. On the left hand sidebar under **Activities**, click **Settings**.
+Next, we'll need to enable Activities for your app. On the left hand sidebar under **Activities**, click [**Settings**](https://discord.com/developers/applications/select/embedded/settings).
 
 Find the first checkbox, labeled `Enable Activities`. Turn it on 🎉
 

--- a/docs/activities/development-guides/assets-and-metadata.mdx
+++ b/docs/activities/development-guides/assets-and-metadata.mdx
@@ -30,7 +30,7 @@ An app can have a different application name and avatar from the application's b
 
 The Activity Shelf is where users can see what Activities can be played. It has various metadata and art assets that can be configured.
 
-To update your app's embedded-specific art assets in the Discord Developer Portal, navigate to the `Activities -> Art Assets` tab of your app.
+To update your app's embedded-specific art assets in the Discord Developer Portal, navigate to the [Activities -> Art Assets](https://discord.com/developers/applications/select/embedded/assets) tab of your app.
 
 ## Embedded Background
 

--- a/docs/activities/development-guides/growth-and-referrals.mdx
+++ b/docs/activities/development-guides/growth-and-referrals.mdx
@@ -106,7 +106,7 @@ This guide covers creating a customizable [Incentivized Link](/docs/activities/d
 
 #### Creating a Link
 
-1. In your Application's portal, visit the Custom Links page under the Activities heading in the navigation pane.
+1. In your Application's portal, visit the [Custom Links page](https://discord.com/developers/applications/select/embedded/custom-links) under the Activities heading in the navigation pane.
 2. On the Custom Links page, click `Create New` to create a new link.
 3. You will need to upload an image with an aspect ratio of 43:24.
 4. Title, and description are also required.

--- a/docs/activities/development-guides/local-development.mdx
+++ b/docs/activities/development-guides/local-development.mdx
@@ -66,7 +66,7 @@ This application now uses the same configuration it will use once it is fully pu
 
 ### Launch your application from the Discord Client
 
-You will be able to see and launch all activities owned by you or any teams you are a member of via the Developer Activity Shelf. One caveat is that the activity will not be shown on the current platform (web/ios/android) unless you have checked your platform in `Settings/Supported Platforms` on the developer portal.
+You will be able to see and launch all activities owned by you or any teams you are a member of via the Developer Activity Shelf. One caveat is that the activity will not be shown on the current platform (web/ios/android) unless you have checked your platform in [Settings/Supported Platforms](https://discord.com/developers/applications/select/embedded/settings) on the developer portal.
 
 To see you app inside of Discord in the Activity Shelf:
 
@@ -94,7 +94,7 @@ Because your application is "sandboxed", it will be unable to make network reque
 
 #### How to set a URL Mapping
 
-To add or modify your application's URL mappings, click on `Activities -> URL Mappings` and set the prefix and target values for each mapping as needed.
+To add or modify your application's URL mappings, click on [Activities -> URL Mappings](https://discord.com/developers/applications/select/embedded/url-mappings) and set the prefix and target values for each mapping as needed.
 
 ![Configuring your URL Mapping](images/activities/url-mapping-tutorial.webp)
 

--- a/docs/activities/development-guides/mobile.mdx
+++ b/docs/activities/development-guides/mobile.mdx
@@ -10,9 +10,9 @@ sidebar_label: Mobile
 
 By default, your Activity will be launchable on web/desktop. To enable or disable support for Web/iOS/Android, do the following:
 
-- Visit the developer portal
+- Visit the [developer portal](https://discord.com/developers/applications)
 - Select your application
-- Select `Activities` -> `Settings` in the left-side of the developer portal, or visit `https://discord.com/developers/<your app id>/embedded/settings`
+- Select [Activities -> Settings](https://discord.com/developers/applications/select/embedded/settings) in the left-side of the developer portal
 - From check the appropriate checkboxes in the developer portal, and save your changes
 
 ![supported-platforms](images/activities/supported-platforms.webp)

--- a/docs/activities/overview.mdx
+++ b/docs/activities/overview.mdx
@@ -26,7 +26,7 @@ Under the hood, Activities are single page web apps hosted in an iframe and use 
 
 ## Launching Activities
 
-After you have Activities enabled in your [app's settings](https://discord.com/developers/applications), your app can launch Activities in two ways:
+After you have Activities enabled in your Application's [Activity's settings](https://discord.com/developers/applications/select/embedded/settings), your app can launch Activities in two ways:
 1. When a user invokes your app's Entry Point command in the App Launcher
 2. By responding to an interaction with the `LAUNCH_ACTIVITY` callback type
 

--- a/docs/developer-tools/game-sdk.mdx
+++ b/docs/developer-tools/game-sdk.mdx
@@ -43,7 +43,7 @@ First, we'll need to set an OAuth2 redirect URL. You can add `http://127.0.0.1` 
 
 Next, copy the **Client ID** at the top of the page. This id, also referred to as an "application id", is your game's unique identifier across Discord. Keep it handy!
 
-While you're here, head to the "OAuth2" section of your application and add `http://127.0.0.1` as a redirect URI for your application. This will allow us to do the OAuth2 token exchange within the Discord client.
+While you're here, head to the ["OAuth2" section](https://discord.com/developers/applications/select/oauth2) of your application and add `http://127.0.0.1` as a redirect URI for your application. This will allow us to do the OAuth2 token exchange within the Discord client.
 
 ### Step 3: Start Coding
 

--- a/docs/discord-social-sdk/core-concepts/communication-features.mdx
+++ b/docs/discord-social-sdk/core-concepts/communication-features.mdx
@@ -92,7 +92,7 @@ Once you have met those requirements, you can apply for increased rate limits by
 
 1. Open the [Application page of the Developer Portal](https://discord.com/developers/applications)
 2. Open the Application you want to apply for rate limit increase
-3. Under the **Discord Social SDK** heading in the sidebar, click the **Comms Access** button
+3. Under the **Discord Social SDK** heading in the sidebar, click the [**Comms Access**](https://discord.com/developers/applications/select/social-sdk/comms-access) button
 4. Fill out the application form with the required information and supporting materials
 
 :::info

--- a/docs/discord-social-sdk/development-guides/account-linking-from-discord.mdx
+++ b/docs/discord-social-sdk/development-guides/account-linking-from-discord.mdx
@@ -24,7 +24,7 @@ Before enabling these entry points, you must have:
 
 - **Discord application setup**
   - Created a Discord application in the [Developer Portal](https://discord.com/developers/applications)
-  - Configured OAuth2 settings with appropriate redirect URLs
+  - Configured [OAuth2 settings](https://discord.com/developers/applications/select/oauth2) with appropriate redirect URLs
 - **Implemented account linking in your game**
   - Discord Social SDK downloaded and integrated into your game
   - SDK initialization working (can connect to Discord)

--- a/docs/discord-social-sdk/development-guides/account-linking-with-discord.mdx
+++ b/docs/discord-social-sdk/development-guides/account-linking-with-discord.mdx
@@ -58,7 +58,7 @@ The OAuth2 flow requires a user's account to be verified
 ## Requesting Access Tokens
 
 ### Step 0: Configure OAuth2 Redirects
-For OAuth2 to work correctly, you must **register the correct redirect URIs** for your app in the **Discord Developer Portal**.
+For OAuth2 to work correctly, you must **register the correct redirect URIs** for your app in the [**Discord Developer Portal**](https://discord.com/developers/applications/select/oauth2).
 
 | Platform    | Redirect URI                                                                               |
 |-------------|--------------------------------------------------------------------------------------------|

--- a/docs/discord-social-sdk/development-guides/setting-rich-presence.mdx
+++ b/docs/discord-social-sdk/development-guides/setting-rich-presence.mdx
@@ -89,7 +89,7 @@ The Rich Presence invite image appears when invites are sent for a 3rd party gam
 
 While integrating Rich Presence, you'll likely want to upload custom art assets for your app. For all Rich Presence assets, it's highly recommended to make them 1024 x 1024.
 
-To add custom assets for Rich Presence, navigate to your app's settings and click Rich Presence on the left-hand sidebar. On the Art Assets page, you can upload two different types of assets.
+To add custom assets for Rich Presence, navigate to your app's settings and click Rich Presence on the left-hand sidebar. On the [Art Assets page](https://discord.com/developers/applications/select/rich-presence/assets), you can upload two different types of assets.
 
 ![Rich Presence invite image in app settings](images/rich-presence-invite-image.webp)
 

--- a/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
+++ b/docs/discord-social-sdk/development-guides/using-provisional-accounts.mdx
@@ -84,7 +84,7 @@ If you are using (2) or (3), you must configure you identity provider before bei
 If you are using the bot token endpoint, no Identity Provider configuration is required.
 :::
 
-Open the Discord app for your game in the [Developer Portal](https://discord.com/developers/applications). Find the `External Auth` page under the `Discord Social SDK` section in the sidebar.
+Open the Discord app for your game in the [Developer Portal](https://discord.com/developers/applications). Find the [External Auth](https://discord.com/developers/applications/select/social-sdk/external-auth-providers) page under the `Discord Social SDK` section in the sidebar.
 
 Click on `Add Auth Provider` and choose the type of provider you're using (Steam, OIDC, etc.). Fill in the required details for your provider.
 
@@ -263,7 +263,7 @@ If you are using OIDC, you may encounter more specific errors:
 | 530009 | OIDC JWKS not found          | Check that your OIDC provider's JWKS endpoint is accessible              |
 | 530020 | Invalid OIDC JWT token       | Ensure your OIDC ID token is properly signed and formatted               |
 
- You can find you OIDC configuration by visiting the [Developer Portal](https://discord.com/developers/applications), selecting your application, and opening the `External Auth` page under the `Discord Social SDK` section in the sidebar.
+ You can find you OIDC configuration by visiting the [Developer Portal](https://discord.com/developers/applications), selecting your application, and opening the [External Auth](https://discord.com/developers/applications/select/social-sdk/external-auth-providers) page under the `Discord Social SDK` section in the sidebar.
 
 ---
 

--- a/docs/discord-social-sdk/getting-started/partials/getting-started.mdx
+++ b/docs/discord-social-sdk/getting-started/partials/getting-started.mdx
@@ -13,10 +13,10 @@ Later, you can invite your team members to your new team to collaborate on your 
 ## Step 2: Create a Discord Application
 
 1. Create a new application on the [Discord Developer Portal](https://discord.com/developers/applications) and assign it to your team.
-3. Add a redirect URL in the `OAuth2` tab:
+3. Add a redirect URL in the [OAuth2 tab](https://discord.com/developers/applications/select/oauth2):
    - For desktop applications: `http://127.0.0.1/callback` (this can be changed later).
    - See [`discordpp::Client::Authorize`](https://discord.com/developers/docs/social-sdk/classdiscordpp_1_1Client.html#ace94a58e27545a933d79db32b387a468) for more details on setting up more advanced redirect URIs.
-4. Enable the `Public Client` toggle in the `OAuth2` tab. 
+4. Enable the `Public Client` toggle in the [OAuth2 tab](https://discord.com/developers/applications/select/oauth2). 
 
 :::warn
 **Note:** This guide requires enabling **Public Client** to allow you to get started with the SDK quickly. Most games will not want to ship as a public client. This setting should be reviewed by your team prior to releasing your game. [Learn more about public clients](/docs/discord-social-sdk/core-concepts/oauth2-scopes#oauth2-client-types).
@@ -29,7 +29,7 @@ Later, you can invite your team members to your new team to collaborate on your 
 Once you've created your Discord application, you'll need to enable the Discord Social SDK for it.
 
 1. From the [Discord Developer Portal](https://discord.com/developers/applications), select your newly created application from Step 2.
-2. In the left sidebar for your app, locate and click the `Getting Started` link under `Discord Social SDK`.
+2. In the left sidebar for your app, locate and click the [Getting Started](https://discord.com/developers/applications/select/social-sdk/getting-started) link under `Discord Social SDK`.
 3. Fill out the form to share details about your game.
 4. Click `Submit` and the Social SDK will be enabled for your application.
-5. Once enabled, you'll find binaries for the Social SDK under `Downloads`.
+5. Once enabled, you'll find binaries for the Social SDK under [Downloads](https://discord.com/developers/applications/select/social-sdk/downloads).

--- a/docs/discord-social-sdk/getting-started/using-c++.mdx
+++ b/docs/discord-social-sdk/getting-started/using-c++.mdx
@@ -38,7 +38,7 @@ Let's walk through the steps in detail.
 
 ## Step 4: Download the Discord SDK for C++
 
-1. Click on the `Downloads` link under the Discord Social SDK section of the sidebar.
+1. Click on the [Downloads](https://discord.com/developers/applications/select/social-sdk/downloads) link under the Discord Social SDK section of the sidebar.
 2. Select the latest version from the version dropdown and download the SDK for C++.
 
 ### Runtime Dependencies

--- a/docs/discord-social-sdk/getting-started/using-unity.mdx
+++ b/docs/discord-social-sdk/getting-started/using-unity.mdx
@@ -36,7 +36,7 @@ Let's walk through the steps in detail.
 
 ## Step 4: Download the Social SDK for Unity
 
-1. Click on the `Downloads` link under the Discord Social SDK section of the sidebar.
+1. Click on the [Downloads](https://discord.com/developers/applications/select/social-sdk/downloads) link under the Discord Social SDK section of the sidebar.
 2. Select the latest version from the version dropdown and download the SDK for Unity.
 
 :::info
@@ -148,7 +148,7 @@ We'll start by adding the following code to your `DiscordManager.cs`:
     }
 ```
 
-This will hook up the API status changes to your text in the game. Then we'll need to get your Client ID from the OAuth2 tab in the developer portal and paste it into the ClientID on the **DiscordManager** in the inspector.
+This will hook up the API status changes to your text in the game. Then we'll need to get your Client ID from the [OAuth2 tab](https://discord.com/developers/applications/select/oauth2) in the developer portal and paste it into the ClientID on the **DiscordManager** in the inspector.
 
 ### What These Callbacks Do
 

--- a/docs/discord-social-sdk/getting-started/using-unreal-engine.mdx
+++ b/docs/discord-social-sdk/getting-started/using-unreal-engine.mdx
@@ -41,7 +41,7 @@ Let's walk through the steps in detail.
 
 ## Step 4: Download the Social SDK for Unreal Engine
 
-1. Click on the `Downloads` link under the Discord Social SDK section of the sidebar.
+1. Click on the [Downloads](https://discord.com/developers/applications/select/social-sdk/downloads) link under the Discord Social SDK section of the sidebar.
 2. Select the latest version from the version dropdown and download the SDK for Unreal Engine.
 
 :::info

--- a/docs/discovery/best-practices.md
+++ b/docs/discovery/best-practices.md
@@ -24,13 +24,13 @@ There are a few places where you can define different descriptions of your app w
 
 #### App General Information Description
 
-On the **General Information** tab, there is a general **Description** field (max of 400 characters) that appears within your bot user's profile. When a new user clicks on your app within Discord, they'll see this description.
+On the [**General Information** tab](https://discord.com/developers/applications/select/information), there is a general **Description** field (max of 400 characters) that appears within your bot user's profile. When a new user clicks on your app within Discord, they'll see this description.
 
 ![App description on the General Information tab](images/bp-productpage-app-description.webp)
 
 #### App Summary
 
-On the **App Directory** tab, the **Summary** field is a short description (max of 200 characters) that users will see when you appear within search results on the App Directory.
+On the [**App Directory** tab](https://discord.com/developers/applications/select/discovery), the **Summary** field is a short description (max of 200 characters) that users will see when you appear within search results on the App Directory.
 
 When writing your app's Summary, think about how to grab the user's attention and quickly convey the value of your app. Consider the following description:
 
@@ -42,7 +42,7 @@ While this could be true, it doesn’t really tell folks how the app makes serve
 
 #### App Expanded Description
 
-On the **App Directory** tab, there is an **Expanded Description** field near the bottom of the page. This description appears when someone clicks on your app and enters its profile within the App Directory. This is your opportunity to showcase why a user should install your app, and the best functionality your app has to offer. The description also supports formatting via markdown.
+On the [**App Directory** tab](https://discord.com/developers/applications/select/discovery), there is an **Expanded Description** field near the bottom of the page. This description appears when someone clicks on your app and enters its profile within the App Directory. This is your opportunity to showcase why a user should install your app, and the best functionality your app has to offer. The description also supports formatting via markdown.
 
 When writing your app's Expanded Description, the first thing you do should be to convey the value of the app to users. After the value is clear, continue on with how to get started with your app after it’s installed. 
 

--- a/docs/discovery/enabling-discovery.mdx
+++ b/docs/discovery/enabling-discovery.mdx
@@ -13,8 +13,8 @@ To enable **Discovery** for your app, we require your team owner to complete ide
 
 To see the list of requirements for **App Verification**:
 
-1. Visit the [Developer Portal](https://discord.com/developers/applications) and select your app. 
-2. Select `App Verification` from the left-hand menu to see the requirements for verification.
+1. Visit the [Developer Portal](https://discord.com/developers/applications) and select your app.
+2. Select [App Verification](https://discord.com/developers/applications/select/verification-onboarding) from the left-hand menu to see the requirements for verification.
 3. Complete the listed App Verification qualification criteria for your app. 
 4. Once you've completed the requirements, you can submit your app for verification.
 
@@ -26,10 +26,10 @@ After you've verified your app, you can opt into **Discovery** in the Developer 
 
 To opt into **Discovery**:
 
-1. Visit the [Developer Portal](https://discord.com/developers/applications) and select your app. 
-2. Select `Discovery -> Discovery Status` from the left-hand menu to see the requirements for enabling discovery.
+1. Visit the [Developer Portal](https://discord.com/developers/applications) and select your app.
+2. Select [Discovery -> Discovery Status](https://discord.com/developers/applications/select/discovery/status) from the left-hand menu to see the requirements for enabling discovery.
 3. Complete the listed **Discovery** qualification criteria for your app.
-4. Add your app metadata and images under the `Discovery -> Discovery Settings` menu to customize your app's appearance in discovery surfaces.
+4. Add your app metadata and images under the [Discovery -> Discovery Settings](https://discord.com/developers/applications/select/discovery/settings) menu to customize your app's appearance in discovery surfaces.
 4. Once you've completed the requirements, you can enable **Discovery** for your app.
 
 For more information on **Discovery**, check out our [Help Center article](https://support-dev.discord.com/hc/en-us/articles/21204493235991-How-Can-Users-Discover-and-Play-My-Activity).

--- a/docs/events/gateway.mdx
+++ b/docs/events/gateway.mdx
@@ -448,7 +448,7 @@ In addition to the gateway restrictions described here, Discord's REST API is al
 
 #### Enabling Privileged Intents
 
-Before using privileged intents, you must enable them in your app's settings. In the [Developer Portal](https://discord.com/developers/applications), you can navigate to your app's settings then toggle the privileged intents on the **Bots** page under the "Privileged Gateway Intents" section. You should only toggle privileged intents that your bot *requires to function*.
+Before using privileged intents, you must enable them in your app's settings. In the [Developer Portal](https://discord.com/developers/applications), you can navigate to your app's settings then toggle the privileged intents on the [**Bot** page](https://discord.com/developers/applications/select/bot) under the "Privileged Gateway Intents" section. You should only toggle privileged intents that your bot *requires to function*.
 
 If your app qualifies for [verification](https://support-dev.discord.com/hc/en-us/articles/23926564536471-How-Do-I-Get-My-App-Verified), you must first [verify your app](https://support-dev.discord.com/hc/en-us/articles/23926564536471-How-Do-I-Get-My-App-Verified) and request access to these intents during the verification process. If your app is already verified and you need to request additional privileged intents, you can [contact support](https://dis.gd/support).
 

--- a/docs/events/webhook-events.mdx
+++ b/docs/events/webhook-events.mdx
@@ -16,7 +16,7 @@ To configure webhook events, you'll need to configure your URL and select the ev
 The steps below walk through subscribing using the developer portal. If you prefer to use the API, you can call [Edit Current Application](/docs/resources/application#edit-current-application).
 :::
 
-In your [app's settings](https://discord.com/developers/applications), navigate to the **Webhooks** page from the left-hand sidebar then complete the following:
+In your [app's settings](https://discord.com/developers/applications), navigate to the [**Webhooks** page](https://discord.com/developers/applications/select/webhooks) from the left-hand sidebar then complete the following:
 
 1. Under **Endpoint**, add a public URL that is set up to receive and acknowledge webhook events. Details about setting up a Webhook Events URL is in the [preparing for events](/docs/events/webhook-events#preparing-for-events) section.
 2. Enable Events by clicking the toggle in the **Events** section.
@@ -80,7 +80,7 @@ We recommend checking out our [Community Resources](/docs/developer-tools/commun
 
 After you have a public endpoint to use as your app's Event Webhooks URL, you can add it to your app by going to your [app's settings](https://discord.com/developers/applications).
 
-On the **Webhooks** page, look for the **Endpoint URL** field. Paste your public URL that is set up to acknowledge `PING` messages and correctly handles security-related signature headers.
+On the [**Webhooks** page](https://discord.com/developers/applications/select/webhooks), look for the **Endpoint URL** field. Paste your public URL that is set up to acknowledge `PING` messages and correctly handles security-related signature headers.
 
 After you configure your Webhook Events URL, you can [enable and subscribe to events](/docs/events/webhook-events#subscribing-to-events) on the same page.
 

--- a/docs/interactions/overview.mdx
+++ b/docs/interactions/overview.mdx
@@ -164,7 +164,7 @@ We highly recommend checking out our [Community Resources](/docs/developer-tools
 
 After you have a public endpoint to use as your app's Interactions Endpoint URL, you can add it to your app by going to your [app's settings](https://discord.com/developers/applications).
 
-On the **General Overview** page, look for the **Interactive Endpoint URL** field. Paste your public URL that is set up to acknowledge `PING` messages and correctly handles security-related signature headers.
+On the [**General Information** page](https://discord.com/developers/applications/select/information), look for the **Interactive Endpoint URL** field. Paste your public URL that is set up to acknowledge `PING` messages and correctly handles security-related signature headers.
 
 ---
 

--- a/docs/monetization/managing-skus.mdx
+++ b/docs/monetization/managing-skus.mdx
@@ -8,7 +8,7 @@ The premium items and subscriptions you offer in your app are represented by SKU
 
 ## Creating a SKU
 
-To create a new SKU, navigate to your [app's settings](https://discord.com/developers/applications) and select the `Monetization -> Manage SKUs` tab. From there, you can create a new SKU by clicking the `Create SKU` button.
+To create a new SKU, navigate to your [app's settings](https://discord.com/developers/applications) and select the [Monetization -> Manage SKUs](https://discord.com/developers/applications/select/skus) tab. From there, you can create a new SKU by clicking the `Create SKU` button.
 
 When you click on `Create SKU`, you have the option to select from the following:
 
@@ -96,7 +96,7 @@ You can find the ID of the emoji in the Discord app by escaping the emoji in a m
 
 When you initially create a SKU, it will be in an `Unavailable` state. This SKU is not yet available for purchase by users. You can edit the SKU to add a price, benefits, and other details before publishing it.
 
-While creating and editing SKUs in your [app's settings](https://discord.com/developers/applications) on the `Monetization -> Manage SKUs` tab, you have a few options for managing your SKUs visibility and publishing to your users:
+While creating and editing SKUs in your [app's settings](https://discord.com/developers/applications) on the [Monetization -> Manage SKUs](https://discord.com/developers/applications/select/skus) tab, you have a few options for managing your SKUs visibility and publishing to your users:
 
 - Publish SKU
 - Unpublish SKU

--- a/docs/quick-start/getting-started.mdx
+++ b/docs/quick-start/getting-started.mdx
@@ -105,9 +105,9 @@ Back in your project folder, rename the `.env.sample` file to `.env`. This is wh
 
 We'll need three values from your app's settings for your `.env` file:
 
-- On the **General Information** page, copy the value for **Application ID**. In `.env`, replace `<YOUR_APP_ID>` with the ID you copied.
-- Back on the **General Information** page, copy the value for **Public Key**, which is used to ensure HTTP requests are coming from Discord. In `.env`, replace `<YOUR_PUBLIC_KEY>` with the value you copied.
-- On the **Bot** page under **Token**, click "Reset Token" to generate a new bot token. In `.env`, replace `<YOUR_BOT_TOKEN>` with your new token.
+- On the [**General Information** page](https://discord.com/developers/applications/select/information), copy the value for **Application ID**. In `.env`, replace `<YOUR_APP_ID>` with the ID you copied.
+- Back on the [**General Information** page](https://discord.com/developers/applications/select/information), copy the value for **Public Key**, which is used to ensure HTTP requests are coming from Discord. In `.env`, replace `<YOUR_PUBLIC_KEY>` with the value you copied.
+- On the [**Bot** page](https://discord.com/developers/applications/select/bot) under **Token**, click "Reset Token" to generate a new bot token. In `.env`, replace `<YOUR_BOT_TOKEN>` with your new token.
 
 :::warn
 You won't be able to view your token again unless you regenerate it, so make sure to keep it somewhere safe (like in a password manager).
@@ -119,7 +119,7 @@ Now that you have the credentials you need, lets configure your bot user and ins
 
 Newly-created apps have a bot user enabled by default. Bot users allow your app to appear and behave similarly to other server members when it's [installed to a server](/docs/quick-start/overview-of-apps#where-are-apps-installed).
 
-On the left hand sidebar in your app's settings, there's a **Bot** page (where we fetched the token from). On this page, you can also configure settings like its [privileged intents](/docs/events/gateway#privileged-intents) or whether it can be installed by other users.
+On the left hand sidebar in your app's settings, there's a [**Bot** page](https://discord.com/developers/applications/select/bot) (where we fetched the token from). On this page, you can also configure settings like its [privileged intents](/docs/events/gateway#privileged-intents) or whether it can be installed by other users.
 
 <Collapsible title="What are intents?" description="Introduction to standard and privileged intents" icon="question">
 Intents determine which events Discord will send your app when you're creating a [Gateway API connection](/docs/events/gateway). For example, if you want your app to perform an action when users add a reaction to a message, you can pass the `GUILD_MESSAGE_REACTIONS` (`1 << 10`) intent.
@@ -142,7 +142,7 @@ Now we'll select where your app can be installed in Discord, which is determined
 - Apps installed in a **[user context](/docs/resources/application#user-context)** (user-installed apps) are visible only to the authorizing user, and therefore don't require any server-specific permissions. Apps installed to a user context are visible across all of the user's servers, DMs, and GDMs—however, they're limited to using commands.
 </Collapsible>
 
-Click on **Installation** in the left sidebar, then under **Installation Contexts** make sure both "User Install" and "Guild Install" are selected.
+Click on [**Installation**](https://discord.com/developers/applications/select/installation) in the left sidebar, then under **Installation Contexts** make sure both "User Install" and "Guild Install" are selected.
 
 :::info
 Some apps may only want to support one installation context—for example, a moderation app may only support a server context. However, by default, we recommend supporting both installation contexts. For detailed information about supporting user-installed apps, you can read the [user-installable app tutorial](/docs/tutorials/developing-a-user-installable-app).
@@ -152,7 +152,7 @@ Some apps may only want to support one installation context—for example, a mod
 
 [Install links](/docs/resources/application#install-links) provide an easy way for users to install your app in Discord. We'll set up the default [Discord Provided Link](/docs/resources/application#discord-provided-link), but you can read more about the different type of install links in the [Application documentation](/docs/resources/application#types-of-install-links).
 
-On the **Installation** page, go to the **Install Link** section and select "Discord Provided Link" if it's not already selected.
+On the [**Installation** page](https://discord.com/developers/applications/select/installation), go to the **Install Link** section and select "Discord Provided Link" if it's not already selected.
 
 When Discorded Provided Link is selected, a new **Default Install Settings** section will appear, which we'll configure next.
 
@@ -167,7 +167,7 @@ When creating an app, scopes and permissions determine what your app can do and 
 - [Permissions](/docs/topics/permissions#permission-overwrites) are the granular permissions for your bot user, the same as other users in Discord have. They can be approved by the installing user or later updated within server settings or with [permission overwrites](/docs/topics/permissions#permission-overwrites). Since apps installed to a user context can only respond to commands, these permissions are only relevant to apps installed to a server.
 </Collapsible>
 
-On the **Installation** page in the **Default Install Settings** section:
+On the [**Installation** page](https://discord.com/developers/applications/select/installation) in the **Default Install Settings** section:
 - For **User Install**, add the `applications.commands` scope
 - For **Guild Install**, add the `applications.commands` scope and `bot` scope. When you select `bot`, a new **Permissions** menu will appear to select the bot user's permissions. Select any permissions that you may want for your app—for now, I'll just select `Send Messages`.
 
@@ -278,7 +278,7 @@ We'll use **Forwarding** URL as the publicly-accessible URL where Discord will s
 
 ### Adding an interaction endpoint URL
 
-Go to your [app's settings](https://discord.com/developers/applications) and on the **General Information** page under **Interaction Endpoint URL**, paste your new ngrok forwarding URL and append `/interactions`.
+Go to your [app's settings](https://discord.com/developers/applications) and on the [**General Information** page](https://discord.com/developers/applications/select/information) under **Interaction Endpoint URL**, paste your new ngrok forwarding URL and append `/interactions`.
 
 ![Interactions Endpoint URL](images/getting-started-interactions-endpoint.webp)
 

--- a/docs/resources/application.mdx
+++ b/docs/resources/application.mdx
@@ -181,7 +181,7 @@ Apps that support the user installation context are visible across all of an aut
 
 By default, newly-created apps only support installation to guilds.
 
-You can update which installation contexts your app supports in your [app's settings](https://discord.com/developers/applications). On the **Installation** page under the **Installation Contexts** section, you can select the installation contexts your app supports.
+You can update which installation contexts your app supports in your [app's settings](https://discord.com/developers/applications). On the [**Installation** page](https://discord.com/developers/applications/select/installation) under the **Installation Contexts** section, you can select the installation contexts your app supports.
 
 :::info
 If you update your app to support a new installation context, you will need to update your existing [commands](/docs/interactions/application-commands#contexts) if you want them to be supported in the new context. Details are in the [Application Command](/docs/interactions/application-commands#contexts) documentation.
@@ -223,9 +223,9 @@ A Custom URL doesn't have strict limitations, but is commonly an [OAuth2 `/autho
 
 ### Configuring an Install Link and Default Install Settings
 
-You can configure your app's install link in your [app's settings](https://discord.com/developers/applications). On the **Installation** page, go to the **Install Link** section, and select which type of install link you want for your app. For most apps, we recommend the Discord Provided Link.
+You can configure your app's install link in your [app's settings](https://discord.com/developers/applications). On the [**Installation** page](https://discord.com/developers/applications/select/installation), go to the **Install Link** section, and select which type of install link you want for your app. For most apps, we recommend the Discord Provided Link.
 
-The Default Install Settings will appear on the **Installation** page when you have "Discord Provided Link" selected as your install link type.
+The Default Install Settings will appear on the [**Installation** page](https://discord.com/developers/applications/select/installation) when you have "Discord Provided Link" selected as your install link type.
 
 ## Get Current Application
 <Route method="GET">/applications/@me</Route>

--- a/docs/rich-presence/overview.mdx
+++ b/docs/rich-presence/overview.mdx
@@ -58,7 +58,7 @@ When integrating Rich Presence with an off-platform game, data can be shown abou
 
 While integrating Rich Presence, you'll likely want to upload custom art assets for your app. **For all Rich Presence assets, it's highly recommended to make them 1024 x 1024**.
 
-To add custom assets for Rich Presence, navigate to your [app's settings](https://discord.com/developers/applications) and click **Rich Presence** on the left-hand sidebar. On the **Art Assets** page, there are two different types of assets you can upload. 
+To add custom assets for Rich Presence, navigate to your [app's settings](https://discord.com/developers/applications) and click **Rich Presence** on the left-hand sidebar. On the [**Art Assets** page](https://discord.com/developers/applications/select/rich-presence/assets), there are two different types of assets you can upload. 
 
 ### Invite Image
 
@@ -90,7 +90,7 @@ When uploading Rich Presence assets, **the asset keys will automatically be chan
 The Rich Presence visualizer currently uses an outdated Discord UI, but can still be helpful as a quick-and-dirty reference for what your Rich Presence data will look like in Discord. 
 :::
 
-In your app's settings, there's a Rich Presence visualizer to make it easier to see what your uploaded [assets](/docs/rich-presence/overview#assets) will look like in the context of a Discord profile. To access the visualizer, navigate to your [app's settings](https://discord.com/developers/applications) and click **Rich Presence** on the left-hand sidebar. On the **Visualizer** page, you can fill out some custom strings, party information, and select your uploaded assets to see a preview.
+In your app's settings, there's a Rich Presence visualizer to make it easier to see what your uploaded [assets](/docs/rich-presence/overview#assets) will look like in the context of a Discord profile. To access the visualizer, navigate to your [app's settings](https://discord.com/developers/applications) and click **Rich Presence** on the left-hand sidebar. On the [**Visualizer** page](https://discord.com/developers/applications/select/rich-presence/visualizer), you can fill out some custom strings, party information, and select your uploaded assets to see a preview.
 
 ## Start Building
 

--- a/docs/topics/teams.md
+++ b/docs/topics/teams.md
@@ -26,7 +26,7 @@ To create a new app that belongs to a team, select the team from the **Team** dr
 
 ### Transferring an App
 
-To transfer an existing app to a team, navigate to the [Application](https://discord.com/developers/applications) that you want to transfer. At the bottom of the app's **General Information** page, click "Transfer App to Team".
+To transfer an existing app to a team, navigate to the [Application](https://discord.com/developers/applications) that you want to transfer. At the bottom of the app's [**General Information** page](https://discord.com/developers/applications/select/information), click "Transfer App to Team".
 
 :::danger
 Once an app has been transferred to a team, it _cannot_ be transferred back.

--- a/docs/tutorials/configuring-app-metadata-for-linked-roles.md
+++ b/docs/tutorials/configuring-app-metadata-for-linked-roles.md
@@ -22,7 +22,7 @@ Basic steps to create an app are outlined below, but a more detailed walkthrough
 
 - Navigate to the [developer dashboard](https://discord.com/developers/applications)
 - Click **New Application** in the upper right corner, then select a name and create your app
-- Click on the **Bot** tab on the left sidebar. On that page, click **Reset Token** and store the token somewhere safe (like in a password manager)
+- Click on the [**Bot** tab](https://discord.com/developers/applications/select/bot) on the left sidebar. On that page, click **Reset Token** and store the token somewhere safe (like in a password manager)
 
 :::warn
 Bot tokens are used to authorize API requests and carry your bot's permissions, making them highly sensitive. Never share your token or check it into any kind of version control.
@@ -32,7 +32,7 @@ Bot tokens are used to authorize API requests and carry your bot's permissions, 
 
 Apps need approval from installing users to perform actions inside of Discord. So before installing your app, let's add some scopes to request during installation.
 
-- Click on `OAuth2` in the left sidebar, then `URL generator`
+- Click on [OAuth2](https://discord.com/developers/applications/select/oauth2/url-generator) in the left sidebar, then `URL generator`
 - Check the `bot` scope
 - After the scope is selected, you should see a **Generated URL** which can be used to install your app
 
@@ -92,7 +92,7 @@ It bears repeating that you should never check any credentials or secrets into s
 
 First, copy your bot user’s token from earlier and paste it in the `DISCORD_TOKEN` variable in your `.env` file.
 
-Next, navigate to your app settings in the developer portal, and navigate to OAuth2 -> General. Copy the Client ID and Client Secret for your application, and paste the values as `DISCORD_CLIENT_ID` and `DISCORD_CLIENT_SECRET` in your `.env`. 
+Next, navigate to your [app settings in the developer portal](https://discord.com/developers/applications), and navigate to [OAuth2 -> General](https://discord.com/developers/applications/select/oauth2). Copy the Client ID and Client Secret for your application, and paste the values as `DISCORD_CLIENT_ID` and `DISCORD_CLIENT_SECRET` in your `.env`. 
 
 ![Configure OAuth2](images/linked-roles-oauth-config.webp)
 
@@ -100,9 +100,9 @@ Now, we need to set the Redirect URL that will be used for our OAuth2 flow. Go b
 
 ![Glitch Share](images/linked-roles-glitch-share-url.webp)
 
-Go back to the OAuth2 -> General tab in the Discord developer portal, and add a new redirect for your app using the Glitch URL and the `/discord-oauth-callback` route. Copy this URL, then paste it as `DISCORD_REDIRECT_URI` in your `.env`. 
+Go back to the [OAuth2 -> General](https://discord.com/developers/applications/select/oauth2) tab in the Discord developer portal, and add a new redirect for your app using the Glitch URL and the `/discord-oauth-callback` route. Copy this URL, then paste it as `DISCORD_REDIRECT_URI` in your `.env`. 
 
-Go to the General Information tab in the developer portal, and scroll down to the `Linked Roles Verification Url` field. Paste the base URL to your Glitch app, add the `/linked-role` route, then save.
+Go to the [General Information tab](https://discord.com/developers/applications/select/information) in the developer portal, and scroll down to the `Linked Roles Verification Url` field. Paste the base URL to your Glitch app, add the `/linked-role` route, then save.
 
 :::info
 For the Glitch project used in the screenshots, the verification URL would be `https://adjoining-crawling-yamamomo.glitch.me/linked-role`

--- a/docs/tutorials/developing-a-user-installable-app.mdx
+++ b/docs/tutorials/developing-a-user-installable-app.mdx
@@ -63,7 +63,7 @@ First, you'll need to create an app in the developer portal if you don't have on
 
 Enter a name for your app, then press **Create**.
 
-After you create your app, you'll land on the **General Overview** page of the app's settings where you can update basic information about your app like its description and icon.
+After you create your app, you'll land on the **General Information** page of the app's settings where you can update basic information about your app like its description and icon.
 
 ### Fetching app credentials
 
@@ -77,9 +77,9 @@ Back in your project folder, rename the `.env.sample` file to `.env`. `.env` is 
 
 We'll need three values from your app's settings for your `.env` file:
 
-- On the **General Information** page, copy the value for **Application ID**. In `.env`, replace `<YOUR_APP_ID>` with the ID you copied.
-- Back on the **General Information** page, copy the value for **Public Key**, which is used to ensure HTTP requests are coming from Discord. In `.env`, replace `<YOUR_PUBLIC_KEY>` with the value you copied.
-- On the **Bot** page under **Token**, click "Reset Token" to generate a new bot token. In `.env`, replace `<YOUR_BOT_TOKEN>` with your new token.
+- On the [**General Information** page](https://discord.com/developers/applications/select/information), copy the value for **Application ID**. In `.env`, replace `<YOUR_APP_ID>` with the ID you copied.
+- Back on the [**General Information** page](https://discord.com/developers/applications/select/information), copy the value for **Public Key**, which is used to ensure HTTP requests are coming from Discord. In `.env`, replace `<YOUR_PUBLIC_KEY>` with the value you copied.
+- On the [**Bot** page](https://discord.com/developers/applications/select/bot) under **Token**, click "Reset Token" to generate a new bot token. In `.env`, replace `<YOUR_BOT_TOKEN>` with your new token.
 
 Now that you have the credentials you need, we'll configure your app to support different installation contexts.
 
@@ -95,7 +95,7 @@ An app's **[installation context](/docs/resources/application#installation-conte
 
 We're going to configure our app to support both installation contexts, and while that's a good default for most apps, some apps may only make sense in one context or the other.
 
-In your app's settings, go to the **Installation** page from the sidebar. Under **Installation Contexts**, check both **User Install** and **Guild Install**, then press **Save Changes**.
+In your app's settings, go to the [**Installation** page](https://discord.com/developers/applications/select/installation) from the sidebar. Under **Installation Contexts**, check both **User Install** and **Guild Install**, then press **Save Changes**.
 
 ### Configuring Default Install Settings
 
@@ -221,7 +221,7 @@ The output will include a **Forwarding** URL, which is the publicly-accessible U
 
 Let's configure our app's **Interaction Endpoint URL**.
 
-Go to your [app's settings](https://discord.com/developers/applications) and on the **General Information** page under **Interaction Endpoint URL**, paste your new ngrok URL and append `/interactions` (it'll be something like `https://84c5df474.ngrok-free.dev/interactions`).
+Go to your [app's settings](https://discord.com/developers/applications) and on the [**General Information** page](https://discord.com/developers/applications/select/information) under **Interaction Endpoint URL**, paste your new ngrok URL and append `/interactions` (it'll be something like `https://84c5df474.ngrok-free.dev/interactions`).
 
 Click **Save Changes** and if all is well, your Interactions Endpoint URL should be verified by Discord.
 

--- a/docs/tutorials/hosting-on-cloudflare-workers.md
+++ b/docs/tutorials/hosting-on-cloudflare-workers.md
@@ -32,7 +32,7 @@ To start, we'll create the app through the [Discord Developer Dashboard](https:/
 
 ![IDs found in app settings](images/cloudflare-general-overview.webp)
 
-- Now click on the **Bot** tab on the left sidebar.
+- Now click on the [**Bot** tab](https://discord.com/developers/applications/select/bot) on the left sidebar.
 - Grab the `token` for your bot, and store it somewhere safe (I like to put these tokens in a password manager like [1password](https://1password.com/) or [lastpass](https://www.lastpass.com/)).
 
 :::warn
@@ -43,7 +43,7 @@ For security reasons, you can only view your bot token once. If you misplace you
 
 Now we'll configure the bot with [permissions](/docs/topics/permissions) required to create and use slash commands, as well as send messages in  channels.
 
-- Click on the `OAuth2` tab, and choose the `URL Generator`. Click the `bot` and `applications.commands` scopes.
+- Click on the [OAuth2 tab](https://discord.com/developers/applications/select/oauth2/url-generator), and choose the `URL Generator`. Click the `bot` and `applications.commands` scopes.
 - Check the boxes next to `Send Messages` and `Use Slash Commands`, then copy the `Generated URL`.
 
 ![Configuring bot permissions in app settings](images/cloudflare-url-generator.webp)

--- a/docs/tutorials/upgrading-to-application-commands.md
+++ b/docs/tutorials/upgrading-to-application-commands.md
@@ -156,7 +156,7 @@ However, before adding your URL to your app settings, your endpoint must be set 
 Many libraries on the [Community Resources page](/docs/developer-tools/community-resources#interactions) simplify verification and interaction request handling by exporting reusable functions and/or handling it automatically.
 :::
 
-After your URL is set up to handle signature verification and `PING` requests, you can add your Interaction Endpoint URL by navigating to your app settings from the [developer portal](https://discord.com/developers/applications). On the **General Information** page, you’ll see a field for your **Interactions Endpoint URL**. 
+After your URL is set up to handle signature verification and `PING` requests, you can add your Interaction Endpoint URL by navigating to your app settings from the [developer portal](https://discord.com/developers/applications). On the [**General Information** page](https://discord.com/developers/applications/select/information), you'll see a field for your **Interactions Endpoint URL**. 
 
 ![Interactions endpoint URL in app settings](images/interactions-url.webp)
 


### PR DESCRIPTION
- Add link to App Verification page (/select/verification-onboarding)
- Add links to Discovery Status (/select/discovery/status) and Discovery Settings (/select/discovery/settings)
- Add link to Activities -> URL Mappings (/select/embedded/url-mappings)
- Add link to Activities settings (/select/embedded/settings)
- Remove backtick formatting from all linked portal section names for consistency

All Developer Portal section references now use the application selector deep-link format for improved user experience.

