### PR TITLE
[MediaGalleryItem][ThumbnailComponent] Mark description nullable

### DIFF
--- a/docs/components/reference.mdx
+++ b/docs/components/reference.mdx
@@ -1648,7 +1648,7 @@ To use this component, you need to send the [message flag](/docs/resources/messa
 | type         | integer                                                               | `11` for thumbnail component                                                                             |
 | id?          | integer                                                               | Optional identifier for component                                                                        |
 | media        | [unfurled media item](/docs/components/reference#unfurled-media-item) | A url or attachment provided as an [unfurled media item](/docs/components/reference#unfurled-media-item) |
-| description? | string                                                                | Alt text for the media, max 1024 characters                                                              |
+| description? | ?string                                                               | Alt text for the media, max 1024 characters                                                              |
 | spoiler?     | boolean                                                               | Whether the thumbnail should be a spoiler (or blurred out). Defaults to `false`                          |
 
 ###### Examples
@@ -1716,7 +1716,7 @@ To use this component in messages you must send the [message flag](/docs/resourc
 | Field        | Type                                                                  | Description                                                                                              |
 |--------------|-----------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
 | media        | [unfurled media item](/docs/components/reference#unfurled-media-item) | A url or attachment provided as an [unfurled media item](/docs/components/reference#unfurled-media-item) |
-| description? | string                                                                | Alt text for the media, max 1024 characters                                                              |
+| description? | ?string                                                               | Alt text for the media, max 1024 characters                                                              |
 | spoiler?     | boolean                                                               | Whether the media should be a spoiler (or blurred out). Defaults to `false`                              |
 
 ###### Examples


### PR DESCRIPTION
Note that the `description` fields on [Media Gallery Item](https://discord.com/developers/docs/components/reference#media-gallery-media-gallery-item-structure) and [Thumbnail](https://discord.com/developers/docs/components/reference#thumbnail) are nullable.

Addresses documentation gap raised in https://github.com/discord/discord-api-docs/issues/8107