### PR TITLE
fix: typos and duplicate words across docs

### DIFF
--- a/developers/change-log.mdx
+++ b/developers/change-log.mdx
@@ -124,7 +124,7 @@ We've released and documented two new API endpoints that enable you to modify th
 both game direct messages and lobby messages.
 
 Combined with the [previously announced](/developers/change-log#discord-social-sdk-release-1813395) [`MessageHandle::ModerationMetadata`], and game direct message and lobby [Webhook Events](/developers/events/webhook-events#event-types),
-this enables server-side lobby and game direct message moderation workflows. Your game backend can now evaluate messages and attache moderation metadata that the Discord Social SDK can then deliver to game clients in real time, driving in-game message rendering dependent on moderation results.
+this enables server-side lobby and game direct message moderation workflows. Your game backend can now evaluate messages and attach moderation metadata that the Discord Social SDK can then deliver to game clients in real time, driving in-game message rendering dependent on moderation results.
 
 To see this in detail, have a look at the newly updated [How To Integrate Moderation](/developers/discord-social-sdk/how-to/integrate-moderation) guide with the full server-side moderation flow.
 

--- a/developers/discord-social-sdk/development-guides/using-provisional-accounts.mdx
+++ b/developers/discord-social-sdk/development-guides/using-provisional-accounts.mdx
@@ -529,7 +529,7 @@ def unmerge_provisional_account(external_user_id):
 ```
 
 <Tip>
-This endpoint can also be useful in cases where the Discord Auth token has been lost to to error or data loss, and an unmerge operation is required to migrate to a provisional account before re-linking a Discord account.
+This endpoint can also be useful in cases where the Discord Auth token has been lost to error or data loss, and an unmerge operation is required to migrate to a provisional account before re-linking a Discord account.
 </Tip>
 
 ### Unmerging Provisional Accounts for Public Clients

--- a/developers/discord-social-sdk/how-to/integrate-moderation.mdx
+++ b/developers/discord-social-sdk/how-to/integrate-moderation.mdx
@@ -128,7 +128,7 @@ sequenceDiagram
 ```
 
 <Info>
-While this sequence diagram demonstrates moderation for direct messaging, the same flow applies to to lobby messages.
+While this sequence diagram demonstrates moderation for direct messaging, the same flow applies to lobby messages.
 See below for the appropriate Social SDK methods, Webhook Event types and API paths to use instead.
 </Info>
 

--- a/developers/resources/emoji.mdx
+++ b/developers/resources/emoji.mdx
@@ -115,7 +115,7 @@ Returns a list of [emoji](/developers/resources/emoji#emoji-object) objects for 
 ## Get Guild Emoji
 <Route method="GET">/guilds/[\{guild.id\}](/developers/resources/guild#guild-object)/emojis/[\{emoji.id\}](/developers/resources/emoji#emoji-object)</Route>
 
-Returns an [emoji](/developers/resources/emoji#emoji-object) object for the given guild and emoji IDs. Includes the `user` field if the bot has the `MANAGE_GUILD_EXPRESSIONS` permission, or if the bot created the emoji and has the the `CREATE_GUILD_EXPRESSIONS` permission.
+Returns an [emoji](/developers/resources/emoji#emoji-object) object for the given guild and emoji IDs. Includes the `user` field if the bot has the `MANAGE_GUILD_EXPRESSIONS` permission, or if the bot created the emoji and has the `CREATE_GUILD_EXPRESSIONS` permission.
 
 ## Create Guild Emoji
 <Route method="POST">/guilds/[\{guild.id\}](/developers/resources/guild#guild-object)/emojis</Route>


### PR DESCRIPTION
## Summary

Fixed typos and duplicate words found across the documentation.

## Changes

| File | Line | Fix |
|------|------|-----|
| `change-log.mdx` | 89 | `attache` → `attach` |
| `emoji.mdx` | 118 | `has the the` → `has the` |
| `integrate-moderation.mdx` | 131 | `applies to to` → `applies to` |
| `using-provisional-accounts.mdx` | 532 | `lost to to` → `lost to` |