### PR TITLE
Add embedl.ink to community resources

### DIFF
--- a/developers/developer-tools/community-resources.mdx
+++ b/developers/developer-tools/community-resources.mdx
@@ -99,6 +99,7 @@ The public preview of the [Discord HTTP API specification](https://github.com/di
 Webhooks and embeds might seem like black magic. That's because they are, but let us help you demystify them a bit. These tools can help you test how embeds will appear inside of Discord:
 
 - [JohnyTheCarrot's Embed Previewer](https://github.com/JohnyTheCarrot/discord-embed-previewer) (Browser Extension)
+- [AshMW's Embed Previewer](https://embedl.ink) (Embed HTML Generation)
 
 ## API Types
 


### PR DESCRIPTION
This pull request adds a new resource to the community resources section, providing an additional tool for making links have nice Discord embeds easier.

Community resources update:

* Added a link to "AshMW's Embed Previewer" ([`https://embedl.ink`](https://embedl.ink)) for embed HTML generation in the community resources documentation.