### PR TITLE
Add clarification about RPC responses

### DIFF
--- a/developers/topics/rpc.mdx
+++ b/developers/topics/rpc.mdx
@@ -154,7 +154,9 @@ You can now call RPC commands on behalf of the authorized user!
 
 Commands are requests made to the RPC socket by a client.
 
+<Warning>
 The structure of responses from the RPC server is similar to the HTTP API but may not be exactly equivalent.
+</Warning>
 
 <ManualAnchor id="commands-and-events-rpc-commands" />
 ###### RPC Commands

--- a/developers/topics/rpc.mdx
+++ b/developers/topics/rpc.mdx
@@ -154,6 +154,8 @@ You can now call RPC commands on behalf of the authorized user!
 
 Commands are requests made to the RPC socket by a client.
 
+The structure of responses from the RPC server is similar to the HTTP API but may not be exactly equivalent.
+
 <ManualAnchor id="commands-and-events-rpc-commands" />
 ###### RPC Commands
 


### PR DESCRIPTION
Adds a sentence to clarify that RPC server responses are not equivalent to the API.