### PR TITLE
Document Discord Social SDK release cadence and support window

### DIFF
--- a/developers/change-log.mdx
+++ b/developers/change-log.mdx
@@ -6,6 +6,39 @@ rss: true
 
 import {Route} from '/snippets/route.jsx'
 
+<Update label="May 26, 2026" tags={["Discord Social SDK"]} rss={{
+    title: "Discord Social SDK Release Cadence & Support",
+    description: "New release cadence and support lifecycle taking effect with the 1.10 release in July 2026: a 5-version support window (1.6–1.10), and a rolling 18-month console OS SDK window where new Xbox and PlayStation SDKs ship only in new Social SDK releases."
+}}>
+
+    ## Discord Social SDK Release Cadence & Support
+
+    We've published a new [Release Cadence & Support](/developers/discord-social-sdk/core-concepts/release-cadence-and-support) page for the Discord Social SDK. It documents:
+
+    - Our new three-per-year minor release cadence (April, July, November)
+    - A new support window covering the five most recent minor versions, with hotfix patches (bug fixes and security fixes) for older supported minor releases
+    - How new Xbox and PlayStation OS SDK supports ship in new Social SDK releases only — each release bundles roughly the last 18 months of console OS SDKs
+    - The new end-of-life process for older minor releases
+
+    ### What this means for you
+
+    - **Over a year and a half of support per minor release.** Three minor releases of the Social SDK per year combined with a 5-version support window means every minor release you ship with gets more than 18 months of patch coverage.
+    - **A predictable release calendar.** Releases land in April, July, and November, so you can plan Social SDK upgrades and console certification windows well in advance.
+    - **More bandwidth for new features and stability.** A defined support window lets us focus engineering effort where it matters most, which means more capacity to build new features in current minor releases and keep the versions in the support window robust and reliable.
+
+    ### What changes with 1.10
+
+    These changes take effect with the 1.10 release, shipping in **July 2026**:
+
+    - The supported version window will cover versions **1.6 through 1.10**. Versions **1.5 and earlier** will be end-of-life and no longer eligible for patch updates.
+    - **New Xbox and PlayStation OS SDK support will ship in new Social SDK releases only**, not as patches to older Social SDK versions. Each Social SDK release will bundle roughly the last 18 months of console OS SDK versions.
+
+    **Already-shipped Social SDK releases (1.6–1.9) are unchanged** — they keep the console OS SDK support they were originally built with. The new model applies from 1.10 forward.
+
+    We're sharing this ahead of the 1.10 release so developers on older versions have plenty of time to upgrade.
+
+</Update>
+
 <Update label="May 22, 2026" tags={["Discord Social SDK"]} rss={{
     title: "Account Linking Failure-Mode Documentation",
     description: "New documentation covering what happens when a Discord account is banned, when OAuth2 tokens are revoked, and how to design account linking for resilience."

--- a/developers/discord-social-sdk/core-concepts/platform-compatibility.mdx
+++ b/developers/discord-social-sdk/core-concepts/platform-compatibility.mdx
@@ -5,9 +5,9 @@ description: Learn about Discord Social SDK platform support and compatibility.
 import ConsoleAccess from '/snippets/discord-social-sdk/callouts/console-access.mdx';
 import SonyCallout from '/snippets/discord-social-sdk/callouts/sony.mdx';
 
-<Info>
+<Tip>
 You can find instructions on how to download the SDK for each platform in the [Getting Started](/developers/discord-social-sdk/getting-started) guide.
-</Info>
+</Tip>
 
 ---
 
@@ -15,11 +15,11 @@ You can find instructions on how to download the SDK for each platform in the [G
 
 The Discord Social SDK supports the following game engines and language environments:
 
-| Integration    | Minimum Supported Version |
-|----------------|---------------------------|
-| Standalone C++ | C++20                     |
-| Unity          | 2021.3                    |
-| Unreal Engine  | 5.5                       |
+| Integration    | Supported Version |
+|----------------|-------------------|
+| Standalone C++ | C++20+            |
+| Unity          | 2021.3+           |
+| Unreal Engine  | 5.5+              |
 
 <Info>
     **PlayStation 4 / PS5 exception:** If you're targeting PlayStation 4, or PlayStation 5 with a PS5 SDK older than
@@ -36,26 +36,31 @@ The Discord Social SDK supports the following game engines and language environm
 
 The Discord Social SDK is available for the following platforms:
 
-| Platform         | Minimum Supported Version | Support Level       | Standalone C++ | Unreal Engine | Unity |
-|------------------|---------------------------|---------------------|----------------|---------------|-------|
-| **Desktop**      |                           |                     |                |               |       |
-| Windows (x64)    | 10                        | Generally Available | ✅              | ✅             | ✅     |
-| Windows (ARM64)  | 11                        | Generally Available | ✅              | ❌             | ❌     |
-| macOS (x64)      | 10.5                      | Generally Available | ✅              | ❌             | ✅     |
-| macOS (ARM64)    | 11                        | Generally Available | ✅              | ❌             | ✅     |
-| Linux            | glibc 2.31*               | Experimental        | ✅              | ✅             | ✅     |
-| **Mobile**       |                           |                     |                |               |       |
-| Android          | 7.0                       | Generally Available | ✅              | ✅             | ✅     |
-| iOS              | 15.1                      | Generally Available | ✅              | ✅             | ✅     |
-| **Console**      |                           |                     |                |               |       |
-| Xbox One         |                           | Experimental        | ✅              | ✅             | ❌     |
-| Xbox Series X\|S |                           | Generally Available | ✅              | ✅             | ✅     |
-| PlayStation 4    |                           | Experimental        | ✅              | ✅             | ❌     |
-| PlayStation 5    |                           | Generally Available | ✅              | ✅             | ✅     |
+| Platform         | Supported Versions | Support Level       | Standalone C++ | Unreal Engine | Unity |
+|------------------|--------------------|---------------------|----------------|---------------|-------|
+| **Desktop**      |                    |                     |                |               |       |
+| Windows (x64)    | 10+                | Generally Available | ✅              | ✅             | ✅     |
+| Windows (ARM64)  | 11+                | Generally Available | ✅              | ❌             | ❌     |
+| macOS (x64)      | 10.5+              | Generally Available | ✅              | ❌             | ✅     |
+| macOS (ARM64)    | 11+                | Generally Available | ✅              | ❌             | ✅     |
+| Linux            | *glibc 2.31+       | Experimental        | ✅              | ✅             | ✅     |
+| **Mobile**       |                    |                     |                |               |       |
+| Android          | 7.0+               | Generally Available | ✅              | ✅             | ✅     |
+| iOS              | 15.1+              | Generally Available | ✅              | ✅             | ✅     |
+| **Console**      |                    |                     |                |               |       |
+| Xbox One         | GDK 250400-260400  | Experimental        | ✅              | ✅             | ❌     |
+| Xbox Series X\|S | GDK 250400-260400  | Generally Available | ✅              | ✅             | ✅     |
+| PlayStation 4    | OS 11.500-12.500   | Experimental        | ✅              | ✅             | ❌     |
+| PlayStation 5    | OS 11.000-13.000   | Generally Available | ✅              | ✅             | ✅     |
 
 <Info>
 \* There are too many Linux distributions to test, but most distros with glibc 2.31, e.g. Ubuntu 20.04,
 or later should work.
+</Info>
+
+<Info>
+Each Social SDK release supports roughly the last 18 months of Xbox and PlayStation OS SDK versions.
+See [Console OS SDK Support](/developers/discord-social-sdk/core-concepts/release-cadence-and-support#console-os-sdk-support) for how the window rolls forward at each release.
 </Info>
 
 <ConsoleAccess />
@@ -66,14 +71,14 @@ or later should work.
 ## Next Steps
 
 import {TrophyIcon} from '/snippets/icons/TrophyIcon.jsx'
-import {UserIcon} from '/snippets/icons/UserIcon.jsx'
 import {PlayIcon} from '/snippets/icons/PlayIcon.jsx'
+import {ShieldIcon} from '/snippets/icons/ShieldIcon.jsx'
 
-Configure authentication, explore features, and get started with setup:
+Configure authentication, explore features, and review our release cadence:
 
 <CardGroup cols={3}>
-    <Card title="OAuth2 Scopes" href="/developers/discord-social-sdk/core-concepts/oauth2-scopes" icon={<UserIcon />}>
-        Understand OAuth2 scopes and client types for authentication.
+    <Card title="Release Cadence & Support" href="/developers/discord-social-sdk/core-concepts/release-cadence-and-support" icon={<ShieldIcon />}>
+        Release cadence, supported version window, and end-of-life process.
     </Card>
     <Card title="Core Features" href="/developers/discord-social-sdk/core-concepts/core-features" icon={<TrophyIcon />}>
         Explore social features like account linking, friends, and rich presence.
@@ -87,7 +92,8 @@ Configure authentication, explore features, and get started with setup:
 
 ## Change Log
 
-| Date          | Changes                                 |
-|---------------|-----------------------------------------|
-| May 20, 2026  | Added Game Engine and Language section. |
-| July 21, 2025 | initial release                         |
+| Date          | Changes                                                             |
+|---------------|---------------------------------------------------------------------|
+| May 26, 2026  | added console minimum versions; linked to Release Cadence & Support |
+| May 20, 2026  | Added Game Engine and Language section.                             |
+| July 21, 2025 | initial release                                                     |

--- a/developers/discord-social-sdk/core-concepts/release-cadence-and-support.mdx
+++ b/developers/discord-social-sdk/core-concepts/release-cadence-and-support.mdx
@@ -1,0 +1,112 @@
+---
+title: Release Cadence & Support
+description: Discord Social SDK release cadence, supported version window, and end-of-life process.
+---
+
+<Info>
+This page describes which Discord Social SDK versions receive updates, our release cadence, and how end-of-life is handled. For platform support details, see [Platform Compatibility](/developers/discord-social-sdk/core-concepts/platform-compatibility).
+</Info>
+
+<Note>
+These changes take effect with the **1.10 release** of the Discord Social SDK, shipping in **July 2026**. Starting with 1.10:
+
+- The supported version window will cover versions **1.6 through 1.10**. Versions **1.5 and earlier** will be end-of-life.
+- New Xbox and PlayStation OS SDK support will ship in new Social SDK releases only — not as patches to older Social SDK versions. Each Social SDK release bundles roughly the last 18 months of console OS SDK versions.
+
+**Already-shipped Social SDK releases (1.6–1.9) are unchanged** — they keep the console OS SDK support they were originally built with. The new model applies from 1.10 forward.
+
+We're announcing this ahead of the 1.10 release so developers on older versions have time to upgrade.
+</Note>
+
+## Release Schedule
+
+We ship **three minor releases of the Discord Social SDK each year**, in **April, July, and November**. This cadence aligns with the release windows for console OS SDKs so that each Discord Social SDK release can pick up the most recent supported console SDK versions.
+
+Between minor releases, we publish patch releases as needed (see [What's Covered](#whats-covered) below).
+
+## Supported Version Window
+
+We provide **hotfix patches** — bug fixes and security fixes — for the **five most recent minor versions** of the Discord Social SDK. Older versions are End-of-Life (EOL) and will not receive further updates.
+
+To receive a patch fix on an EOL version, upgrade to a supported release first.
+
+For how console OS SDK updates work, see [Console OS SDK Support](#console-os-sdk-support) below.
+
+### Supported Versions
+
+Once the 1.10 release ships in July 2026, the supported version window will be:
+
+| Version         | Status              |
+|-----------------|---------------------|
+| 1.10            | Supported — current |
+| 1.9             | Supported           |
+| 1.8             | Supported           |
+| 1.7             | Supported           |
+| 1.6             | Supported           |
+| 1.5 and earlier | End-of-Life         |
+
+## Console OS SDK Support
+
+New Xbox and PlayStation OS SDK support ships in **new minor Social SDK releases only** (the three minor releases per year). They are not backported to older Social SDK versions as patches.
+
+Each Social SDK release bundles roughly the last **18 months** of console OS SDK versions — from whatever Xbox GDK or PlayStation OS was current ~18 months before the release, up through the latest available at release time. Console OS SDK versions older than that window are dropped at each new Social SDK release.
+
+In practice, this means:
+
+- If you need the latest Xbox or PlayStation platform SDK, upgrade to the latest Social SDK release.
+- Already-shipped Social SDK releases continue to support the console OS SDK versions they were originally built with — we don't add or remove support for console OS SDKs from already-shipped versions.
+
+The minimum supported Xbox and PlayStation platform SDK versions for the current Social SDK release are listed in [Platform Compatibility](/developers/discord-social-sdk/core-concepts/platform-compatibility).
+
+## End-of-Life Process
+
+When a new minor version of the Social SDK is released, the oldest version in the support window rolls off and reaches End-of-Life:
+
+1. It is removed from the supported version table above
+2. No new hotfix patch builds are produced for that version
+3. Developers on that version should upgrade to the latest supported version
+
+EOL transitions are announced in the [Change Log](/developers/change-log) entry for the corresponding minor release.
+
+## What's Covered
+
+Within the supported Social SDK version window, hotfix patches for a minor version may include:
+
+- Bug-fix and stability hotfix patches
+- Security hotfix patches
+
+## What's Not Covered
+
+The following are **not** provided for older minor versions of the Social SDK:
+
+- New feature development
+- Backports of features introduced in a newer minor version
+- Backports of support for newer console OS SDK versions
+
+---
+
+## Next Steps
+
+import {UserPlatformIcon} from '/snippets/icons/UserPlatformIcon.jsx'
+import {BookCheckIcon} from '/snippets/icons/BookCheckIcon.jsx'
+import {PlayIcon} from '/snippets/icons/PlayIcon.jsx'
+
+<CardGroup cols={3}>
+    <Card title="Platform Compatibility" href="/developers/discord-social-sdk/core-concepts/platform-compatibility" icon={<UserPlatformIcon />}>
+        See supported platforms and minimum supported versions.
+    </Card>
+    <Card title="Change Log" href="/developers/change-log" icon={<BookCheckIcon />}>
+        Browse release notes and EOL announcements.
+    </Card>
+    <Card title="Getting Started" href="/developers/discord-social-sdk/getting-started" icon={<PlayIcon/>}>
+        Download the latest supported SDK version.
+    </Card>
+</CardGroup>
+
+---
+
+## Change Log
+
+| Date         | Changes         |
+|--------------|-----------------|
+| May 26, 2026 | initial release |

--- a/docs.json
+++ b/docs.json
@@ -191,6 +191,7 @@
               "developers/discord-social-sdk/core-concepts/communication-features",
               "developers/discord-social-sdk/core-concepts/integration-overview",
               "developers/discord-social-sdk/core-concepts/platform-compatibility",
+              "developers/discord-social-sdk/core-concepts/release-cadence-and-support",
               "developers/discord-social-sdk/core-concepts/oauth2-scopes"
             ]
           },


### PR DESCRIPTION
- Add new core-concepts/release-cadence-and-support page covering the three-per-year minor release cadence, the five-version support window, the console OS SDK rolling-window model, and the EOL process.
- Update Platform Compatibility matrix with concrete console SDK version ranges (Xbox GDK 250400-260400, PS4 OS 11.500-12.500, PS5 OS 11.000-13.000), an Info callout pointing to Console OS SDK Support, and a Next Steps card linking to the new page.
- Add standalone changelog entry announcing the new page and the changes taking effect with the 1.10 release in July 2026.