### PR TITLE
Document array query string format

### DIFF
--- a/developers/reference.mdx
+++ b/developers/reference.mdx
@@ -256,6 +256,10 @@ The HTTP API implements a process for limiting and preventing excessive requests
 
 Certain endpoints in the API are documented to accept booleans for their query string parameters. While there is no standard system for boolean representation in query string parameters, Discord represents such cases using `True`, `true`, or `1` for true and `False`, `false` or `0` for false.
 
+### Array Query Strings
+
+Certain endpoints in the API are documented to accept arrays for their query string parameters. Unless otherwise specified, Discord represents such cases using multiple instances of the same query string parameter. For example, `?id=123&id=456` for `["123", "456"]`.
+
 ## Gateway (WebSocket) API
 
 Discord's Gateway API is used for maintaining persistent, stateful websocket connections between your client and our servers. These connections are used for sending and receiving real-time events your client can use to track and update local state. The Gateway API uses secure websocket connections as specified in [RFC 6455](https://tools.ietf.org/html/rfc6455). For information on opening Gateway connections, please see the [Gateway API](/developers/events/gateway#connections) section.

--- a/developers/resources/message.mdx
+++ b/developers/resources/message.mdx
@@ -905,32 +905,32 @@ Additionally, when messages are actively being created or deleted, the `total_re
 <ManualAnchor id="search-guild-messages-query-string-params" />
 ###### Query String Params
 
-| Field                  | Type                | Description                                                                                                                         |
-|------------------------|---------------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| limit?                 | integer             | Max number of messages to return (1-25, default 25)                                                                                 |
-| offset?                | integer             | Number to offset the returned messages by (max 9975)                                                                                |
-| max_id?                | snowflake           | Get messages before this message ID                                                                                                 |
-| min_id?                | snowflake           | Get messages after this message ID                                                                                                  |
-| slop?                  | integer             | Max number of words to skip between matching tokens in the search `content` (max 100, default 2)                                    |
-| content?               | string              | Filter messages by content (max 1024 characters)                                                                                    |
-| channel_id?            | array of snowflakes | Filter messages by these channels (max 500)                                                                                         |
-| author_type?           | array of strings    | Filter messages by [author type](/developers/resources/message#search-guild-messages-author-types)                                  |
-| author_id?             | array of snowflakes | Filter messages by these authors (max 100)                                                                                          |
-| mentions?              | array of snowflakes | Filter messages that mention these users (max 100)                                                                                  |
-| mentions_role_id?      | array of snowflakes | Filter messages that mention these roles (max 100)                                                                                  |
-| mention_everyone?      | boolean             | Filter messages that do or do not mention @everyone                                                                                 |
-| replied_to_user_id?    | array of snowflakes | Filter messages that reply to these users (max 100)                                                                                 |
-| replied_to_message_id? | array of snowflakes | Filter messages that reply to these messages (max 100)                                                                              |
-| pinned?                | boolean             | Filter messages by whether they are or are not pinned                                                                               |
-| has?                   | array of strings    | Filter messages by whether or not they [have specific things](/developers/resources/message#search-guild-messages-search-has-types) |
-| embed_type?            | array of strings    | Filter messages by [embed type](/developers/resources/message#search-guild-messages-search-embed-types)                             |
-| embed_provider?        | array of strings    | Filter messages by embed provider (case-sensitive, e.g. `Tenor`) (max 256 characters, max 100)                                      |
-| link_hostname?         | array of strings    | Filter messages by link hostname (e.g. `discordapp.com`) (max 256 characters, max 100)                                              |
-| attachment_filename?   | array of strings    | Filter messages by attachment filename (max 1024 characters, max 100)                                                               |
-| attachment_extension?  | array of strings    | Filter messages by attachment extension (e.g. `txt`) (max 256 characters, max 100)                                                  |
-| sort_by? \[1\]         | string              | The [sorting algorithm](/developers/resources/message#search-guild-messages-search-sort-modes) to use                               |
-| sort_order? \[1\]      | string              | The direction to sort (`asc` or `desc`, default `desc`)                                                                             |
-| include_nsfw?          | boolean             | Whether to include results from age-restricted channels (default false)                                                             |
+| Field                  | Type                                                             | Description                                                                                                                         |
+|------------------------|------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| limit?                 | integer                                                          | Max number of messages to return (1-25, default 25)                                                                                 |
+| offset?                | integer                                                          | Number to offset the returned messages by (max 9975)                                                                                |
+| max_id?                | snowflake                                                        | Get messages before this message ID                                                                                                 |
+| min_id?                | snowflake                                                        | Get messages after this message ID                                                                                                  |
+| slop?                  | integer                                                          | Max number of words to skip between matching tokens in the search `content` (max 100, default 2)                                    |
+| content?               | string                                                           | Filter messages by content (max 1024 characters)                                                                                    |
+| channel_id?            | [array](/developers/reference#array-query-strings) of snowflakes | Filter messages by these channels (max 500)                                                                                         |
+| author_type?           | [array](/developers/reference#array-query-strings) of strings    | Filter messages by [author type](/developers/resources/message#search-guild-messages-author-types)                                  |
+| author_id?             | [array](/developers/reference#array-query-strings) of snowflakes | Filter messages by these authors (max 100)                                                                                          |
+| mentions?              | [array](/developers/reference#array-query-strings) of snowflakes | Filter messages that mention these users (max 100)                                                                                  |
+| mentions_role_id?      | [array](/developers/reference#array-query-strings) of snowflakes | Filter messages that mention these roles (max 100)                                                                                  |
+| mention_everyone?      | [boolean](/developers/reference#boolean-query-strings)           | Filter messages that do or do not mention @everyone                                                                                 |
+| replied_to_user_id?    | [array](/developers/reference#array-query-strings) of snowflakes | Filter messages that reply to these users (max 100)                                                                                 |
+| replied_to_message_id? | [array](/developers/reference#array-query-strings) of snowflakes | Filter messages that reply to these messages (max 100)                                                                              |
+| pinned?                | [boolean](/developers/reference#boolean-query-strings)           | Filter messages by whether they are or are not pinned                                                                               |
+| has?                   | [array](/developers/reference#array-query-strings) of strings    | Filter messages by whether or not they [have specific things](/developers/resources/message#search-guild-messages-search-has-types) |
+| embed_type?            | [array](/developers/reference#array-query-strings) of strings    | Filter messages by [embed type](/developers/resources/message#search-guild-messages-search-embed-types)                             |
+| embed_provider?        | [array](/developers/reference#array-query-strings) of strings    | Filter messages by embed provider (case-sensitive, e.g. `Tenor`) (max 256 characters, max 100)                                      |
+| link_hostname?         | [array](/developers/reference#array-query-strings) of strings    | Filter messages by link hostname (e.g. `discordapp.com`) (max 256 characters, max 100)                                              |
+| attachment_filename?   | [array](/developers/reference#array-query-strings) of strings    | Filter messages by attachment filename (max 1024 characters, max 100)                                                               |
+| attachment_extension?  | [array](/developers/reference#array-query-strings) of strings    | Filter messages by attachment extension (e.g. `txt`) (max 256 characters, max 100)                                                  |
+| sort_by? \[1\]         | string                                                           | The [sorting algorithm](/developers/resources/message#search-guild-messages-search-sort-modes) to use                               |
+| sort_order? \[1\]      | string                                                           | The direction to sort (`asc` or `desc`, default `desc`)                                                                             |
+| include_nsfw?          | [boolean](/developers/reference#boolean-query-strings)           | Whether to include results from age-restricted channels (default false)                                                             |
 
 \[1\] Sort order is not respected when sorting by relevance.
 


### PR DESCRIPTION
Fixes https://github.com/discord/discord-api-docs/issues/8257

Documents the array query string format, and links to it in the Search Guild Messages params. Also links to the boolean section, like we usually do for boolean query string params.