### PR TITLE
Add Java example on how to validate webhook requests

### DIFF
--- a/developers/interactions/overview.mdx
+++ b/developers/interactions/overview.mdx
@@ -158,7 +158,7 @@ except BadSignatureError:
 
 **Java**
 
-We will use `tink-java` (`com.google.crypto.tink:tink:1.22.0`), the minimum Java version required is 11.
+We will use `tink-java` ([`com.google.crypto.tink:tink:1.22.0`](https://mvnrepository.com/artifact/com.google.crypto.tink/tink/1.22.0)), the minimum Java version required is 11.
 
 Using the provided class:
 

--- a/developers/interactions/overview.mdx
+++ b/developers/interactions/overview.mdx
@@ -155,6 +155,56 @@ try:
 except BadSignatureError:
     abort(401, 'invalid request signature')
 ```
+
+**Java**
+
+We will use `tink-java` (`com.google.crypto.tink:tink:1.22.0`), the minimum Java version required is 11.
+
+Using the provided class:
+
+```java
+import com.google.crypto.tink.subtle.Ed25519Verify;
+import com.google.crypto.tink.subtle.Hex;
+
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+
+public class Ed25519WebhookVerifier {
+    private final Ed25519Verify verifier;
+
+    public Ed25519WebhookVerifier(String publicKey) {
+        this.verifier = new Ed25519Verify(Hex.decode(publicKey));
+    }
+
+    public boolean verify(String signature, String timestamp, String body) {
+        try {
+            verifier.verify(Hex.decode(signature), (timestamp + body).getBytes(StandardCharsets.UTF_8));
+            return true;
+        } catch (GeneralSecurityException e) {
+            return false;
+        }
+    }
+}
+```
+
+Verify your interactions with:
+
+```java
+// Your public key can be found on your application in the Developer Portal
+var verifier = new Ed25519WebhookVerifier("PUBLIC_KEY");
+
+// Get those from your favorite web server library
+// The "X-Signature-Ed25519" header
+String signature;
+// The "X-Signature-Timestamp" header
+String timestamp;
+// Request body
+String body;
+if (!verifier.verify(signature, timestamp, body)) {
+    // Signature is invalid, return an HTTP 401 response
+    throw new UnsupportedOperationException("Return a HTTP 401 response");
+}
+```
 </Accordion>
 
 In addition to ensuring your app validates security-related request headers at the time of saving your endpoint, Discord will also perform automated, routine security checks against your endpoint, including purposefully sending you invalid signatures. If you fail the validation, we will remove your interactions URL and alert you via email and System DM.


### PR DESCRIPTION
Title. Used an external dependency as it is much cleaner than using the standard library.