### PR TITLE
Add game detection requirement to claim-your-game prerequisites

### DIFF
--- a/developers/platform/claim-your-game.mdx
+++ b/developers/platform/claim-your-game.mdx
@@ -41,10 +41,19 @@ Once your claim is confirmed, your Discord server receives a green verified badg
 Make sure the following are in place before you start:
 
 - Your game must have a Steam store page. Other storefronts are not yet supported.
+- Your Steam store page must have a publicly visible Discord invite link. During the claim process, you'll receive a `proof` value to append to that link before the claim can be submitted.
 - Games whose primary purpose is the delivery of sexual content or are Mods of other games are not eligible for claiming.
 - Your Discord application must be assigned to a [development team](/developers/topics/teams#teams), not owned by an individual account.
-- Your Steam store page must have a publicly visible Discord invite link. During the claim process, you'll receive a `proof` value to append to that link before the claim can be submitted.
 - The server owner must be a member of your Team. Discord verifies ownership by sending a verification code to the server owner's email address.
+- Discord must have an official record of your game. Discord automatically recognizes games that have established a sufficient playerbase and play time among Discord users over an extended period.
+
+<Tip>
+To check whether Discord has a record of your game, search for it in the Game Identity dropdown in [Step 2](#step-2-find-and-select-your-game).
+If your game does not appear there, Discord does not yet have an official
+record of it. As your game's playerbase and playtime grow, it will become eligible for automatic recognition.
+
+Note that implementing [Rich Presence](/developers/platform/rich-presence) via the Discord Social SDK is separate from automatic game detection as these are independent systems, and having Rich Presence alone does not make a game claimable.
+</Tip>
 
 <Info>
 At this time, games in private beta or limited release are not supported. Your game must be publicly available and playable to be eligible for claiming.
@@ -67,7 +76,6 @@ If you're an existing SDK partner, claim your game to the application you're alr
 ### Step 2: Find and Select Your Game
 
 Search for your game by name in the Game Identity interface and select it to begin the claim.
-
 
 ### Step 3: Update Your Steam Invite Link
 

--- a/developers/platform/claim-your-game.mdx
+++ b/developers/platform/claim-your-game.mdx
@@ -77,6 +77,8 @@ If you're an existing SDK partner, claim your game to the application you're alr
 
 Search for your game by name in the Game Identity interface and select it to begin the claim.
 
+If your game does not appear there, Discord does not yet have an official record of it. As such, you will not be able to claim your game at this time. As your game’s playerbase and playtime grow, it will become eligible for automatic recognition.
+
 ### Step 3: Update Your Steam Invite Link
 
 After selecting your game, the claim interface will display a `proof` query parameter. Copy this value and append it to your Discord invite link on your Steam store page.


### PR DESCRIPTION
Documents that Discord must have an official record of a game before it can be claimed, explains that recognition grows with playerbase and playtime, and clarifies that Rich Presence is separate from automatic game detection. Directs developers to the Step 2 dropdown as the definitive way to check whether their game is eligible.