### PR TITLE
Add Discord Social SDK 1.9.15332 release to changelog

### DIFF
--- a/developers/change-log.mdx
+++ b/developers/change-log.mdx
@@ -7,6 +7,20 @@ rss: true
 import {Route} from '/snippets/route.jsx'
 
 <Update label="April 23, 2026" tags={["Discord Social SDK"]} rss={{
+    title: "Discord Social SDK 1.9.15332",
+    description: "PlayStation 5 OS 13.000 support."
+  }}>
+
+    ## Discord Social SDK Release 1.9.15332
+
+    A new release of the Discord Social SDK is now available, with the following updates:
+
+    ### Playstation 5
+    - Added OS 13.000 support
+
+</Update>
+
+<Update label="April 23, 2026" tags={["Discord Social SDK"]} rss={{
     title: "Proximity Voice Chat Guide for Game Developers",
     description: "New guide on how to intercept Discord Social SDK voice audio and route it to Unity's 3D audio system to build proximity voice chat for multiplayer games."
   }}>


### PR DESCRIPTION
Adds changelog entry for Discord Social SDK version 1.9.15332 (released 2026-04-23), which adds PlayStation 5 OS 13.000 support.