### PR TITLE
Bot OAuth2: mention `integration_type` and Default Install Settings default

### DIFF
--- a/developers/topics/oauth2.mdx
+++ b/developers/topics/oauth2.mdx
@@ -307,13 +307,14 @@ Bot authorization is a special server-less and callback-less OAuth2 flow that ma
 <ManualAnchor id="bot-authorization-flow-bot-auth-parameters" />
 ###### Bot Auth Parameters
 
-| name                 | description                                                           |
-|----------------------|-----------------------------------------------------------------------|
-| client_id            | your app's client id                                                  |
-| scope                | needs to include `bot` for the bot flow                               |
-| permissions          | the [permissions](/developers/topics/permissions) you're requesting   |
-| guild_id             | pre-fills the dropdown picker with a guild for the user               |
-| disable_guild_select | `true` or `false`—disallows the user from changing the guild dropdown |
+| name                  | description                                                                                                                          |
+|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| client_id             | your app's client id                                                                                                                 |
+| scope?                | needs to include `bot` for the bot flow                                                                                              |
+| permissions?          | the [permissions](/developers/topics/permissions) you're requesting                                                                  |
+| guild_id?             | pre-fills the dropdown picker with a guild for the user                                                                              |
+| disable_guild_select? | `true` or `false`—disallows the user from changing the guild dropdown                                                                |
+| integration_type?     | the [installation context](/developers/resources/application#application-object-application-integration-types) for the authorization |
 
 <ManualAnchor id="bot-authorization-flow-url-example" />
 ###### URL Example
@@ -328,6 +329,8 @@ When the user navigates to this page, they'll be prompted to add the bot to a gu
 
 If you happen to already know the ID of the guild the user will add your bot to, you can provide this ID in the URL as a `guild_id=GUILD_ID` parameter.
 When the authorization page loads, that guild will be preselected in the dialog if that user has permission to add the bot to that guild. You can use this in conjunction with the parameter `disable_guild_select=true` to disallow the user from picking a different guild.
+
+If you don't provide the `scope` parameter, it will default to the [default install settings](/developers/resources/application#configuring-an-install-link-and-default-install-settings) set in developer portal.
 
 If your bot is super specific to your private clubhouse, or you just don't like sharing, you can leave the `Public Bot` option unchecked in your application's settings. If unchecked, only you can add the bot to guilds. If marked as public, anyone with your bot's URL can add it to guilds in which they have proper permissions.
 

--- a/developers/topics/oauth2.mdx
+++ b/developers/topics/oauth2.mdx
@@ -330,7 +330,7 @@ When the user navigates to this page, they'll be prompted to add the bot to a gu
 If you happen to already know the ID of the guild the user will add your bot to, you can provide this ID in the URL as a `guild_id=GUILD_ID` parameter.
 When the authorization page loads, that guild will be preselected in the dialog if that user has permission to add the bot to that guild. You can use this in conjunction with the parameter `disable_guild_select=true` to disallow the user from picking a different guild.
 
-If you only provide the client_id parameter (with optionally permissions, guild_id, or disable_guild_select), the authorization will use the [default install settings](/developers/resources/application#configuring-an-install-link-and-default-install-settings) configured in the developer portal. Specifying scope, integration_type, or redirect_uri will override this behavior.
+If you only provide the `client_id` parameter (with optionally `permissions`, `guild_id`, or `disable_guild_select`), the authorization will use the [default install settings](/developers/resources/application#configuring-an-install-link-and-default-install-settings) configured in the developer portal. Specifying `scope`, `integration_type`, or `redirect_uri` will override this behavior.
 
 If your bot is super specific to your private clubhouse, or you just don't like sharing, you can leave the `Public Bot` option unchecked in your application's settings. If unchecked, only you can add the bot to guilds. If marked as public, anyone with your bot's URL can add it to guilds in which they have proper permissions.
 

--- a/developers/topics/oauth2.mdx
+++ b/developers/topics/oauth2.mdx
@@ -330,7 +330,7 @@ When the user navigates to this page, they'll be prompted to add the bot to a gu
 If you happen to already know the ID of the guild the user will add your bot to, you can provide this ID in the URL as a `guild_id=GUILD_ID` parameter.
 When the authorization page loads, that guild will be preselected in the dialog if that user has permission to add the bot to that guild. You can use this in conjunction with the parameter `disable_guild_select=true` to disallow the user from picking a different guild.
 
-If you don't provide the `scope` parameter, it will default to the [default install settings](/developers/resources/application#configuring-an-install-link-and-default-install-settings) set in developer portal.
+If you only provide the client_id parameter (with optionally permissions, guild_id, or disable_guild_select), the authorization will use the [default install settings](/developers/resources/application#configuring-an-install-link-and-default-install-settings) configured in the developer portal. Specifying scope, integration_type, or redirect_uri will override this behavior.
 
 If your bot is super specific to your private clubhouse, or you just don't like sharing, you can leave the `Public Bot` option unchecked in your application's settings. If unchecked, only you can add the bot to guilds. If marked as public, anyone with your bot's URL can add it to guilds in which they have proper permissions.
 


### PR DESCRIPTION
* add `integration_type` as query param
* show which params are optional
* mention how you don't need to specify anything other than `client_id`

<sub>[(thx to @Soheab for callout)](https://discord.com/channels/613425648685547541/1130595287078015027/1498345051263074494)</sub>