### PR TITLE
Add changelog: Riot Games deprecation from GET /users/@me/connections

### DIFF
--- a/developers/change-log.mdx
+++ b/developers/change-log.mdx
@@ -6,6 +6,18 @@ rss: true
 
 import {Route} from '/snippets/route.jsx'
 
+<Update label="July 7, 2026" tags={["HTTP API", "Discord Social SDK"]} rss={{
+    title: "Deprecation: Riot Games Connections in Get Current User Connections",
+    description: "Riot Games and League of Legends connections are no longer returned by the /users/@me/connections endpoint as part of their migration to the Discord Social SDK."
+  }}>
+
+  ## Deprecation: Riot Games Connections in `Get Current User Connections`
+
+  The new Riot Games connection is powered by the [Discord Social SDK](/developers/discord-social-sdk/overview) and application identities. As a result, newly created Riot Games connections are no longer returned by the [`Get Current User Connections`](/developers/resources/user#get-current-user-connections) endpoint (`GET /users/@me/connections`).
+
+  Starting July 10, 2026, legacy Riot Games and League of Legends connections will also no longer be returned by this endpoint. There is no replacement for this functionality.
+</Update>
+
 <Update label="June 30, 2026" tags={["Discord Social SDK"]} rss={{
     title: "Discord Social SDK 1.9.17379",
     description: "Fixed a PlayStation 5 crash caused by re-entrant HTTP requests during connection teardown."

--- a/developers/resources/user.mdx
+++ b/developers/resources/user.mdx
@@ -194,34 +194,32 @@ The connection object that the user has attached.
 <ManualAnchor id="connection-object-services" />
 ###### Services
 
-| Value           | Name                |
-|-----------------|---------------------|
-| amazon-music    | Amazon Music        |
-| battlenet       | Battle.net          |
-| bungie          | Bungie.net          |
-| bluesky         | Bluesky             |
-| crunchyroll     | Crunchyroll         |
-| domain          | Domain              |
-| ebay            | eBay                |
-| epicgames       | Epic Games          |
-| facebook        | Facebook            |
-| github          | GitHub              |
-| instagram *     | Instagram           |
-| leagueoflegends | League of Legends   |
-| mastodon        | Mastodon            |
-| paypal          | PayPal              |
-| playstation     | PlayStation Network |
-| reddit          | Reddit              |
-| riotgames       | Riot Games          |
-| roblox          | Roblox              |
-| spotify         | Spotify             |
-| skype *         | Skype               |
-| steam           | Steam               |
-| tiktok          | TikTok              |
-| twitch          | Twitch              |
-| twitter         | X (Twitter)         |
-| xbox            | Xbox                |
-| youtube         | YouTube             |
+| Value        | Name                |
+|--------------|---------------------|
+| amazon-music | Amazon Music        |
+| battlenet    | Battle.net          |
+| bungie       | Bungie.net          |
+| bluesky      | Bluesky             |
+| crunchyroll  | Crunchyroll         |
+| domain       | Domain              |
+| ebay         | eBay                |
+| epicgames    | Epic Games          |
+| facebook     | Facebook            |
+| github       | GitHub              |
+| instagram *  | Instagram           |
+| mastodon     | Mastodon            |
+| paypal       | PayPal              |
+| playstation  | PlayStation Network |
+| reddit       | Reddit              |
+| roblox       | Roblox              |
+| spotify      | Spotify             |
+| skype *      | Skype               |
+| steam        | Steam               |
+| tiktok       | TikTok              |
+| twitch       | Twitch              |
+| twitter      | X (Twitter)         |
+| xbox         | Xbox                |
+| youtube      | YouTube             |
 
 \* Service can no longer be added by users
 


### PR DESCRIPTION
Documents that new Riot Games connections are no longer returned by the /users/@me/connections endpoint, and that legacy Riot Games and League of Legends connections will also stop being returned starting July 10, 2026, as part of their migration to the Discord Social SDK.