### PR TITLE
[docs] Add policy and terms redirects

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -312,6 +312,30 @@
       "source": "/developers/docs/policy",
       "destination": "https://support-dev.discord.com/hc/articles/8563934450327-Discord-Developer-Policy"
     },
+     {
+      "source": "/developers/policies-and-agreements/monetization-policy",
+      "destination": "https://support.discord.com/hc/en-us/articles/10575066024983-Monetization-Policy"
+    },
+    {
+      "source": "/developers/policies-and-agreements/developer-terms-of-service",
+      "destination": "https://support-dev.discord.com/hc/articles/8562894815383-Discord-Developer-Terms-of-Service"
+    },
+    {
+      "source": "/developers/policies-and-agreements/terms-of-service",
+      "destination": "https://support-dev.discord.com/hc/articles/8562894815383-Discord-Developer-Terms-of-Service"
+    },
+    {
+      "source": "/developers/legal",
+      "destination": "https://support-dev.discord.com/hc/articles/8562894815383-Discord-Developer-Terms-of-Service"
+    },
+    {
+      "source": "/developers/policies-and-agreements/developer-policy",
+      "destination": "https://support-dev.discord.com/hc/articles/8563934450327-Discord-Developer-Policy"
+    },
+    {
+      "source": "/developers/policy",
+      "destination": "https://support-dev.discord.com/hc/articles/8563934450327-Discord-Developer-Policy"
+    },
     {
       "source": "/developers/docs/best-practices/crafting-your-app-directory-product-page",
       "destination": "/developers/discovery/best-practices"


### PR DESCRIPTION
Adds /developers/* redirects in addition to the /developers/docs/* redirects for monetization policy, developer policy and developer terms