### PR TITLE
use Game Identity deep link in claim-your-game Step 1

### DIFF
--- a/developers/platform/claim-your-game.mdx
+++ b/developers/platform/claim-your-game.mdx
@@ -65,8 +65,7 @@ At this time, games in private beta or limited release are not supported. Your g
 
 ### Step 1: Open Game Identity in the Developer Portal
 
-1. Visit the [Developer Portal](https://discord.com/developers/applications) and select your application.
-2. Select **Game Identity** from the left-hand menu. The game claiming interface will appear automatically.
+Visit [Game Identity in the Developer Portal](https://discord.com/developers/applications/select/game-identity) and select your application. The game claiming interface will appear automatically.
 
 <Info>
 If you're an existing SDK partner, claim your game to the application you're already using for your SDK integration.


### PR DESCRIPTION
Replaces the two-step "go to Developer Portal, then click Game Identity" instruction with a single link to the /applications/select/game-identity deep link, which pops up an app selector and lands users directly on the Game Identity page.