### PR TITLE
remove duplicated Client Tools on SDK debug page

### DIFF
--- a/developers/discord-social-sdk/how-to/debug-log.mdx
+++ b/developers/discord-social-sdk/how-to/debug-log.mdx
@@ -93,14 +93,6 @@ The Discord client now includes some built-in developer tools to help you diagno
 
 This tab shows you the status of each of the on-platform account linking flows as well as provides a quick option to start the account linking flow without needing to find one of the entry points within the client. For more information on each of the flows, read the [Account Linking from Discord guide](/developers/discord-social-sdk/development-guides/account-linking-from-discord).
 
-## Client Tools
-
-The Discord client now includes some built-in developer tools to help you diagnose issues and test some of the features of the Discord Social SDK. To enable these new tools, navigate to `Settings > Advanced` and toggle on Application Test Mode. For the purposes of this guide, enter your Application ID and ignore the rest of the options in this modal, then click Activate. Once you've enabled Application Test Mode, you should see a new wrench icon in the upper right corner of your client. Click on this to open the developer tools.
-
-### Account Linking
-
-This tab shows you the status of each of the on-platform account linking flows as well as provides a quick option to start the account linking flow without needing to find one of the entry points within the client. For more information on each of the flows, read the [Account Linking from Discord guide](/developers/discord-social-sdk/development-guides/account-linking-from-discord).
-
 --- 
 
 ## Next Steps


### PR DESCRIPTION
Accidentally'd a whole section - closes #8372 

<img width="468" height="354" alt="CleanShot 2026-06-03 at 15 00 29@2x" src="https://github.com/user-attachments/assets/cdad0449-3521-4c12-9b65-180378152ca5" />
