### PR TITLE
Add Discord Social SDK 1.9.16441 changelog entry

### DIFF
--- a/developers/change-log.mdx
+++ b/developers/change-log.mdx
@@ -6,6 +6,20 @@ rss: true
 
 import {Route} from '/snippets/route.jsx'
 
+<Update label="June 3, 2026" tags={["Discord Social SDK"]} rss={{
+    title: "Discord Social SDK 1.9.16441",
+    description: "Fixed a PlayStation 5 crash caused by a use-after-free in WebSocket callbacks."
+  }}>
+
+    ## Discord Social SDK Release 1.9.16441
+
+    A new release of the Discord Social SDK is now available, with the following updates:
+
+    ### Playstation 5
+    - Fixed crash caused by use-after-free in WebSocket callbacks
+
+</Update>
+
 <Update label="June 3, 2026" tags={["Discord Social SDK", "HTTP API"]} rss={{
     title: "New Lobby HTTP API Endpoints",
     description: "Reference documentation added for create-or-join, send/get messages, and linked-channel invite endpoints on the Lobby resource."


### PR DESCRIPTION
Document the 1.9.16441 release (2026-06-03), which fixes a PlayStation 5 crash caused by a use-after-free in WebSocket callbacks.