### PR TITLE
Fix "Unified Friends List" guidelines hyperlink

### DIFF
--- a/developers/discord-social-sdk/core-concepts/core-features.mdx
+++ b/developers/discord-social-sdk/core-concepts/core-features.mdx
@@ -48,7 +48,7 @@ The SDK models friendships and relationships in two ways:
 
 | Design Guidelines                                                                             |
 |-----------------------------------------------------------------------------------------------|
-| [Unified Friends List](/developers/discord-social-sdk/design-guidelines/provisional-accounts) |
+| [Unified Friends List](/developers/discord-social-sdk/design-guidelines/unified-friends-list) |
 | [Game Friends](/developers/discord-social-sdk/design-guidelines/game-friends)                 |
 
 ## Presence & Rich Presence


### PR DESCRIPTION
The "Unified Friends List" link points to the provisional-accounts page instead.