### PR TITLE
Deprecate OAuth2 refresh_token grant for OIDC provisional accounts

### DIFF
--- a/developers/change-log.mdx
+++ b/developers/change-log.mdx
@@ -6,6 +6,28 @@ rss: true
 
 import {Route} from '/snippets/route.jsx'
 
+<Update label="April 16, 2026" tags={["Discord Social SDK"]} rss={{
+    title: "Deprecation: OAuth2 Refresh Token Grant for OIDC Provisional Accounts",
+    description: "Using the OAuth2 refresh_token grant to refresh OIDC server-side provisional account tokens is deprecated. Re-authenticate using a fresh provider token instead."
+  }}>
+
+  ## Deprecation: OAuth2 Refresh Token Grant for OIDC Provisional Accounts
+
+    If you are using [OIDC server-side authentication](/developers/discord-social-sdk/development-guides/using-provisional-accounts#server-authentication-with-external-credentials-exchange)
+    for provisional accounts, a `refresh_token` is returned — but using it via the OAuth2 `refresh_token` grant is now
+    deprecated.
+
+    This brings OIDC in line with all other provisional account authentication methods: when the token
+    expires, re-authenticate using a fresh provider token and pass the new access token to [`Client::UpdateToken`].
+
+    See the [Refreshing Provisional Account Tokens](/developers/discord-social-sdk/development-guides/using-provisional-accounts#refreshing-provisional-account-tokens)
+    section for details.
+
+    [`Client::UpdateToken`]:
+    https://discord.com/developers/docs/social-sdk/classdiscordpp_1_1Client.html#a606b32cef7796f7fb91c2497bc31afc4
+
+</Update>
+
 <Update label="April 14, 2026" tags={["HTTP API"]} rss={{
     title: "Message Forwarding Requires Message Content Access",
     description: "Starting today, applications must be able to read a message's content in order to forward it."

--- a/developers/discord-social-sdk/development-guides/using-provisional-accounts.mdx
+++ b/developers/discord-social-sdk/development-guides/using-provisional-accounts.mdx
@@ -129,9 +129,9 @@ Once authentication is complete, you can use the access token as you would a ful
 
 ### Server Authentication with Bot Token Endpoint
 
-<Info>
+<Tip>
 This is the preferred method of authentication. It ends up being the simplest choice for most provisional account integrations.
-</Info>
+</Tip>
 
 ```python
 # filepath: your_game/server/auth.py
@@ -191,10 +191,13 @@ def get_provisional_token(external_token: str):
   "id_token": "<id token>",
   "token_type": "Bearer",
   "expires_in": 604800,
-  "refresh_token": "<refresh token>", # only provided for OIDC when *not* a public client
   "scope": "sdk.social_layer"
 }
 ```
+
+<Info>
+If you are using OIDC, you may see a `refresh_token` in this response. Using it via the OAuth2 `refresh_token` grant is **deprecated** — re-authenticate using a fresh provider token instead. See [Refreshing Provisional Account Tokens](#refreshing-provisional-account-tokens) for details.
+</Info>
 
 ### Authentication for Public Clients
 
@@ -235,7 +238,7 @@ All these methods will return with an access token that expires in 7 days.
 
 Use [`Client::SetTokenExpirationCallback`] to receive a callback when the current token is about to expire or has expired, so you can refresh it without interrupting the user's experience.
 
-Unlike full Discord accounts, **provisional accounts do not support refresh tokens**. When the token expires, you must re-acquire a new token by calling the same method you used originally (e.g. the [Server Authentication with Bot Token Endpoint](#server-authentication-with-bot-token-endpoint) or [`Client::GetProvisionalToken`]), and then pass the new access token to [`Client::UpdateToken`].
+When the token expires, re-call the same method you used originally to obtain a new access token, then pass it to [`Client::UpdateToken`].
 
 <Info>
 When the token expires, the SDK will still receive updates, such as new messages sent in a lobby, and any voice calls will continue to be active. However, any new actions, such as sending a message or adding a friend, will fail. You can get a new token and pass it to [`Client::UpdateToken`] without interrupting the user's experience.
@@ -265,6 +268,9 @@ client->SetTokenExpirationCallback([client](discordpp::AuthorizationTokenType to
         });
 });
 ```
+<Info>
+    If you are using Server Authentication with OIDC, a `refresh_token` is returned but using it via the OAuth2 `refresh_token` grant is **deprecated**. Re-authenticate using a fresh provider token instead.
+</Info>
 
 #### Provisional Account Access Token Storage
 


### PR DESCRIPTION
Using the refresh_token grant for provisional account token refresh is deprecated. All methods should now re-authenticate via a fresh provider token. Updates the provisional accounts guide and adds a changelog entry.