### PR TITLE
Fix mobile auth redirect - one slash

### DIFF
--- a/developers/discord-social-sdk/development-guides/account-linking-on-mobile.mdx
+++ b/developers/discord-social-sdk/development-guides/account-linking-on-mobile.mdx
@@ -52,12 +52,12 @@ If you haven't completed these prerequisites, we recommend first following the [
 
 For OAuth2 to work correctly on mobile, you must first register the correct redirect URI for your app in the [**Discord Developer Portal**](https://discord.com/developers/applications/select/oauth2).
 
-| Platform                   | Redirect URI                                                                                          |
-|----------------------------|-------------------------------------------------------------------------------------------------------|
-| **Mobile (iOS & Android)** | `discord-YOUR_APP_ID://authorize/callback` _(replace `YOUR_APP_ID` with your Discord application ID)_ |
+| Platform                   | Redirect URI                                                                                         |
+|----------------------------|------------------------------------------------------------------------------------------------------|
+| **Mobile (iOS & Android)** | `discord-YOUR_APP_ID:/authorize/callback` _(replace `YOUR_APP_ID` with your Discord application ID)_ |
 
 <Warning>
-The redirect URI must use your application ID in the format `discord-YOUR_APP_ID://authorize/callback`. Do not use `http://127.0.0.1/callback` on mobile.
+The redirect URI must use your application ID in the format `discord-YOUR_APP_ID:/authorize/callback`. Do not use `http://127.0.0.1/callback` on mobile.
 </Warning>
 
 ---
@@ -580,7 +580,7 @@ player's access token, which is covered under [Refreshing Access Tokens](/develo
 **Solutions**:
 1. Verify that `LSApplicationQueriesSchemes` includes `discord` in your Info.plist
 2. Ensure the Discord mobile app is installed on the device
-3. Check that your redirect URI is correctly configured as `discord-YOUR_APP_ID://authorize/callback`
+3. Check that your redirect URI is correctly configured as `discord-YOUR_APP_ID:/authorize/callback`
 
 #### Android: Deep Link Not Working
 


### PR DESCRIPTION
`discord-YOUR_APP_ID://authorize/callback` -> `discord-YOUR_APP_ID:/authorize/callback`