### PR TITLE
Add timestamp styles anchor

### DIFF
--- a/developers/reference.mdx
+++ b/developers/reference.mdx
@@ -289,6 +289,7 @@ Timestamps are expressed in seconds and display the given timestamp in the user'
 
 \*\* Subcommands and subcommand groups can also be mentioned by using respectively `</NAME SUBCOMMAND:ID>` and `</NAME SUBCOMMAND_GROUP SUBCOMMAND:ID>`.
 
+<ManualAnchor id="message-formatting-timestamp-styles" />
 **Timestamp Styles**
 
 | Style | Example Output                   | Description             |


### PR DESCRIPTION
This is the only anchor linked to in the Serenity library docs that is still missing following the Mintlify migration.