### PR TITLE
style: use Note for notice about all parameters are optional

### DIFF
--- a/developers/resources/application.mdx
+++ b/developers/resources/application.mdx
@@ -246,9 +246,9 @@ Returns the [application](/developers/resources/application#application-object) 
 
 Edit properties of the app associated with the requesting bot user. Only properties that are passed will be updated. Returns the updated [application](/developers/resources/application#application-object) object on success.
 
-<Info>
-All parameters to this endpoint are optional
-</Info>
+<Note>
+All parameters to this endpoint are optional.
+</Note>
 
 <ManualAnchor id="edit-current-application-json-params" />
 ###### JSON Params

--- a/developers/resources/channel.mdx
+++ b/developers/resources/channel.mdx
@@ -376,9 +376,9 @@ Get a channel by ID. Returns a [channel](/developers/resources/channel#channel-o
 
 Update a channel's settings. Returns a [channel](/developers/resources/channel#channel-object) on success, and a 400 BAD REQUEST on invalid parameters.
 
-<Info>
-All parameters to this endpoint are optional
-</Info>
+<Note>
+All parameters to this endpoint are optional.
+</Note>
 
 <Info>
 This endpoint supports the `X-Audit-Log-Reason` header.

--- a/developers/resources/emoji.mdx
+++ b/developers/resources/emoji.mdx
@@ -30,9 +30,9 @@ Routes for controlling emojis do not follow the normal rate limit conventions. T
 <ManualAnchor id="emoji-object-premium-emoji" />
 ###### Premium Emoji
 
-Roles with the `integration_id` tag being the guild's guild_subscription integration are considered subscription roles.  
-An emoji cannot have both subscription roles and non-subscription roles.  
-Emojis with subscription roles are considered premium emoji, and count toward a separate limit of 25.  
+Roles with the `integration_id` tag being the guild's guild_subscription integration are considered subscription roles.
+An emoji cannot have both subscription roles and non-subscription roles.
+Emojis with subscription roles are considered premium emoji, and count toward a separate limit of 25.
 Emojis cannot be converted between normal and premium after creation.
 
 <ManualAnchor id="emoji-object-emoji-formats" />
@@ -148,9 +148,9 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 
 Modify the given emoji. For emojis created by the current user, requires either the `CREATE_GUILD_EXPRESSIONS` or `MANAGE_GUILD_EXPRESSIONS` permission. For other emojis, requires the `MANAGE_GUILD_EXPRESSIONS` permission. Returns the updated [emoji](/developers/resources/emoji#emoji-object) object on success. Fires a [Guild Emojis Update](/developers/events/gateway-events#guild-emojis-update) Gateway event.
 
-<Info>
+<Note>
 All parameters to this endpoint are optional.
-</Info>
+</Note>
 
 <Info>
 This endpoint supports the `X-Audit-Log-Reason` header.

--- a/developers/resources/guild-scheduled-event.mdx
+++ b/developers/resources/guild-scheduled-event.mdx
@@ -359,9 +359,9 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 This endpoint silently discards `entity_metadata` for non-`EXTERNAL` events.
 </Info>
 
-<Info>
-All parameters to this endpoint are optional
-</Info>
+<Note>
+All parameters to this endpoint are optional.
+</Note>
 
 <ManualAnchor id="modify-guild-scheduled-event-json-params" />
 ###### JSON Params

--- a/developers/resources/guild.mdx
+++ b/developers/resources/guild.mdx
@@ -841,9 +841,9 @@ If the user is not in the guild, then the guild must be [discoverable](/develope
 
 Modify a guild's settings. Requires the `MANAGE_GUILD` permission. Returns the updated [guild](/developers/resources/guild#guild-object) object on success. Fires a [Guild Update](/developers/events/gateway-events#guild-update) Gateway event.
 
-<Info>
-All parameters to this endpoint are optional
-</Info>
+<Note>
+All parameters to this endpoint are optional.
+</Note>
 
 <Info>
 This endpoint supports the `X-Audit-Log-Reason` header.
@@ -889,9 +889,9 @@ Returns a list of guild [channel](/developers/resources/channel#channel-object) 
 
 Create a new [channel](/developers/resources/channel#channel-object) object for the guild. Requires the `MANAGE_CHANNELS` permission. If setting permission overwrites, only permissions your bot has in the guild can be allowed/denied. Setting `MANAGE_ROLES` permission in channels is only possible for guild administrators. Returns the new [channel](/developers/resources/channel#channel-object) object on success. Fires a [Channel Create](/developers/events/gateway-events#channel-create) Gateway event.
 
-<Info>
-All parameters to this endpoint are optional and nullable excluding `name`
-</Info>
+<Note>
+All parameters to this endpoint are optional and nullable excluding `name`.
+</Note>
 
 <Info>
 This endpoint supports the `X-Audit-Log-Reason` header.
@@ -973,9 +973,9 @@ Returns a list of [guild member](/developers/resources/guild#guild-member-object
 This endpoint is restricted according to whether the `GUILD_MEMBERS` [Privileged Intent](/developers/events/gateway#privileged-intents) is enabled for your application.
 </Warning>
 
-<Info>
-All parameters to this endpoint are optional
-</Info>
+<Note>
+All parameters to this endpoint are optional.
+</Note>
 
 <ManualAnchor id="list-guild-members-query-string-params" />
 ###### Query String Params
@@ -1034,9 +1034,9 @@ The Authorization header must be a Bot token (belonging to the same application 
 
 Modify attributes of a [guild member](/developers/resources/guild#guild-member-object). Returns a 200 OK with the [guild member](/developers/resources/guild#guild-member-object) as the body. Fires a [Guild Member Update](/developers/events/gateway-events#guild-member-update) Gateway event. If the `channel_id` is set to null, this will force the target user to be disconnected from voice.
 
-<Info>
+<Note>
 All parameters to this endpoint are optional and nullable. When moving members to channels, the API user _must_ have permissions to both connect to the channel and have the `MOVE_MEMBERS` permission.
-</Info>
+</Note>
 
 <Info>
 This endpoint supports the `X-Audit-Log-Reason` header.
@@ -1274,9 +1274,9 @@ This endpoint takes a JSON array of parameters in the following format:
 
 Modify a guild role. Requires the `MANAGE_ROLES` permission. Returns the updated [role](/developers/topics/permissions#role-object) on success. Fires a [Guild Role Update](/developers/events/gateway-events#guild-role-update) Gateway event.
 
-<Info>
+<Note>
 All parameters to this endpoint are optional and nullable.
-</Info>
+</Note>
 
 <Info>
 This endpoint supports the `X-Audit-Log-Reason` header.
@@ -1414,9 +1414,9 @@ This endpoint is required to get the usage count of the vanity invite, but the i
 
 Returns a PNG image widget for the guild. Requires no permissions or authentication.
 
-<Info>
+<Note>
 All parameters to this endpoint are optional.
-</Info>
+</Note>
 
 <ManualAnchor id="get-guild-widget-image-query-string-params" />
 ###### Query String Params
@@ -1446,9 +1446,9 @@ Returns the [Welcome Screen](/developers/resources/guild#welcome-screen-object) 
 
 Modify the guild's [Welcome Screen](/developers/resources/guild#welcome-screen-object). Requires the `MANAGE_GUILD` permission. Returns the updated [Welcome Screen](/developers/resources/guild#welcome-screen-object) object. May fire a [Guild Update](/developers/events/gateway-events#guild-update) Gateway event.
 
-<Info>
-All parameters to this endpoint are optional and nullable
-</Info>
+<Note>
+All parameters to this endpoint are optional and nullable.
+</Note>
 
 <Info>
 This endpoint supports the `X-Audit-Log-Reason` header.
@@ -1481,9 +1481,9 @@ Onboarding enforces constraints when enabled. These constraints are that there m
 This endpoint supports the `X-Audit-Log-Reason` header.
 </Info>
 
-<Info>
+<Note>
 All parameters to this endpoint are optional.
-</Info>
+</Note>
 
 <ManualAnchor id="modify-guild-onboarding-json-params" />
 ###### JSON Params

--- a/developers/resources/message.mdx
+++ b/developers/resources/message.mdx
@@ -693,7 +693,7 @@ In **regular messages**, all mention types are parsed, which is equivalent to se
 ```json
 {
   "parse": ["users", "roles", "everyone"]
-} 
+}
 ```
 
 In **interactions** and **webhooks**, only user mentions are parsed, which corresponds to the following:
@@ -701,7 +701,7 @@ In **interactions** and **webhooks**, only user mentions are parsed, which corre
 ```json
 {
   "parse": ["users"]
-} 
+}
 ```
 
 | Field         | Type                           | Description                                                                                                                                |
@@ -977,9 +977,9 @@ Any provided files will be **appended** to the message. To remove or replace fil
 Starting with API v10, the `attachments` array must contain all attachments that should be present after edit, including **retained and new** attachments provided in the request body.
 </Warning>
 
-<Info>
+<Note>
 All parameters to this endpoint are optional and nullable.
-</Info>
+</Note>
 
 <ManualAnchor id="edit-message-json/form-params" />
 ###### JSON/Form Params

--- a/developers/resources/soundboard.mdx
+++ b/developers/resources/soundboard.mdx
@@ -132,9 +132,9 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 
 Modify the given soundboard sound. For sounds created by the current user, requires either the `CREATE_GUILD_EXPRESSIONS` or `MANAGE_GUILD_EXPRESSIONS` permission. For other sounds, requires the `MANAGE_GUILD_EXPRESSIONS` permission. Returns the updated [soundboard sound](/developers/resources/soundboard#soundboard-sound-object) object on success. Fires a [Guild Soundboard Sound Update](/developers/events/gateway-events#guild-soundboard-sound-update) Gateway event.
 
-<Warning>
+<Note>
 All parameters to this endpoint are optional.
-</Warning>
+</Note>
 
 <Info>
 This endpoint supports the `X-Audit-Log-Reason` header.

--- a/developers/resources/sticker.mdx
+++ b/developers/resources/sticker.mdx
@@ -175,9 +175,9 @@ Uploaded stickers are constrained to 5 seconds in length for animated stickers, 
 
 Modify the given sticker. For stickers created by the current user, requires either the `CREATE_GUILD_EXPRESSIONS` or `MANAGE_GUILD_EXPRESSIONS` permission. For other stickers, requires the `MANAGE_GUILD_EXPRESSIONS` permission. Returns the updated [sticker](/developers/resources/sticker#sticker-object) object on success. Fires a [Guild Stickers Update](/developers/events/gateway-events#guild-stickers-update) Gateway event.
 
-<Info>
+<Note>
 All parameters to this endpoint are optional.
-</Info>
+</Note>
 
 <Info>
 This endpoint supports the `X-Audit-Log-Reason` header.

--- a/developers/resources/user.mdx
+++ b/developers/resources/user.mdx
@@ -261,9 +261,9 @@ Returns a [user](/developers/resources/user#user-object) object for a given user
 
 Modify the requester's user account settings. Returns a [user](/developers/resources/user#user-object) object on success. Fires a [User Update](/developers/events/gateway-events#user-update) Gateway event.
 
-<Info>
+<Note>
 All parameters to this endpoint are optional.
-</Info>
+</Note>
 
 <ManualAnchor id="modify-current-user-json-params" />
 ###### JSON Params

--- a/developers/resources/webhook.mdx
+++ b/developers/resources/webhook.mdx
@@ -167,9 +167,9 @@ Same as above, except this call does not require authentication and returns no u
 
 Modify a webhook. Requires the `MANAGE_WEBHOOKS` permission. Returns the updated [webhook](/developers/resources/webhook#webhook-object) object on success. Fires a [Webhooks Update](/developers/events/gateway-events#webhooks-update) Gateway event.
 
-<Info>
-All parameters to this endpoint are optional
-</Info>
+<Note>
+All parameters to this endpoint are optional.
+</Note>
 
 <Info>
 This endpoint supports the `X-Audit-Log-Reason` header.
@@ -311,9 +311,9 @@ Any provided files will be **appended** to the message. To remove or replace fil
 Starting with API v10, the `attachments` array must contain all attachments that should be present after edit, including **retained and new** attachments provided in the request body.
 </Warning>
 
-<Info>
+<Note>
 All parameters to this endpoint are optional and nullable.
-</Info>
+</Note>
 
 <ManualAnchor id="edit-webhook-message-query-string-params" />
 ###### Query String Params


### PR DESCRIPTION
This PR try to make a little improvement to the notice about "modify" or "update" where all the parameters are optional or nullable, the most noticeable change its mark all that using "Note" and not Info/Warning for make consistent with all.