### PR TITLE
Warning callouts for test account usage on Rich Presence/Invites

### DIFF
--- a/developers/discord-social-sdk/development-guides/managing-game-invites.mdx
+++ b/developers/discord-social-sdk/development-guides/managing-game-invites.mdx
@@ -187,6 +187,10 @@ client->RegisterLaunchSteamApplication(YOUR_APP_ID, STEAM_GAME_ID);
 
 ## Sending Game Invites
 
+<Warning>
+**Testing invites requires a second account.** A user cannot see their own Rich Presence Invite — you won't receive invites you send to yourself. To test the full invite flow, you'll need to use a separate test account.
+</Warning>
+
 Game invites can be sent in two ways:
 
 1. Users can send game invites directly through the Discord client.

--- a/developers/rich-presence/overview.mdx
+++ b/developers/rich-presence/overview.mdx
@@ -20,9 +20,9 @@ There are three options when integrating Rich Presence. Depending on what you're
 
 All SDKs use similar underlying primitives (like the [`SET_ACTIVITY` RPC command](/developers/topics/rpc#setactivity)), so a lot is the same between them. But there are a few differences, like feature compatibility, which is covered in the sections below.
 
-<Info>
+<Warning>
 Rich Presence data appears publicly on your Discord profile, so during development you should use a test account that only belongs to your private development server(s).
-</Info>
+</Warning>
 
 ### Discord Social SDK
 


### PR DESCRIPTION
Users cannot see their own Rich Presence Invite, which is a common source of confusion during development. Adds a Warning callout to the "Sending Game Invites" section and upgrades the existing test account note in the Rich Presence overview to a Warning for better visibility.