### PR TITLE
Add missing anchor for Poll Answer Count Object Structure

### DIFF
--- a/developers/resources/poll.mdx
+++ b/developers/resources/poll.mdx
@@ -116,6 +116,7 @@ If `answer_counts` does not contain an entry for a particular answer, then there
 | is_finalized  | boolean                                                                                                               | Whether the votes have been precisely counted |
 | answer_counts | List of [Poll Answer Count Object](/developers/resources/poll#poll-results-object-poll-answer-count-object-structure) | The counts for each answer                    |
 
+<ManualAnchor id="poll-results-object-poll-answer-count-object-structure" />
 ###### Poll Answer Count Object Structure
 
 | Field    | Type    | Description                                    |


### PR DESCRIPTION
Found one more missing anchor that is linked in Serenity docs. It's also linked just above in the Discord docs (in `Poll Results Object Structure`), so this fixes that broken link too.