### PR TITLE
Add DiscordBM library to community resources

### DIFF
--- a/developers/developer-tools/community-resources.mdx
+++ b/developers/developer-tools/community-resources.mdx
@@ -41,6 +41,7 @@ Discord does not maintain official SDKs.  The following table is an inexhaustive
 | [pycord](https://github.com/Pycord-Development/pycord)        | Python     |
 | [discordrb](https://github.com/shardlab/discordrb)            | Ruby       |
 | [Serenity](https://github.com/serenity-rs/serenity)           | Rust       |
+| [DiscordBM](https://github.com/DiscordBM/DiscordBM)           | Swift      |
 
 ## Interactions
 


### PR DESCRIPTION
Hello everyone.
By this PR, I'm trying to propose [`DiscordBM`](https://github.com/DiscordBM/DiscordBM) as a "community library" to be added to the community resources in Discord docs.
Please let me know if there is a better place to do this.
Also I don't mind if this PR gets rejected. I just thought it's worth proposing since I see no `Swift` libraries in the list.

### Why
* `DiscordBM` is in Swift's Official SSWG (Server-Side Working Group)'s incubation program since 2023, which tries to ensure longevity of the projects. See the related web page on swift.org: https://www.swift.org/sswg/incubated-packages.html.
* In _public_ development since August 2022. 127 stars currently, 866 commits on the main branch (1000+ if you consider the squashed commits).
* Supports pretty much all bot APIs, except Voice.
* Properly handles HTTP rate limits and Gateway rate limits.
  * There are configurable auto-retry mechanisms. For example by default if Discord mentions that a request needs to be retried in 5 seconds or less, the library just retries the request instead of shooting the error at user's face.
  * Other kinds of ratelimits (like global ratelimits, or interaction ratelimits) are also respected and there are tests for these as well.
* Contains a lot of Integration tests that actually call Discord to ensure the library works in practice as well.
  * Including Gateway connection integration tests.
  * Including REST API endpoint tests for all endpoints where it was possible.
    * For example some interaction endpoints can't be easily triggered via an automation, with acceptable parameters.
* The library goes "above and beyond" in some instances as well, and is not just a minimal implementation.
  * For example using Gateway compression is enabled, and I recently updated the library to use the more-performant zstd compression algorithm.
  * Or it contains a dedicated `UnstableEnum` macro, which might sound "ok" to you, but only someone who uses Swift on the daily would appreciate.
    * The enum ensures full usability and compatibility even if Discord introduces a new "case" to some of the APIs "enum"s.
  * Some other such instances, off-hand, are `DiscordCache`, REST API cache, payload validation, permission checker, and `DiscordUtils`.
* Consistently maintained over the years. Yes, I haven't been the fastest to support the new features recently, but the library has been consistently updated at least every few months ever-since its inception.

If someone from the Discord team wants to see how much `DiscordBM` is used, this is the `User-Agent` header that the library uses: `DiscordBM (https://github.com/discordbm/discordbm, 1.0.0)`, and the library also sends `DiscordBM` as the `browser` in Gateway connections. I'm also curious to know.

I do _think_ `DiscordBM` is not _super_ popular at the scale of likely all the other featured libraries, but we're doing what we can do considering Swift's server-side community is still "up and coming", and I think it's important for Swift to have a showing in the list.
If needed, I can ask some folks from the SSWG to vouch for the library so you can feel more comfortable making this change.