### PR TITLE
fix: spelling errors and duplicate words across docs

### DIFF
--- a/developers/discord-social-sdk/development-guides/account-linking-from-discord.mdx
+++ b/developers/discord-social-sdk/development-guides/account-linking-from-discord.mdx
@@ -100,7 +100,7 @@ Choose which flows work best for your game and follow the implementation guides 
 
 ## Connected Game Flow
 
-This is our prefered account linking flow as we think it provides the best user experience when it's available. The connected game flow will send the user into your game client to begin the account linking flow.
+This is our preferred account linking flow as we think it provides the best user experience when it's available. The connected game flow will send the user into your game client to begin the account linking flow.
 
 ### Prerequisites
 

--- a/developers/events/gateway-events.mdx
+++ b/developers/events/gateway-events.mdx
@@ -624,7 +624,7 @@ Sent when a message is pinned or unpinned in a text channel. This is not sent wh
 #### Entitlement Create
 
 <Warning>
-Note: The`ENTITLEMENT_CREATE` event behavior changed on October 1, 2024. Please see the [Change Log and Entitlement Migration Guide](/developers/change-log#premium-apps-entitlement-migration-and-new-subscription-api) for more information on what changed.
+Note: The `ENTITLEMENT_CREATE` event behavior changed on October 1, 2024. Please see the [Change Log and Entitlement Migration Guide](/developers/change-log#premium-apps-entitlement-migration-and-new-subscription-api) for more information on what changed.
 </Warning>
 
 Sent when an entitlement is created. The inner payload is an [entitlement](/developers/resources/entitlement#entitlement-object) object.
@@ -632,7 +632,7 @@ Sent when an entitlement is created. The inner payload is an [entitlement](/deve
 #### Entitlement Update
 
 <Warning>
-Note: The`ENTITLEMENT_UPDATE` event behavior changed on October 1, 2024. Please see the [Change Log and Entitlement Migration Guide](/developers/change-log#premium-apps-entitlement-migration-and-new-subscription-api) for more information on what changed.
+Note: The `ENTITLEMENT_UPDATE` event behavior changed on October 1, 2024. Please see the [Change Log and Entitlement Migration Guide](/developers/change-log#premium-apps-entitlement-migration-and-new-subscription-api) for more information on what changed.
 </Warning>
 
 Sent when an entitlement is updated. The inner payload is an [entitlement](/developers/resources/entitlement#entitlement-object) object. 

--- a/developers/resources/guild-template.mdx
+++ b/developers/resources/guild-template.mdx
@@ -1,7 +1,7 @@
 ---
 title: Guild Template Resource
 sidebarTitle: Guild Template
-description: Reference for Discord Guilt Template objects and management endpoints.
+description: Reference for Discord Guild Template objects and management endpoints.
 ---
 
 import {ManualAnchor} from '/snippets/manualanchor.jsx'

--- a/developers/resources/message.mdx
+++ b/developers/resources/message.mdx
@@ -419,7 +419,7 @@ There are multiple message types that have a `message_reference` object.
 ###### Context Menu Command messages
 
 - These are messages sent when a user uses a context menu Application Command. (type 23)
-- If the command was a [message command](/developers/interactions/application-commands#message-commands), the message will have have `message_id` and `channel_id`, and `guild_id` if it is in a guild, which point to the message that the command was used on. The channel_id and guild_id will be the same as the new message.
+- If the command was a [message command](/developers/interactions/application-commands#message-commands), the message will have `message_id` and `channel_id`, and `guild_id` if it is in a guild, which point to the message that the command was used on. The channel_id and guild_id will be the same as the new message.
 - These messages can have the referenced message resolved in the `referenced_message` field.
 
 #### Voice Messages


### PR DESCRIPTION
## Summary

Fixed spelling errors and duplicate words found across the documentation.

## Changes

| File | Line | Error | Fix |
|------|------|-------|-----|
| `guild-template.mdx` | 4 | `Guilt Template` | `Guild Template` |
| `message.mdx` | 422 | `will have have` | `will have` |
| `account-linking-from-discord.mdx` | 103 | `prefered` | `preferred` |
| `gateway-events.mdx` | 627 | `The\x60ENTITLEMENT_CREATE\x60` (missing space) | `The \x60ENTITLEMENT_CREATE\x60` |
| `gateway-events.mdx` | 635 | `The\x60ENTITLEMENT_UPDATE\x60` (missing space) | `The \x60ENTITLEMENT_UPDATE\x60` |

All fixes are spelling corrections or duplicate word removals per [CONTRIBUTING.md](https://github.com/discord/discord-api-docs/blob/main/CONTRIBUTING.md#wanted-changes) guidelines.