### PR TITLE
Clarify app verification no longer tied to PI review

### DIFF
--- a/developers/change-log.mdx
+++ b/developers/change-log.mdx
@@ -35,6 +35,10 @@ import {Route} from '/snippets/route.jsx'
 
     Under the new user-based threshold, apps can continue joining servers and reaching new users while their submission is under review. 
 
+    #### 4. App Verification and Privileged Intent review are now separate
+
+    Previously, [App Verification](https://support-dev.discord.com/hc/en-us/articles/23926564536471-How-Do-I-Get-My-App-Verified) and Privileged Intent review were part of the same review process. With this change, we have separated App Verification and the Privileged Intent review process.
+
     ![Privileged Intents Requirements](/images/platform/priv-intents-requirements.png)
 
     ### What This Means For Your App


### PR DESCRIPTION
Previously, [App Verification](https://support-dev.discord.com/hc/en-us/articles/23926564536471-How-Do-I-Get-My-App-Verified) and Privileged Intent review were part of the same review process. With this change, we have separated App Verification and the Privileged Intent review process.