### PR TITLE
Fix incorrect token revocation URL in Social SDK account-linking guide

### DIFF
--- a/developers/discord-social-sdk/development-guides/account-linking-with-discord.mdx
+++ b/developers/discord-social-sdk/development-guides/account-linking-with-discord.mdx
@@ -259,7 +259,7 @@ CLIENT_SECRET = 'YOUR_CLIENT_SECRET'
 def revoke_token(access_or_refresh_token):
     data = {'token': access_or_refresh_token}
     headers = {'Content-Type': 'application/x-www-form-urlencoded'}
-    r = requests.post(f'{API_ENDPOINT}/oauth2/token', data=data, headers=headers, auth=(CLIENT_ID, CLIENT_SECRET))
+    r = requests.post(f'{API_ENDPOINT}/oauth2/token/revoke', data=data, headers=headers, auth=(CLIENT_ID, CLIENT_SECRET))
     r.raise_for_status()
 ```
 


### PR DESCRIPTION
The revoke_token example was calling /oauth2/token (the token exchange endpoint) instead of /oauth2/token/revoke (the revocation endpoint).