### PR TITLE
Remove ACTIVE_DEVELOPER from user flags

### DIFF
--- a/developers/resources/user.mdx
+++ b/developers/resources/user.mdx
@@ -111,7 +111,6 @@ There are other rules and restrictions not shared here for the sake of spam and 
 | `1 << 17` | VERIFIED_DEVELOPER       | Early Verified Bot Developer                                                                                                                         |
 | `1 << 18` | CERTIFIED_MODERATOR      | Moderator Programs Alumni                                                                                                                            |
 | `1 << 19` | BOT_HTTP_INTERACTIONS    | Bot uses only [HTTP interactions](/developers/interactions/receiving-and-responding#receiving-an-interaction) and is shown in the online member list |
-| `1 << 22` | ACTIVE_DEVELOPER         | User is an [Active Developer](https://support-dev.discord.com/hc/articles/10113997751447)                                                            |
 
 <ManualAnchor id="user-object-premium-types" />
 ###### Premium Types


### PR DESCRIPTION
This badge is no longer available.