### PR TITLE
Document app role connection platform_username

### DIFF
--- a/developers/resources/user.mdx
+++ b/developers/resources/user.mdx
@@ -240,11 +240,11 @@ The role connection object that an application has attached to a user.
 <ManualAnchor id="application-role-connection-object-application-role-connection-structure" />
 ###### Application Role Connection Structure
 
-| Field             | Type    | Description                                                                                                                                                                                                                                                            |
-|-------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| platform_name     | ?string | the vanity name of the platform a bot has connected (max 50 characters)                                                                                                                                                                                                |
-| platform_username | ?string | the username on the platform a bot has connected (max 100 characters)                                                                                                                                                                                                  |
-| metadata          | object  | object mapping [application role connection metadata](/developers/resources/application-role-connection-metadata#application-role-connection-metadata-object) keys to their `string`-ified value (max 100 characters) for the user on the platform a bot has connected |
+| Field              | Type    | Description                                                                                                                                                                                                                                                            |
+|--------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| platform_name?     | ?string | the vanity name of the platform a bot has connected (max 50 characters)                                                                                                                                                                                                |
+| platform_username? | ?string | the username on the platform a bot has connected (max 100 characters)                                                                                                                                                                                                  |
+| metadata?          | object  | object mapping [application role connection metadata](/developers/resources/application-role-connection-metadata#application-role-connection-metadata-object) keys to their `string`-ified value (max 100 characters) for the user on the platform a bot has connected |
 
 ## Get Current User
 <Route method="GET">/users/@me</Route>

--- a/developers/resources/user.mdx
+++ b/developers/resources/user.mdx
@@ -240,10 +240,11 @@ The role connection object that an application has attached to a user.
 <ManualAnchor id="application-role-connection-object-application-role-connection-structure" />
 ###### Application Role Connection Structure
 
-| Field         | Type    | Description                                                                                                                                                                                                                                                            |
-|---------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| platform_name | ?string | the vanity name of the platform a bot has connected (max 50 characters)                                                                                                                                                                                                |
-| metadata      | object  | object mapping [application role connection metadata](/developers/resources/application-role-connection-metadata#application-role-connection-metadata-object) keys to their `string`-ified value (max 100 characters) for the user on the platform a bot has connected |
+| Field             | Type    | Description                                                                                                                                                                                                                                                            |
+|-------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| platform_name     | ?string | the vanity name of the platform a bot has connected (max 50 characters)                                                                                                                                                                                                |
+| platform_username | ?string | the username on the platform a bot has connected (max 100 characters)                                                                                                                                                                                                  |
+| metadata          | object  | object mapping [application role connection metadata](/developers/resources/application-role-connection-metadata#application-role-connection-metadata-object) keys to their `string`-ified value (max 100 characters) for the user on the platform a bot has connected |
 
 ## Get Current User
 <Route method="GET">/users/@me</Route>


### PR DESCRIPTION
This was included in the PUT request body but not the response object.
