### PR TITLE
Add Discord Social SDK 1.9.15780 release notes to changelog

### DIFF
--- a/developers/change-log.mdx
+++ b/developers/change-log.mdx
@@ -6,6 +6,23 @@ rss: true
 
 import {Route} from '/snippets/route.jsx'
 
+<Update label="May 12, 2026" tags={["Discord Social SDK"]} rss={{
+    title: "Discord Social SDK 1.9.15780",
+    description: "Xbox GDK 260400 support and Krisp noise suppression integration across Android, iOS, macOS, and Windows."
+  }}>
+
+    ## Discord Social SDK Release 1.9.15780
+
+    A new release of the Discord Social SDK is now available, with the following updates:
+
+    ### Xbox
+    - Added Xbox GDK 260400 support
+
+    ### Noise Suppression
+    - Integrated Krisp noise suppression across Android, iOS, macOS, and Windows
+
+</Update>
+
 <Update label="May 7, 2026" tags={["HTTP API"]} rss={{
     title: "New flags_new Field on Application Object",
     description: "The Application object now includes a `flags_new` field, a string-serialized integer containing all application flag bits including those beyond 32-bit precision."


### PR DESCRIPTION
Adds Xbox GDK 260400 support and Krisp noise suppression integration across Android, iOS, macOS, and Windows.