### PR TITLE
Document supported image formats for Rich Presence assets

### DIFF
--- a/developers/discord-social-sdk/development-guides/setting-rich-presence.mdx
+++ b/developers/discord-social-sdk/development-guides/setting-rich-presence.mdx
@@ -96,7 +96,7 @@ To add custom assets for Rich Presence, navigate to your app's settings and clic
 
 Up to 300 custom assets can be added to your app for later use when setting Rich Presence for a Discord user. These assets can be anything that help orient others to what a user is doing inside of your Activity or 3rd party game.
 
-If you need more than 300 custom assets or want to use images stored somewhere else, you can also [specify an external URL](/developers/events/gateway-events#activity-object-activity-asset-image) as long it still has the proper dimensions and size. Unlike uploaded assets, external URLs also support GIF and animated WebP.
+If you need more than 300 custom assets or want to use images stored somewhere else, you can also [specify an external URL](/developers/events/gateway-events#activity-object-activity-asset-image) as long it still has the proper dimensions and size. Unlike uploaded assets, external URLs also support GIF, animated WebP, and AVIF.
 
 <Info>
 For tips on choosing assets, take a look at the [Rich Presence best practices guide](/developers/rich-presence/best-practices#have-interesting-expressive-art).
@@ -163,7 +163,7 @@ activity.SetAssets(assets);
 <Info>
 If you need more than 300 custom assets or want to use images stored somewhere else, you can also [specify an external URL](/developers/events/gateway-events#activity-object-activity-asset-image) as long it still has the proper dimensions and size.
 
-Unlike uploaded assets, external URLs also support GIF and animated WebP.
+Unlike uploaded assets, external URLs also support GIF, animated WebP, and AVIF.
 </Info>
 
 ---

--- a/developers/discord-social-sdk/development-guides/setting-rich-presence.mdx
+++ b/developers/discord-social-sdk/development-guides/setting-rich-presence.mdx
@@ -96,7 +96,7 @@ To add custom assets for Rich Presence, navigate to your app's settings and clic
 
 Up to 300 custom assets can be added to your app for later use when setting Rich Presence for a Discord user. These assets can be anything that help orient others to what a user is doing inside of your Activity or 3rd party game.
 
-If you need more than 300 custom assets or want to use images stored somewhere else, you can also [specify an external URL](/developers/events/gateway-events#activity-object-activity-asset-image) as long it still has the proper dimensions and size.
+If you need more than 300 custom assets or want to use images stored somewhere else, you can also [specify an external URL](/developers/events/gateway-events#activity-object-activity-asset-image) as long it still has the proper dimensions and size. Unlike uploaded assets, external URLs also support GIF and animated WebP.
 
 <Info>
 For tips on choosing assets, take a look at the [Rich Presence best practices guide](/developers/rich-presence/best-practices#have-interesting-expressive-art).
@@ -162,6 +162,8 @@ activity.SetAssets(assets);
 
 <Info>
 If you need more than 300 custom assets or want to use images stored somewhere else, you can also [specify an external URL](/developers/events/gateway-events#activity-object-activity-asset-image) as long it still has the proper dimensions and size.
+
+Unlike uploaded assets, external URLs also support GIF and animated WebP.
 </Info>
 
 ---

--- a/developers/events/gateway-events.mdx
+++ b/developers/events/gateway-events.mdx
@@ -1308,6 +1308,12 @@ To use an external image via media proxy, specify the URL as the field's value w
 | Application Asset | `{application_asset_id}` | See [Application Asset Image Formatting](/developers/reference#image-formatting) |
 | Media Proxy Image | `mp:{image_id}`          | `https://media.discordapp.net/{image_id}`                                        |
 
+<Info>
+**Uploaded assets** (Application Asset type) support PNG, JPEG, and WebP. Animated images are not supported for uploaded assets.
+
+**External URL assets** (Media Proxy Image type) support any publicly accessible image URL, including GIF and animated WebP.
+</Info>
+
 <ManualAnchor id="activity-object-activity-secrets" />
 ###### Activity Secrets
 

--- a/developers/events/gateway-events.mdx
+++ b/developers/events/gateway-events.mdx
@@ -1311,7 +1311,7 @@ To use an external image via media proxy, specify the URL as the field's value w
 <Info>
 **Uploaded assets** (Application Asset type) support PNG, JPEG, and WebP. Animated images are not supported for uploaded assets.
 
-**External URL assets** (Media Proxy Image type) support any publicly accessible image URL, including GIF and animated WebP.
+**External URL assets** (Media Proxy Image type) support any publicly accessible image URL, including GIF, animated WebP, and AVIF.
 </Info>
 
 <ManualAnchor id="activity-object-activity-secrets" />

--- a/developers/rich-presence/using-with-the-embedded-app-sdk.mdx
+++ b/developers/rich-presence/using-with-the-embedded-app-sdk.mdx
@@ -169,6 +169,6 @@ await discordSdk.commands.setActivity({
 <Note>
 Uploaded assets (added via the developer portal) support PNG, JPEG, and WebP only — animated images are not supported for uploaded assets.
 
-Unlike uploaded assets, external URLs also support GIF and animated WebP. See [Activity Asset Image](/developers/events/gateway-events#activity-object-activity-asset-image) for details.
+Unlike uploaded assets, external URLs also support GIF, animated WebP, and AVIF. See [Activity Asset Image](/developers/events/gateway-events#activity-object-activity-asset-image) for details.
 </Note>
 

--- a/developers/rich-presence/using-with-the-embedded-app-sdk.mdx
+++ b/developers/rich-presence/using-with-the-embedded-app-sdk.mdx
@@ -166,3 +166,9 @@ await discordSdk.commands.setActivity({
 ```
 </Accordion>
 
+<Note>
+Uploaded assets (added via the developer portal) support PNG, JPEG, and WebP only — animated images are not supported for uploaded assets.
+
+Unlike uploaded assets, external URLs also support GIF and animated WebP. See [Activity Asset Image](/developers/events/gateway-events#activity-object-activity-asset-image) for details.
+</Note>
+


### PR DESCRIPTION
Clarifies that uploaded assets support PNG, JPEG, and WebP only (no animated), while external URLs also support GIF and animated WebP.