### PR TITLE
fix: add missing Team fields to application details example

### DIFF
--- a/developers/resources/application.mdx
+++ b/developers/resources/application.mdx
@@ -97,8 +97,10 @@ import {Route} from '/snippets/route.jsx'
   "primary_sku_id": "172150183260323840",
   "slug": "test",
   "team": {
+    "name": "A team",
     "icon": "dd9b7dcfdf5351b9c3de0fe167bacbe1",
     "id": "531992624043786253",
+    "owner_user_id": "511972282709709995",
     "members": [
       {
         "membership_state": 2,


### PR DESCRIPTION
https://docs.discord.com/developers/topics/teams#data-models-team-object define a few fields (like name of owner) of a Team how a required field but the example not include that.