### PR TITLE
Add search keywords for account unlinking/unmerging terminology

### DIFF
--- a/developers/discord-social-sdk/development-guides/using-provisional-accounts.mdx
+++ b/developers/discord-social-sdk/development-guides/using-provisional-accounts.mdx
@@ -1,6 +1,7 @@
 ---
 title: Using Provisional Accounts
 description: Implement provisional Discord accounts for users who don't have Discord accounts yet.
+keywords: ['unlinking accounts', 'unlink account', 'unmerging accounts', 'unmerge account', 'account unlinking', 'provisional account unlinking']
 ---
 
 import {ManualAnchor} from '/snippets/manualanchor.jsx'


### PR DESCRIPTION
Adds Mintlify keywords frontmatter so users searching for "unlinking accounts" find the provisional accounts page, which uses the term "unmerging".