### PR TITLE
Update poll.mdx with text specification for PollMedia

### DIFF
--- a/developers/resources/poll.mdx
+++ b/developers/resources/poll.mdx
@@ -68,7 +68,7 @@ For now, `question` only supports `text`, while answers can have an optional `em
 
 | Field  | Type                                                      | Description            |
 |--------|-----------------------------------------------------------|------------------------|
-| text   | string                                                    | The text of the field  |
+| text?  | string                                                    | The text of the field  |
 | emoji? | partial [emoji](/developers/resources/emoji#emoji-object) | The emoji of the field |
 
 `text` should always be non-null for both questions and answers, but please do not depend on that in the future.

--- a/developers/resources/poll.mdx
+++ b/developers/resources/poll.mdx
@@ -68,6 +68,7 @@ For now, `question` only supports `text`, while answers can have an optional `em
 
 | Field  | Type                                                      | Description            |
 |--------|-----------------------------------------------------------|------------------------|
+| text   | string                                                    | The text of the field  |
 | emoji? | partial [emoji](/developers/resources/emoji#emoji-object) | The emoji of the field |
 
 `text` should always be non-null for both questions and answers, but please do not depend on that in the future.


### PR DESCRIPTION
The poll media object was currently missing specification for the `text` field.