### PR TITLE
Document Discord account bans, token revocation, and unmerge lifecycle

### DIFF
--- a/developers/change-log.mdx
+++ b/developers/change-log.mdx
@@ -6,6 +6,21 @@ rss: true
 
 import {Route} from '/snippets/route.jsx'
 
+<Update label="May 22, 2026" tags={["Discord Social SDK"]} rss={{
+    title: "Account Linking Failure-Mode Documentation",
+    description: "New documentation covering what happens when a Discord account is banned, when OAuth2 tokens are revoked, and how to design account linking for resilience."
+  }}>
+
+  ## Account Linking Failure Modes
+
+  We've expanded documentation across the Social SDK guides to cover what happens when the Discord-to-game account link is severed — whether by a Discord account ban, an explicit unmerge, or an OAuth2 token revocation. Highlights:
+
+  - **[Ban-Driven Unmerge](/developers/discord-social-sdk/development-guides/using-provisional-accounts#ban-driven-unmerge)** documents the full lifecycle when a user's Discord account is banned: tokens are deleted immediately, a new cross-platform-restricted provisional account is created carrying the original external identity, and merge attempts return error [`530017`](/developers/discord-social-sdk/development-guides/using-provisional-accounts#merge-request-failures) until the ban lifts (or, for permanent bans, indefinitely).
+  - **[Out-of-Band Revocation](/developers/discord-social-sdk/development-guides/account-linking-with-discord#out-of-band-revocation)** describes the auth-side observable signals (`APPLICATION_DEAUTHORIZED` webhook + `invalid_grant` on refresh) when a user removes your app from Discord or has their account banned.
+  - **[When Refresh Fails](/developers/discord-social-sdk/development-guides/account-linking-with-discord#when-refresh-fails)** documents the `/oauth2/token` response when the underlying token has been deleted, and recommends treating `invalid_grant` as equivalent to receiving the webhook.
+
+</Update>
+
 <Update label="May 12, 2026" tags={["Discord Social SDK"]} rss={{
     title: "Discord Social SDK 1.9.15780",
     description: "Xbox GDK 260400 support and Krisp noise suppression integration across Android, iOS, macOS, and Windows."

--- a/developers/discord-social-sdk/development-guides/account-linking-with-discord.mdx
+++ b/developers/discord-social-sdk/development-guides/account-linking-with-discord.mdx
@@ -17,6 +17,9 @@ This guide explains how to authenticate users with their existing Discord accoun
 ### Flexible Account Options
 If a player does not have a Discord account, you can use the SDK to [create a provisional account](/developers/discord-social-sdk/development-guides/using-provisional-accounts) instead so that they can still access your game's features.
 
+For the account linking integration flow we recommend — provisional account first, and Discord-linked
+account second — see [Recommended Integration Path](#recommended-integration-path) below.
+
 ### Prerequisites
 
 Before you begin, make sure you have:
@@ -241,11 +244,39 @@ client->RefreshToken(
       });
 ```
 
+### When Refresh Fails
+
+A stored refresh token can become invalid between sessions for several reasons — the user revoked your application from their *User Settings → Authorized Apps* page,
+you called the [unmerge or token revocation endpoint](#revoking-access-tokens),
+or the [user's Discord account was banned](/developers/discord-social-sdk/development-guides/using-provisional-accounts#ban-driven-unmerge).
+
+In every one of these cases the response on `/oauth2/token` with `grant_type=refresh_token` is the same:
+
+- **HTTP status:** `400`
+- **Body:** `{ "error": "invalid_grant", "error_description": "Invalid \"refresh_token\" in request" }`
+
+There is no ban-specific or unlink-specific error code on this path — by the time the refresh runs, the underlying tokens have already been deleted server-side, so the lookup fails.
+
+When you do see `invalid_grant` on refresh, drop the stored Discord tokens for the user and fall back to the [provisional account flow](/developers/discord-social-sdk/development-guides/using-provisional-accounts#implementing-provisional-accounts) to keep the player in-game even if their Discord link is gone.
+
+<Tip>
+To be notified when a user's authorization for your app is revoked — whether by an unlink, a token revocation, or a Discord account ban — integrate the [`APPLICATION_DEAUTHORIZED`](/developers/events/webhook-events#application-deauthorized) webhook event. That gives you a proactive signal you can act on immediately, rather than discovering the change the next time a refresh fails.
+</Tip>
+
 ---
 
 ## Revoking Access Tokens
 
-If a user wants to disconnect their Discord account or if a token is compromised, you can revoke access and refresh tokens.
+A user's authorization for your app can be revoked in several ways — by your own backend, by the user from Discord's UI, or by Discord itself when an account is banned. Regardless of how the revocation is triggered:
+
+- The user's access and refresh tokens are immediately invalidated. Any subsequent refresh on `/oauth2/token` returns `HTTP 400` with `error: "invalid_grant"` (see [When Refresh Fails](#when-refresh-fails)).
+- An [`APPLICATION_DEAUTHORIZED`](/developers/events/webhook-events#application-deauthorized) webhook is fired to your app.
+
+<Info>
+For Discord Social SDK-integrated apps, every revocation path in this section is mechanically an [unmerge](/developers/discord-social-sdk/development-guides/using-provisional-accounts#unmerging-provisional-accounts): the merged Discord account reverts to a new provisional account carrying the original `external_auth_token`. This holds whether revocation comes from `/oauth2/token/revoke`, `Client::RevokeToken`, the user removing your app from Discord's UI, or a ban. Only [ban-driven unmerges](/developers/discord-social-sdk/development-guides/using-provisional-accounts#ban-driven-unmerge) create a *restricted* provisional account — the others create an unrestricted one that can be re-merged freely.
+</Info>
+
+You'll naturally know about revocations your own code initiates. For revocations triggered outside your code — see [Out-of-Band Revocation](#out-of-band-revocation) below — the webhook is the only proactive way to find out.
 
 <Warning>
 When any valid access or refresh token is revoked, all of your application's access and refresh tokens for that user are immediately invalidated.
@@ -294,12 +325,70 @@ client->RevokeToken(YOUR_DISCORD_APPLICATION_ID,
                     });
 ```
 
-### Handling User Initiated Revocation
+### Out-of-Band Revocation
 
-Users can unlink their account by removing access to your application on their Discord `User Settings -> Authorized Apps` page.
+Two paths sever the user's Discord link without your code calling any unmerge or revoke endpoint:
 
-If you would like to be notified when a user unlinks this way, you can [configure you application to listen for the `APPLICATION_DEAUTHORIZED` webhook event](/developers/events/webhook-events#application-deauthorized).
-Otherwise, you will know that the user has unlinked because their access token and refresh token (if you have one) will be invalidated.
+- The user removes your app from their Discord *User Settings → Authorized Apps* page (a [user-initiated unmerge](/developers/discord-social-sdk/development-guides/using-provisional-accounts#out-of-band-unmerge)).
+- The user's Discord account is banned (a [ban-driven unmerge](/developers/discord-social-sdk/development-guides/using-provisional-accounts#ban-driven-unmerge), with an additional cross-platform-restricted state on the new provisional account).
+
+Subscribe to [`APPLICATION_DEAUTHORIZED`](/developers/events/webhook-events#application-deauthorized) to be notified when either happens. If you miss the webhook, the [next token use will fail](#when-refresh-fails) and your game should fall back to the [provisional account flow](/developers/discord-social-sdk/development-guides/using-provisional-accounts#implementing-provisional-accounts).
+
+---
+
+## Recommended Integration Path
+
+The recommended path for integrating the Discord Social SDK is that your game has a primary authentication other than Discord that initially sets up a provisional account, and have the player link their Discord account to this primary authentication.
+
+This approach protects your users' game access and data if they encounter issues with their Discord account, such as a permanent or temporary ban. To implement this recommended path:
+
+1. Create an account through a [non-Discord authentication provider](/developers/discord-social-sdk/development-guides/using-provisional-accounts#configuring-your-identity-provider), and create a provisional account attached to it.
+2. When users later authenticate through Discord to link their account, have your game back end execute the [merge their provisional account with their Discord Account](/developers/discord-social-sdk/development-guides/using-provisional-accounts#merging-provisional-accounts).
+3. The account merging process will internally store the `externalAuthToken` from the provisional account against their Discord account. If a ban of the Discord account happens, that `externalAuthToken` will be attached to the new provisional account that is created in its stead, with the original Discord account's in-game friends, and will be available through the authentication provider the account was initially setup with.
+4. As a last step, your game back end should maintain the record of the `externalAuthToken` against the user account, even after the account merging process, since it will be needed to [authenticate via a provisional account](/developers/discord-social-sdk/development-guides/using-provisional-accounts#implementing-provisional-accounts) should Discord authentication fails for a ban, or any other reason.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Game
+    participant NonDiscordAuth as Non-Discord Auth Provider
+    participant GameBackend as Game Backend
+    participant Discord
+
+    User->>Game: Start game
+    Game->>NonDiscordAuth: Create account
+    NonDiscordAuth-->>Game: Authentication successful
+    Game->>GameBackend: Request provisional account
+    GameBackend->>Discord: Create provisional account
+    Discord-->>GameBackend: Account created
+    GameBackend-->>Game: Return Provisional Account
+    Note over GameBackend: Store externalAuthToken
+
+    User->>Game: Choose to link Discord account
+    Game->>Discord: Request authentication
+    Discord-->>Game: Auth successful
+    Game->>GameBackend: Request account merge
+    GameBackend->>Discord: Merge Provisional Account
+    Note over Discord: Stores externalAuthToken against Discord account
+    Discord-->>GameBackend: Merge successful
+
+    Note over GameBackend: Maintain externalAuthToken record
+
+    alt Discord Authentication Fails (Ban or Other Issue)
+        User->>Game: Attempt to login
+        Game->>Discord: Request authentication
+        Discord-->>Game: Auth failed
+        Game->>NonDiscordAuth: Fallback authentication
+        NonDiscordAuth-->>Game: Authentication successful
+        Game->>GameBackend: Access provisional account with externalAuthToken
+        GameBackend-->>Game: Access granted with in-game friends list
+        Game-->>User: Access game
+    end
+```
+
+<Warning>
+If you use Discord as the primary or sole authentication mechanism for your game, you risk players permanently losing access to their in-game data if their Discord account is banned, as there is no way to migrate them to a provisional account that is connected to an external authentication provider.
+</Warning>
 
 ---
 
@@ -329,9 +418,10 @@ import {UserIcon} from '/snippets/icons/UserIcon.jsx'
 
 ## Change Log
 
-| Date           | Changes         |
-|----------------|-----------------|
-| March 17, 2025 | initial release |
+| Date           | Changes                                                     |
+|----------------|-------------------------------------------------------------|
+| May 22, 2026   | Add out-of-band revocation and recommended integration path |
+| March 17, 2025 | initial release                                             |
 
 {/* Autogenerated Reference Links */}
 [`Client::Authorize`]: https://discord.com/developers/docs/social-sdk/classdiscordpp_1_1Client.html#ace94a58e27545a933d79db32b387a468

--- a/developers/discord-social-sdk/development-guides/using-provisional-accounts.mdx
+++ b/developers/discord-social-sdk/development-guides/using-provisional-accounts.mdx
@@ -584,15 +584,20 @@ You may receive a merge specific error code while attempting this operation:
 | 530023 | 400         | Too many application identities | User already has an associated external identity for this application |
 | -      | 423         | Resource locked                 | Transient error, wait and retry                                       |
 
+<Info>
+Error `530017` is most commonly seen *after* a successful link: when a previously linked Discord account is banned, that user's identity is severed back into a new provisional account in a **restricted** state, and that restricted provisional account cannot be merged into a different Discord account until the ban expires (temp ban) or is lifted. See [Ban-Driven Unmerge](#ban-driven-unmerge) for the full lifecycle.
+</Info>
+
 ---
 
 ## Unmerging Provisional Accounts
 
-When a player wants to unlink their Discord account from their provisional account, there are three options:
+The link between a Discord account and a provisional account can be severed in four ways:
 
 1. The user can unmerge their account from the Discord client
 2. A developer can unmerge the account using the unmerge endpoint on the Discord API
 3. A developer can use the SDK helper method for public clients
+4. Discord can sever the link automatically when the user's Discord account is banned — see [Ban-Driven Unmerge](#ban-driven-unmerge) below
 
 <Warning>
 Unmerging invalidates all access/refresh tokens for the user. They cannot be used again after the unmerge operation completes. Any connected game sessions will be disconnected.
@@ -603,16 +608,6 @@ Unmerging invalidates all access/refresh tokens for the user. They cannot be use
     unmerge completes, you can use the same token to retrieve the new provisional token for the newly created provisional
     account.
 </Tip>
-
-### Discord Users
-
-Users can unmerge their account by removing access to your application on their Discord `User Settings -> Authorized Apps` page.
-
-This method doesn't require any code changes from developers, but we recommend providing unmerging functionality through
-one of the options below for a better user experience.
-
-If you would like to be notified when a user unlinks this way, you can [configure you application to listen for the `APPLICATION_DEAUTHORIZED` webhook event](/developers/events/webhook-events#application-deauthorized).
-Otherwise, you will know that the user has unlinked because their access token and refresh token (if you have one) will be invalidated.
 
 ### Unmerging Provisional Accounts for Servers
 
@@ -730,6 +725,36 @@ void UnmergeUserAccount(const std::shared_ptr<discordpp::Client>& client) {
 }
 ```
 
+### Out-of-Band Unmerge
+
+The link can also be severed without your code calling any unmerge endpoint:
+
+- **User-initiated**: the user removes your app from their Discord `User Settings -> Authorized Apps` page. The result is a standard unmerge — the user can re-link freely later.
+- **Ban-driven**: when the user's Discord account is banned by Discord, the link is severed automatically. This is mechanically an unmerge, but with additional lifecycle consequences — see [Ban-Driven Unmerge](#ban-driven-unmerge) below.
+
+In both cases your app observes the same auth-side signals — an `APPLICATION_DEAUTHORIZED` webhook fires and stored tokens are invalidated. See [Out-of-Band Revocation](/developers/discord-social-sdk/development-guides/account-linking-with-discord#out-of-band-revocation) in the Account Linking guide for the details and recommended recovery path.
+
+These paths don't require any code changes from you, but we recommend providing an in-app unmerge option through one of the methods above for a better user experience.
+
+#### Ban-Driven Unmerge
+
+When a player's Discord account is banned (temporarily or permanently), Discord performs an unmerge automatically. Two things happen:
+
+1. **OAuth2 tokens are deleted immediately** — producing the same `APPLICATION_DEAUTHORIZED` webhook and `invalid_grant`-on-refresh signals as any out-of-band revocation. There is no grace period.
+2. **A new provisional account is created for the same external identity.** Standard [unmerge data migration](#data-migration-during-unmerging) applies — username, friends list, lobbies, and so on are preserved — so the player retains their in-game social graph even though their Discord identity is gone. The new provisional account is created in a **restricted** state.
+
+While the new provisional account is restricted:
+
+- It **cannot be merged** into a different Discord account. Any merge attempt via [`/oauth2/token` with `external_auth_token`](#merging-provisional-accounts-for-servers) will fail with error [`530017` "Merge source user is banned"](#merge-request-failures).
+- For a **temporary ban**, the restriction lifts automatically when the ban expires, and the provisional account can then be merged again.
+- For a **permanent ban**, the restriction stays in place indefinitely.
+
+<Info>
+There is no API to look up whether a player's Discord account is currently banned. In practice, the combination of
+    `APPLICATION_DEAUTHORIZED` and/or `invalid_grant`-on-refresh is the signal you should fall
+    back to the [provisional account flow](#implementing-provisional-accounts).
+</Info>
+
 ### Data Migration During Unmerging
 
 When a user unmerges their account, a new provisional account is created with a new user ID. The following data is transferred to the new provisional account:
@@ -789,6 +814,7 @@ import {UserStatusIcon} from '/snippets/icons/UserStatusIcon.jsx'
 
 | Date              | Changes                                          |
 |-------------------|--------------------------------------------------|
+| May 22, 2026      | Document ban-driven unmerge lifecycle            |
 | April 21, 2026    | Document OIDC integration requirements           |
 | April 14, 2026    | Clarify provisional account token refresh flow   |
 | April 13, 2026    | Clarify Merging Provisional Accounts for Servers |

--- a/developers/discord-social-sdk/how-to/integrate-moderation.mdx
+++ b/developers/discord-social-sdk/how-to/integrate-moderation.mdx
@@ -298,66 +298,10 @@ event for the edit, which you can use to trigger re-moderation of the new conten
 
 ### Discord Platform Bans
 
-<Info>
-If a player has connected their Discord account with your game, and it is banned, their [`Client`] will be
-immediately disconnected, and that user will no longer be able to authenticate through Discord.
-</Info>
+When a player's Discord account is banned by Discord — whether temporarily or permanently — they will no longer be able to authenticate to your app via Discord, their existing [`Client`] is disconnected, their OAuth2 tokens are invalidated, and an [`APPLICATION_DEAUTHORIZED`](/developers/events/webhook-events#application-deauthorized) webhook is fired.
 
-The recommended path for integrating the Discord Social SDK is that your game has a primary authentication other than Discord that initially sets up a provisional account, and have the player link their Discord account to this primary authentication.
-
-This approach protects your users' game access and data if they encounter issues with their Discord account, such as a permanent or temporary ban. To implement this recommended path:
-
-1. Create an account through a [non-Discord authentication provider](/developers/discord-social-sdk/development-guides/using-provisional-accounts#configuring-your-identity-provider), and create a provisional account attached to it.
-2. When users later authenticate through Discord to link their account, have your game back end execute the [merge their provisional account with their Discord Account](/developers/discord-social-sdk/development-guides/using-provisional-accounts#merging-provisional-accounts).
-3. The account merging process will internally store the `externalAuthToken` from the provisional account against their Discord account. If a ban of the Discord account happens, that `externalAuthToken` will be attached to the new provisional account that is created in its stead, with the original Discord account's in-game friends, and will be available through the authentication provider the account was initially setup with.
-4. As a last step, your game back end should maintain the record of the `externalAuthToken` against the user account, even after the account merging process, since it will be needed to [authenticate via a provisional account](/developers/discord-social-sdk/development-guides/using-provisional-accounts#implementing-provisional-accounts) should Discord authentication fails for a ban, or any other reason.
-
-```mermaid
-sequenceDiagram
-    participant User
-    participant Game
-    participant NonDiscordAuth as Non-Discord Auth Provider
-    participant GameBackend as Game Backend
-    participant Discord
-
-    User->>Game: Start game
-    Game->>NonDiscordAuth: Create account
-    NonDiscordAuth-->>Game: Authentication successful
-    Game->>GameBackend: Request provisional account
-    GameBackend->>Discord: Create provisional account
-    Discord-->>GameBackend: Account created
-    GameBackend-->>Game: Return Provisional Account
-    Note over GameBackend: Store externalAuthToken
-
-    User->>Game: Choose to link Discord account
-    Game->>Discord: Request authentication
-    Discord-->>Game: Auth successful
-    Game->>GameBackend: Request account merge
-    GameBackend->>Discord: Merge Provisional Account
-    Note over Discord: Stores externalAuthToken against Discord account
-    Discord-->>GameBackend: Merge successful
-
-    Note over GameBackend: Maintain externalAuthToken record
-
-    alt Discord Authentication Fails (Ban or Other Issue)
-        User->>Game: Attempt to login
-        Game->>Discord: Request authentication
-        Discord-->>Game: Auth failed
-        Game->>NonDiscordAuth: Fallback authentication
-        NonDiscordAuth-->>Game: Authentication successful
-        Game->>GameBackend: Access provisional account with externalAuthToken
-        GameBackend-->>Game: Access granted with in-game friends list
-        Game-->>User: Access game
-    end
-```
-
-<Warning>
-If you use Discord as the primary or sole authentication mechanism for your game, you risk players permanently losing access to their in-game data if their Discord account is banned, as there is no way to migrate them to a provisional account that is connected to an external authentication provider.
-</Warning>
-
-<Info>
-At this time, there is no API to look up if a player's Discord account has been banned.
-</Info>
+A ban is mechanically an [unmerge](/developers/discord-social-sdk/development-guides/using-provisional-accounts#unmerging-provisional-accounts) that Discord initiates — the OAuth2 tokens are deleted and a new cross-platform-restricted provisional account takes the place of the linked Discord identity.
+For the full lifecycle see [Ban-Driven Unmerge](/developers/discord-social-sdk/development-guides/using-provisional-accounts#ban-driven-unmerge) in the Provisional Accounts guide. For the auth-side observable signals and recommended integration architecture, see [Out-of-Band Revocation](/developers/discord-social-sdk/development-guides/account-linking-with-discord#out-of-band-revocation) in the Account Linking guide.
 
 ### Discord Server Bans
 
@@ -417,6 +361,7 @@ import {TextControllerIcon} from '/snippets/icons/TextControllerIcon.jsx'
 
 | Date         | Changes                                                                     |
 |--------------|-----------------------------------------------------------------------------|
+| May 22, 2026 | Move platform-ban lifecycle details to the Account Linking guide            |
 | Feb 20, 2026 | Replaced client-side message moderation with server-side message moderation |
 | May 22, 2025 | initial release                                                             |
 

--- a/developers/events/webhook-events.mdx
+++ b/developers/events/webhook-events.mdx
@@ -219,6 +219,17 @@ The "Value" column corresponds to the event's `type` field value in the [event b
 }
 ```
 
+###### Discord Social SDK
+
+For [Discord Social SDK](/developers/discord-social-sdk) apps, `APPLICATION_DEAUTHORIZED` is the **only out-of-game signal that a user's link state has changed**. Listening for it is required to keep your application state in sync — if you miss the webhook, the [next token use will fail](/developers/discord-social-sdk/development-guides/account-linking-with-discord#when-refresh-fails) and the game should fall back to the [provisional account flow](/developers/discord-social-sdk/development-guides/using-provisional-accounts#implementing-provisional-accounts).
+
+Every revocation that fires this event is mechanically an [unmerge](/developers/discord-social-sdk/development-guides/using-provisional-accounts#unmerging-provisional-accounts) — the merged Discord account reverts to a new provisional account, and the OAuth2 tokens for the Discord user become invalid. The triggers include:
+
+- Token revocations via [`/oauth2/token/revoke`](/developers/topics/oauth2#authorization-code-grant) or `Client::RevokeToken`.
+- The user removing your app from *User Settings → Authorized Apps* in Discord.
+- The [Social SDK unmerge endpoints](/developers/discord-social-sdk/development-guides/using-provisional-accounts#unmerging-provisional-accounts).
+- The user's Discord [account being banned](/developers/discord-social-sdk/development-guides/using-provisional-accounts#ban-driven-unmerge).
+
 #### Entitlement Create
 
 `ENTITLEMENT_CREATE` is sent when an [entitlement](/developers/resources/entitlement) is created when a user purchases or is otherwise granted one of your app's SKUs. Refer to the [Monetization documentation](/developers/monetization/overview) for details.


### PR DESCRIPTION
Expanded coverage across the Social SDK guides for what happens when the Discord-to-game link is severed — by ban, explicit unmerge, or OAuth2 token revocation. Adds Ban-Driven Unmerge, Out-of-Band Revocation, When Refresh Fails, and Recommended Integration Path sections, plus a Discord Social SDK Considerations subsection on the APPLICATION_DEAUTHORIZED webhook event. Moves ban-lifecycle detail out of the moderation guide, which is no longer the natural home for it.