### PR TITLE
Document flags_new field on Application object

### DIFF
--- a/developers/change-log.mdx
+++ b/developers/change-log.mdx
@@ -6,6 +6,21 @@ rss: true
 
 import {Route} from '/snippets/route.jsx'
 
+<Update label="May 7, 2026" tags={["HTTP API"]} rss={{
+    title: "New flags_new Field on Application Object",
+    description: "The Application object now includes a `flags_new` field, a string-serialized integer containing all application flag bits including those beyond 32-bit precision."
+  }}>
+
+  ## New `flags_new` Field on Application Object
+
+  The [Application object](/developers/resources/application#application-object) now includes a `flags_new` field — a string-serialized integer containing the full set of [application flag bits](/developers/resources/application#application-object-application-flags), including any new flag bits introduced beyond bit 30.
+
+  The existing `flags` field continues to be serialized as a 32-bit integer. Existing integrations consuming `flags` for bits at or below `2^30` are not impacted, and request payloads that include flag values should continue to use the original `flags` field.
+
+  This mirrors the [`permissions_new` / `allow_new` / `deny_new`](/developers/topics/permissions) pattern previously introduced for permission bitfields.
+
+</Update>
+
 <Update label="May 5, 2026" tags={["HTTP API"]} rss={{
     title: "User Premium Type Field Now Requires A Scope",
     description: "The `premium_type` field on the User object now requires the `identify.premium` scope to return a user's Nitro subscription level."

--- a/developers/resources/application.mdx
+++ b/developers/resources/application.mdx
@@ -58,6 +58,8 @@ import {Route} from '/snippets/route.jsx'
   "bot_require_code_grant": false,
   "cover_image": "31deabb7e45b6c8ecfef77d2f99c81a5",
   "description": "Test",
+  "flags": 8192,
+  "flags_new": "8192",
   "guild_id": "290926798626357260",
   "icon": null,
   "id": "172150183260323840",
@@ -144,6 +146,10 @@ Status indicating whether event webhooks are enabled or disabled for an applicat
 
 <ManualAnchor id="application-object-application-flags" />
 ###### Application Flags
+
+<Info>
+The `flags` field is serialized as a number; however, this number will not grow beyond 31 bits. New flag bits beyond bit 30 will only appear in `flags_new`, a string-serialized integer containing the full set of flag bits. Existing integrations consuming `flags` are not impacted. `flags_new` is for response serialization only — requests that accept flag values should continue to use the original `flags` field.
+</Info>
 
 | Value     | Name                                          | Description                                                                                                                                                                                                                                                         |
 |-----------|-----------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
Adds a callout under the Application Flags heading explaining that new flag bits beyond bit 30 only appear in `flags_new` (a stringified integer), updates the example Application JSON to show both fields, and publishes a changelog entry. Mirrors the precedent set by `permissions_new`/`allow_new`/`deny_new`.