### PR TITLE
Enable RSS feed for changelog page

### DIFF
--- a/developers/change-log.mdx
+++ b/developers/change-log.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Change Log"
 description: "Discover the latest updates, new features, and bug fixes on the Discord Developer Platform. To join in on the conversation, join the [Discord Developers Server](https://discord.com/invite/discord-developers)."
+rss: true
 ---
 
 import {Route} from '/snippets/route.jsx'


### PR DESCRIPTION
Add rss: true to change-log.mdx frontmatter to surface the auto-generated RSS feed with a discoverable icon at the top of the changelog page.