### PR TITLE
Update changelog tag to "Discord Social SDK" for consistency

### DIFF
--- a/developers/change-log.mdx
+++ b/developers/change-log.mdx
@@ -12,7 +12,7 @@ import {Route} from '/snippets/route.jsx'
     - Fixed an occasional crash when linking your Discord account to your Application while in a Voice Call
 </Update>
 
-<Update label="Publisher Level Account Linking" description="2026-02-18" tags={["Social SDK", "Docs"]}>
+<Update label="Publisher Level Account Linking" description="2026-02-18" tags={["Discord Social SDK", "Docs"]}>
 
     We've published new documentation for **Publisher Level Account Linking**, a feature that enables game publishers with multiple titles to implement a single authorization flow across their entire game portfolio.
 


### PR DESCRIPTION
Just realised the tag on this changelog item is wrong, so fixing it.