### PR TITLE
Update permissions for community invites

### DIFF
--- a/docs/events/gateway-events.mdx
+++ b/docs/events/gateway-events.mdx
@@ -978,6 +978,7 @@ Sent when a new invite to a channel is created.
 | temporary           | boolean                                                                      | Whether or not the invite is temporary (invited users will be kicked on disconnect unless they're assigned a role) |
 | uses                | integer                                                                      | How many times the invite has been used (always will be 0)                                                         |
 | expires_at          | ?ISO8601 timestamp                                                           | the expiration date of this invite                                                                                 |
+| role_ids?           | array of snowflakes                                                          | the role ID(s) for roles in the guild given to the users that accept this invite                                   |
 
 #### Invite Delete
 

--- a/docs/events/gateway-events.mdx
+++ b/docs/events/gateway-events.mdx
@@ -963,22 +963,22 @@ Sent when a new invite to a channel is created.
 
 ###### Invite Create Event Fields
 
-| Field               | Type                                                                         | Description                                                                                                        |
-|---------------------|------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
-| channel_id          | snowflake                                                                    | Channel the invite is for                                                                                          |
-| code                | string                                                                       | Unique invite [code](/docs/resources/invite#invite-object)                                                         |
-| created_at          | ISO8601 timestamp                                                            | Time at which the invite was created                                                                               |
-| guild_id?           | snowflake                                                                    | Guild of the invite                                                                                                |
-| inviter?            | [user](/docs/resources/user#user-object) object                              | User that created the invite                                                                                       |
-| max_age             | integer                                                                      | How long the invite is valid for (in seconds)                                                                      |
-| max_uses            | integer                                                                      | Maximum number of times the invite can be used                                                                     |
-| target_type?        | integer                                                                      | [Type of target](/docs/resources/invite#invite-object-invite-target-types) for this voice channel invite           |
-| target_user?        | [user](/docs/resources/user#user-object) object                              | User whose stream to display for this voice channel stream invite                                                  |
-| target_application? | partial [application](/docs/resources/application#application-object) object | Embedded application to open for this voice channel embedded application invite                                    |
-| temporary           | boolean                                                                      | Whether or not the invite is temporary (invited users will be kicked on disconnect unless they're assigned a role) |
-| uses                | integer                                                                      | How many times the invite has been used (always will be 0)                                                         |
-| expires_at          | ?ISO8601 timestamp                                                           | the expiration date of this invite                                                                                 |
-| role_ids?           | array of snowflakes                                                          | the role ID(s) for roles in the guild given to the users that accept this invite                                   |
+| Field               | Type                                                                         | Description                                                                                                              |
+|---------------------|------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| channel_id          | snowflake                                                                    | Channel the invite is for                                                                                                |
+| code                | string                                                                       | Unique invite [code](/docs/resources/invite#invite-object)                                                               |
+| created_at          | ISO8601 timestamp                                                            | Time at which the invite was created                                                                                     |
+| guild_id?           | snowflake                                                                    | Guild of the invite                                                                                                      |
+| inviter?            | [user](/docs/resources/user#user-object) object                              | User that created the invite                                                                                             |
+| max_age             | integer                                                                      | How long the invite is valid for (in seconds)                                                                            |
+| max_uses            | integer                                                                      | Maximum number of times the invite can be used                                                                           |
+| target_type?        | integer                                                                      | [Type of target](/docs/resources/invite#invite-object-invite-target-types) for this voice channel invite                 |
+| target_user?        | [user](/docs/resources/user#user-object) object                              | User whose stream to display for this voice channel stream invite                                                        |
+| target_application? | partial [application](/docs/resources/application#application-object) object | Embedded application to open for this voice channel embedded application invite                                          |
+| temporary           | boolean                                                                      | Whether or not the invite is temporary (invited users will be kicked on disconnect unless they're assigned a role)       |
+| uses                | integer                                                                      | How many times the invite has been used (always will be 0)                                                               |
+| expires_at          | ?ISO8601 timestamp                                                           | the expiration date of this invite                                                                                       |
+| role_ids?           | array of snowflakes                                                          | the role ID(s) for [roles](/docs/topics/permissions#role-object) in the guild given to the users that accept this invite |
 
 #### Invite Delete
 

--- a/docs/resources/channel.mdx
+++ b/docs/resources/channel.mdx
@@ -481,7 +481,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | target_users_file?\*  | file                | a csv file with a single column of user IDs for all the users able to accept this invite                                                  |                  |
 | role_ids?\*\*         | array of snowflakes | the role ID(s) for roles in the guild given to the users that accept this invite                                                          |                  |
 
-\* Requires `multipart/form-data` as the content type with other parameters as form fields in the multipart body. Requires the `CREATE_INSTANT_INVITE` permission. Uploading a file with invalid user IDs will result in a 400 with the invalid IDs described.
+\* Requires `multipart/form-data` as the content type with other parameters as form fields in the multipart body. Uploading a file with invalid user IDs will result in a 400 with the invalid IDs described.
 
 \*\* Requires the `MANAGE_ROLES` permission and cannot assign roles with higher permissions than the sender.
 

--- a/docs/resources/channel.mdx
+++ b/docs/resources/channel.mdx
@@ -481,7 +481,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | target_users_file?\*  | file                | a csv file with a single column of user IDs for all the users able to accept this invite                                                  |                  |
 | role_ids?\*\*         | array of snowflakes | the role ID(s) for roles in the guild given to the users that accept this invite                                                          |                  |
 
-\* Requires `multipart/form-data` as the content type with other parameters as form fields in the multipart body. Requires the `MANAGE_GUILD` permission. Uploading a file with invalid user IDs will result in a 400 with the invalid IDs described.
+\* Requires `multipart/form-data` as the content type with other parameters as form fields in the multipart body. Requires the `CREATE_INSTANT_INVITE` permission. Uploading a file with invalid user IDs will result in a 400 with the invalid IDs described.
 
 \*\* Requires the `MANAGE_ROLES` permission and cannot assign roles with higher permissions than the sender.
 

--- a/docs/resources/channel.mdx
+++ b/docs/resources/channel.mdx
@@ -480,7 +480,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | target_application_id | snowflake           | the id of the embedded application to open for this invite, required if `target_type` is 2, the application must have the `EMBEDDED` flag |                  |
 | target_users_file?\*  | file                | a csv file with a single column of user IDs for all the users able to accept this invite                                                  |                  |
 | payload_json?         | string              | JSON-encoded body of non-file params, only for `multipart/form-data` requests.                                                            |                  |
-| role_ids?\*\*         | array of snowflakes | the role ID(s) for roles in the guild given to the users that accept this invite                                                          |                  |
+| role_ids?\*\*         | array of snowflakes | the role ID(s) for [roles](/docs/topics/permissions#role-object) in the guild given to the users that accept this invite                  |                  |
 
 \* Requires `multipart/form-data` as the content type with other parameters as form fields in the multipart body. Uploading a file with invalid user IDs will result in a 400 with the invalid IDs described.
 

--- a/docs/resources/channel.mdx
+++ b/docs/resources/channel.mdx
@@ -479,6 +479,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 | target_user_id        | snowflake           | the id of the user whose stream to display for this invite, required if `target_type` is 1, the user must be streaming in the channel     |                  |
 | target_application_id | snowflake           | the id of the embedded application to open for this invite, required if `target_type` is 2, the application must have the `EMBEDDED` flag |                  |
 | target_users_file?\*  | file                | a csv file with a single column of user IDs for all the users able to accept this invite                                                  |                  |
+| payload_json?         | string              | JSON-encoded body of non-file params, only for `multipart/form-data` requests.                                                            |                  |
 | role_ids?\*\*         | array of snowflakes | the role ID(s) for roles in the guild given to the users that accept this invite                                                          |                  |
 
 \* Requires `multipart/form-data` as the content type with other parameters as form fields in the multipart body. Uploading a file with invalid user IDs will result in a 400 with the invalid IDs described.

--- a/docs/resources/guild.mdx
+++ b/docs/resources/guild.mdx
@@ -583,17 +583,17 @@ Represents the [onboarding](https://support.discord.com/hc/en-us/articles/110749
 
 ###### Prompt Option Structure
 
-| Field           | Type                                               | Description                                                       |
-|-----------------|----------------------------------------------------|-------------------------------------------------------------------|
-| id              | snowflake                                          | ID of the prompt option                                           |
-| channel_ids     | array of snowflakes                                | IDs for channels a member is added to when the option is selected |
-| role_ids        | array of snowflakes                                | IDs for roles assigned to a member when the option is selected    |
-| emoji?          | [emoji](/docs/resources/emoji#emoji-object) object | Emoji of the option (see below)                                   |
-| emoji_id?       | snowflake                                          | Emoji ID of the option (see below)                                |
-| emoji_name?     | string                                             | Emoji name of the option (see below)                              |
-| emoji_animated? | boolean                                            | Whether the emoji is animated (see below)                         |
-| title           | string                                             | Title of the option                                               |
-| description     | ?string                                            | Description of the option                                         |
+| Field           | Type                                               | Description                                                                                            |
+|-----------------|----------------------------------------------------|--------------------------------------------------------------------------------------------------------|
+| id              | snowflake                                          | ID of the prompt option                                                                                |
+| channel_ids     | array of snowflakes                                | IDs for channels a member is added to when the option is selected                                      |
+| role_ids        | array of snowflakes                                | IDs for [roles](/docs/topics/permissions#role-object) assigned to a member when the option is selected |
+| emoji?          | [emoji](/docs/resources/emoji#emoji-object) object | Emoji of the option (see below)                                                                        |
+| emoji_id?       | snowflake                                          | Emoji ID of the option (see below)                                                                     |
+| emoji_name?     | string                                             | Emoji name of the option (see below)                                                                   |
+| emoji_animated? | boolean                                            | Whether the emoji is animated (see below)                                                              |
+| title           | string                                             | Title of the option                                                                                    |
+| description     | ?string                                            | Description of the option                                                                              |
 
 :::warn
 When creating or updating a prompt option, the `emoji_id`, `emoji_name`, and `emoji_animated` fields must be used instead of the emoji object.

--- a/docs/resources/invite.mdx
+++ b/docs/resources/invite.mdx
@@ -176,7 +176,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 ## Get Target Users
 <Route method="GET">/invites/[\{invite.code\}](/docs/resources/invite#invite-object)/target-users</Route>
 
-Gets the users allowed to see and accept this invite. Response is a CSV file with a single column `Users` containing the user IDs. Requires the caller to be the inviter, or have `MANAGE_GUILD` permission, or have `VIEW_AUDIT_LOG` permission.
+Gets the users allowed to see and accept this invite. Response is a CSV file containing the user IDs in the same format file that was uploaded on [invite create](/docs/resources/channel#create-channel-invite). Requires the caller to be the inviter, or have `MANAGE_GUILD` permission, or have `VIEW_AUDIT_LOG` permission.
 
 ## Update Target Users
 <Route method="PUT">/invites/[\{invite.code\}](/docs/resources/invite#invite-object)/target-users</Route>

--- a/docs/resources/invite.mdx
+++ b/docs/resources/invite.mdx
@@ -176,12 +176,12 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 ## Get Target Users
 <Route method="GET">/invites/[\{invite.code\}](/docs/resources/invite#invite-object)/target-users</Route>
 
-Gets the users allowed to see and accept this invite. Response is a CSV file with a single column `Users` containing the user IDs. Requires the `MANAGE_GUILD` permission or the caller to be the inviter.
+Gets the users allowed to see and accept this invite. Response is a CSV file with a single column `Users` containing the user IDs. Requires the caller to be the inviter, or have `MANAGE_GUILD` permission, or have `VIEW_AUDIT_LOG` permission.
 
 ## Update Target Users
 <Route method="PUT">/invites/[\{invite.code\}](/docs/resources/invite#invite-object)/target-users</Route>
 
-Updates the users allowed to see and accept this invite. Uploading a file with invalid user IDs will result in a 400 with the invalid IDs described. Requires the `MANAGE_GUILD` permission or the caller to be the inviter.
+Updates the users allowed to see and accept this invite. Uploading a file with invalid user IDs will result in a 400 with the invalid IDs described. Requires the caller to be the inviter or have the `MANAGE_GUILD` permission.
 
 ###### Form Params
 
@@ -203,7 +203,7 @@ Updates the users allowed to see and accept this invite. Uploading a file with i
 ## Get Target Users Job Status
 <Route method="GET">/invites/[\{invite.code\}](/docs/resources/invite#invite-object)/target-users/job-status</Route>
 
-Processing target users from a CSV when creating or updating an invite is done asynchronously. This endpoint allows you to check the status of that job. Requires the `MANAGE_GUILD` permission or the caller to be the inviter.
+Processing target users from a CSV when creating or updating an invite is done asynchronously. This endpoint allows you to check the status of that job. Requires the caller to be the inviter, or have `MANAGE_GUILD` permission, or have `VIEW_AUDIT_LOG` permission.
 
 ###### Example Response
 

--- a/docs/resources/invite.mdx
+++ b/docs/resources/invite.mdx
@@ -176,12 +176,12 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 ## Get Target Users
 <Route method="GET">/invites/[\{invite.code\}](/docs/resources/invite#invite-object)/target-users</Route>
 
-Gets the users allowed to see and accept this invite. Response is a CSV file with a single column `Users` containing the user IDs. Requires the `MANAGE_GUILD` permission.
+Gets the users allowed to see and accept this invite. Response is a CSV file with a single column `Users` containing the user IDs. Requires the `MANAGE_GUILD` permission or the caller to be the inviter.
 
 ## Update Target Users
 <Route method="PUT">/invites/[\{invite.code\}](/docs/resources/invite#invite-object)/target-users</Route>
 
-Updates the users allowed to see and accept this invite. Uploading a file with invalid user IDs will result in a 400 with the invalid IDs described. Requires the `MANAGE_GUILD` permission.
+Updates the users allowed to see and accept this invite. Uploading a file with invalid user IDs will result in a 400 with the invalid IDs described. Requires the `MANAGE_GUILD` permission or the caller to be the inviter.
 
 ###### Form Params
 
@@ -203,7 +203,7 @@ Updates the users allowed to see and accept this invite. Uploading a file with i
 ## Get Target Users Job Status
 <Route method="GET">/invites/[\{invite.code\}](/docs/resources/invite#invite-object)/target-users/job-status</Route>
 
-Processing target users from a CSV when creating or updating an invite is done asynchronously. This endpoint allows you to check the status of that job. Requires the `MANAGE_GUILD` permission.
+Processing target users from a CSV when creating or updating an invite is done asynchronously. This endpoint allows you to check the status of that job. Requires the `MANAGE_GUILD` permission or the caller to be the inviter.
 
 ###### Example Response
 


### PR DESCRIPTION
In order to view target users or update target users on an invite the caller must be the invite creator or have `MANAGE_GUILD` permissions. In order to create an invite with target users the caller no longer needs `MANAGE_GUILD`, they will only need `CREATE_INSTANT_INVITE`.