### PR TITLE
Fix incorrect library filenames in C++ Getting Started guide

### DIFF
--- a/developers/discord-social-sdk/getting-started/using-c++.mdx
+++ b/developers/discord-social-sdk/getting-started/using-c++.mdx
@@ -54,8 +54,8 @@ To utilize the Discord Social SDK with C++, the following requirements must be m
 - `discordpp.h` is included in your C++ source code.
 - The appropriate SDK libraries for your platform are linked in your build system:
     - **Windows:** `discord_partner_sdk.dll`
-    - **Linux**: `discord_partner_sdk.so`
-    - **macOS:** `discord_partner_sdk.dylib`
+    - **Linux**: `libdiscord_partner_sdk.so`
+    - **macOS:** `libdiscord_partner_sdk.dylib`
 
 All of which can be found in the SDK download archive.
 


### PR DESCRIPTION
Linux and macOS SDK libraries require the `lib` prefix (libdiscord_partner_sdk.so / libdiscord_partner_sdk.dylib).