### PR TITLE
Mark File component name/size fields as optional

### DIFF
--- a/developers/components/reference.mdx
+++ b/developers/components/reference.mdx
@@ -1803,8 +1803,8 @@ To use this component in messages you must send the [message flag](/developers/r
 | id?      | integer                                                                     | Optional identifier for component                                                                                                |
 | file     | [unfurled media item](/developers/components/reference#unfurled-media-item) | This unfurled media item is unique in that it **only** supports attachment references using the `attachment://<filename>` syntax |
 | spoiler? | boolean                                                                     | Whether the media should be a spoiler (or blurred out). Defaults to `false`                                                      |
-| name     | string                                                                      | The name of the file. This field is ignored and provided by the API as part of the response                                      |
-| size     | integer                                                                     | The size of the file in bytes. This field is ignored and provided by the API as part of the response                             |
+| name?    | string                                                                      | The name of the file. This field is ignored and provided by the API as part of the response                                      |
+| size?    | integer                                                                     | The size of the file in bytes. This field is ignored and provided by the API as part of the response                             |
 
 <ManualAnchor id="file-examples" />
 ###### Examples


### PR DESCRIPTION
Marks `name` and `size` as optional (`?`) in the File component documentation table.

Both fields are server-populated from the referenced attachment and cannot be provided by clients. The descriptions already say "This field is ignored and provided by the API as part of the response", but the field names were missing the `?` suffix that similar server-populated fields.

Fixes #8152