### PR TITLE
Fix cmake bug in C++ getting started guide

### DIFF
--- a/developers/discord-social-sdk/getting-started/using-c++.mdx
+++ b/developers/discord-social-sdk/getting-started/using-c++.mdx
@@ -129,7 +129,7 @@ endif()
 add_custom_command(TARGET DiscordSDKExample POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
     "${DISCORD_SHARED_LIB}"
-    $&lt;TARGET_FILE_DIR:DiscordSDKExample&gt;
+    $<TARGET_FILE_DIR:DiscordSDKExample>
 )
 ```
 


### PR DESCRIPTION
There was a bug in the old docs platform that required this.

I forgot about it with the switchover, but it came up recently - so fixing it!