### PR TITLE
Update Developer Portal link to new landing page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -615,7 +615,7 @@
     "primary": {
       "type": "button",
       "label": "Developer Portal",
-      "href": "https://discord.com/developers/applications"
+      "href": "https://discord.com/developers/home"
     }
   },
   "footer": {


### PR DESCRIPTION
The Developer Portal nav button now links to /developers/home instead of /developers/applications to reflect the new developer portal landing page.