### PR TITLE
docs: fix C++ UpdateRichPresence examples in game invites guide

### DIFF
--- a/developers/discord-social-sdk/development-guides/managing-game-invites.mdx
+++ b/developers/discord-social-sdk/development-guides/managing-game-invites.mdx
@@ -54,7 +54,7 @@ activity.SetState("In Competitive Match");
 activity.SetDetails("Valhalla");
 
 // Update Rich Presence presence
-client.UpdateRichPresence(activity, [](discordpp::ClientResult result) {
+client->UpdateRichPresence(activity, [](discordpp::ClientResult result) {
     if(result.Successful()) {
         std::cout << "🎮 Rich Presence updated successfully!\n";
         // Note: Invites are NOT yet enabled - we need party info and join secret
@@ -144,7 +144,7 @@ activity.SetSecrets(secrets);
 activity.SetSupportedPlatforms(discordpp::ActivityGamePlatforms::Desktop);
 
 // Update Rich Presence presence
-client.UpdateRichPresence(activity, [](discordpp::ClientResult result) {
+client->UpdateRichPresence(activity, [](discordpp::ClientResult result) {
     if(result.Successful()) {
         std::cout << "🎮 Rich Presence updated successfully!\n";
         // ✅ Rich Presence updated = Game invites now available!


### PR DESCRIPTION
Fixed : #8383

## Summary

Fixes two C++ Social SDK examples in the Managing Game Invites guide to use `client->UpdateRichPresence(...)` instead of `client.UpdateRichPresence(...)`.

## Why

The guide uses `std::shared_ptr<discordpp::Client>` for C++ examples, so member calls should use `->`. The previous examples would fail to compile if copied directly.

## Testing

- Checked other C++ Social SDK examples for consistency.