### PR TITLE
Fix hardcoded directory paths for js scripts

### DIFF
--- a/tools/find-unused-images.js
+++ b/tools/find-unused-images.js
@@ -5,8 +5,8 @@ import path from "path";
 
 // Configuration
 const CONFIG = {
-  imagesDir: "static/images",
-  docsDir: "docs",
+  imagesDir: "images",
+  docsDir: "developers",
   rootFiles: ["."], // Check root markdown files too
   imageExtensions: [".gif", ".png", ".jpg", ".jpeg", ".webp", ".svg"],
   markupExtensions: [".md", ".mdx", ".js", ".ts", ".tsx", ".jsx"], // Include JS/TS for potential imports

--- a/tools/optimize-images.js
+++ b/tools/optimize-images.js
@@ -6,8 +6,8 @@ import { exec } from "child_process";
 
 // Configuration
 const CONFIG = {
-  imagesDir: "static/images",
-  docsDir: "docs",
+  imagesDir: "images",
+  docsDir: "developers",
   tempDir: "/tmp/image-optimization-backup",
   reportsDir: "reports",
   dryRun: false, // Set to true to preview changes without executing

--- a/tools/rename-files.js
+++ b/tools/rename-files.js
@@ -21,4 +21,4 @@ async function renameFilesInDirectory(directory) {
   }
 }
 
-await renameFilesInDirectory("docs");
+await renameFilesInDirectory("developers");


### PR DESCRIPTION
After #8124 was merged, the js util scripts were overlooked.  
They still reference the obsolete `docs/` and `static/images/` paths, neither of which exists.