### PR TITLE
Standardize YouTube embeds behind a <YouTubeEmbed /> snippet

### DIFF
--- a/developers/discord-social-sdk/overview.mdx
+++ b/developers/discord-social-sdk/overview.mdx
@@ -31,13 +31,9 @@ import {CompassIcon} from '/snippets/icons/CompassIcon.jsx'
 
 ## Dive Deeper into the Discord Social SDK
 
-<center>
-    <iframe style={{width: '50%', maxWidth: 560, height: 315, paddingBottom: "20px"}}
-            src="https://www.youtube.com/embed/voEc21roLas?si=DBc_jBIJHqMtoDYc"
-            title="YouTube video player" frameborder="0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-</center>
+import {YouTubeEmbed} from '/snippets/youtube.jsx'
+
+<YouTubeEmbed src="https://www.youtube.com/embed/voEc21roLas?si=DBc_jBIJHqMtoDYc" title="Power Player Connections with Discord Social SDK" />
 
 import {WrenchIcon} from '/snippets/icons/WrenchIcon.jsx'
 import {PaintPaletteIcon} from '/snippets/icons/PaintPaletteIcon.jsx'

--- a/developers/game-development/how-to-add-proximity-voice-chat-to-your-game.mdx
+++ b/developers/game-development/how-to-add-proximity-voice-chat-to-your-game.mdx
@@ -6,6 +6,7 @@ keywords: ['prox chat', 'proximity chat', 'spatial', 'spatial audio']
 
 import {ImageCard} from '/snippets/imagecard.jsx'
 import CommsScopeWarning from '/snippets/discord-social-sdk/callouts/oauth-comms-scopes.mdx';
+import {YouTubeEmbed} from '/snippets/youtube.jsx'
 
 <img src="/images/game-development/how-to-add-proximity-voice-chat-to-your-game/banner-proximity-voice-chat.webp" alt="A banner showing a microphone that produces audio waves that look like they're in 3d space" style={{width: "100%", height: "auto"}} />
 
@@ -19,13 +20,7 @@ Discord handles everything about the voice call itself, and your game just needs
 
 This guide assumes you have already integrated the Discord Social SDK into a multiplayer Unity project. If you need to get set up with the Social SDK, follow the [Unity getting started guide](/developers/discord-social-sdk/getting-started/using-unity) first.
 
-<iframe
-  className="w-full aspect-video rounded-xl"
-  src="https://www.youtube.com/embed/AiDiu0xU3uI"
-  title="Proximity Voice Chat with the Discord Social SDK"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowFullScreen
-></iframe>
+<YouTubeEmbed src="https://www.youtube.com/embed/AiDiu0xU3uI" title="Proximity Voice Chat with the Discord Social SDK" />
 
 ---
 
@@ -288,13 +283,7 @@ Discord handles voice networking. Unity handles spatial audio. The `VoiceAudioSo
 
 Now you have a working proximity voice solution combining the power of the Discord Social SDK and Unity's 3D audio system. From here you can integrate this into an existing game, or create your own!
 
-<iframe
-  className="w-full aspect-video rounded-xl"
-  src="https://www.youtube.com/embed/qupje9hoXdw"
-  title="Proximity Voice Chat with the Discord Social SDK"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowFullScreen
-></iframe>
+<YouTubeEmbed src="https://www.youtube.com/embed/qupje9hoXdw" title="Proximity Voice Chat with the Discord Social SDK" />
 
 ---
 

--- a/developers/game-development/how-to-create-a-community-for-your-game.mdx
+++ b/developers/game-development/how-to-create-a-community-for-your-game.mdx
@@ -5,6 +5,7 @@ sidebarTitle: Create a Community For Your Game
 
 import {ImageCard} from '/snippets/imagecard.jsx'
 import {InboxIcon} from '/snippets/icons/InboxIcon.jsx'
+import {YouTubeEmbed} from '/snippets/youtube.jsx'
 
 <img src="/images/game-development/how-to-create-a-community-for-your-game/banner-how-to-create-a-community-for-your-game.webp" alt="A banner showing pieces of a community Discord server" style={{width: "100%", height: "auto"}} />
 
@@ -116,7 +117,7 @@ Wait until you see a need or the community asking for channels like these.
 
 Start with a core set of channels and add more only when you see a need for it in your server. You can use categories to logically group channels as your server grows.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/muFizGqksfQ?si=Npc33r8s1M-OR6lQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<YouTubeEmbed src="https://www.youtube.com/embed/muFizGqksfQ?si=Npc33r8s1M-OR6lQ" title="How to Structure Your Discord Server" />
 
 ---
 
@@ -169,7 +170,7 @@ Use Server Settings > Roles > Selected Role > View Server As Role to see exactly
 
 You do not need to configure every permission from the start. Focus on the channels where the wrong access would cause real problems, your announcement and private channels, and leave the rest at their defaults until you have a reason to change them.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/nkQK9IU5UCQ?si=qd77jaPqJTfpQTLg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<YouTubeEmbed src="https://www.youtube.com/embed/nkQK9IU5UCQ?si=qd77jaPqJTfpQTLg" title="How to Set Up Discord Server Roles and Permissions" />
 
 ---
 

--- a/developers/platform/rich-presence.mdx
+++ b/developers/platform/rich-presence.mdx
@@ -4,11 +4,13 @@ sidebarTitle: Rich Presence
 description: Display real-time game activity on Discord user profiles with rich presence.
 ---
 
+import {YouTubeEmbed} from '/snippets/youtube.jsx'
+
 ![Rich Presence](/images/game-development/how-to-get-your-game-seen/banner-how-to-get-your-game-seen.webp)
 
 Rich Presence lets your game display live, actionable data on a Discord user's profile when they have activity sharing enabled: what they're playing, what level they're on, how long they've been in a session, or a prompt for friends to join. It's a lightweight integration that connects your app to Discord's social layer.
 
-<iframe className="w-full aspect-video rounded-3xl" src="https://www.youtube-nocookie.com/embed/NlRtLGwemMw?si=L6Bho5MksTjn4n-W" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<YouTubeEmbed src="https://www.youtube.com/embed/NlRtLGwemMw?si=L6Bho5MksTjn4n-W" title="Boost Game Discovery with Discord Rich Presence [Discord DevBytes]" />
 
 The data you surface is entirely up to you. Rich Presence supports custom text fields, timestamps, party size indicators, and uploaded art assets. When configured with a "Join" button, friends can jump directly into a user's game session from the profile card.
 

--- a/developers/platform/social-layer.mdx
+++ b/developers/platform/social-layer.mdx
@@ -4,7 +4,9 @@ sidebarTitle: Social Layer
 description: Add Discord-powered social features directly into your game using the Discord Social SDK.
 ---
 
-<iframe className="w-full aspect-video rounded-3xl" src="https://www.youtube-nocookie.com/embed/Uc8wLXMBRnM?si=didYKcNb7KUqlfNG" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+import {YouTubeEmbed} from '/snippets/youtube.jsx'
+
+<YouTubeEmbed src="https://www.youtube.com/embed/Uc8wLXMBRnM?si=didYKcNb7KUqlfNG" title="Bring the Social Power of Discord Into Your Game with the Discord Social SDK [Discord DevBytes]" />
 
 _Already familiar? Jump to the [Discord Social SDK docs](/developers/discord-social-sdk/overview) or [Getting Started guides](/developers/discord-social-sdk/getting-started)._
 

--- a/developers/quick-start/overview-of-apps.mdx
+++ b/developers/quick-start/overview-of-apps.mdx
@@ -9,12 +9,13 @@ import {ShapesIcon} from '/snippets/icons/ShapesIcon.jsx'
 import {GameControllerIcon} from '/snippets/icons/GameControllerIcon.jsx'
 import {AppsIcon} from '/snippets/icons/AppsIcon.jsx'
 import {WrenchIcon} from '/snippets/icons/WrenchIcon.jsx'
+import {YouTubeEmbed} from '/snippets/youtube.jsx'
 
 A **Discord application** is the core entity that represents your integration with the Discord platform. Every bot, Activity, and Social SDK integration is backed by an application registered in the [Discord Developer Portal](https://discord.com/developers/applications).
 
 Applications hold your credentials, OAuth2 settings, bot configuration, and metadata. Whether you're building a simple command-response bot or a full game integration with voice chat and rich presence, it all starts with creating an application.
 
-<iframe className="w-full aspect-video rounded-3xl" src="https://www.youtube-nocookie.com/embed/CFxo5w3SY2w?si=AFrLSog_hjC-xiV7" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<YouTubeEmbed src="https://www.youtube.com/embed/CFxo5w3SY2w?si=AFrLSog_hjC-xiV7" title="Discord Apps 101: Bots, Activities, and Social SDK [Discord DevBytes]" />
 
 ## The Three Types of Discord Apps
 

--- a/snippets/youtube.jsx
+++ b/snippets/youtube.jsx
@@ -1,0 +1,13 @@
+export const YouTubeEmbed = ({ src, title = "YouTube video player" }) => {
+  return (
+    <iframe
+      className="w-full aspect-video rounded-xl"
+      src={src}
+      title={title}
+      frameBorder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+      referrerPolicy="strict-origin-when-cross-origin"
+      allowFullScreen
+    ></iframe>
+  );
+};


### PR DESCRIPTION
The docs had 8 hand-pasted YouTube iframes across 6 files in four different styles: mismatched corner radii (rounded-xl vs rounded-3xl vs none), two embeds stuck at a fixed 560x315 with no responsive classes, and two missing frameborder/referrerpolicy/web-share.

Add snippets/youtube.jsx exporting YouTubeEmbed, which owns the markup: w-full aspect-video rounded-xl plus the standard share-embed attributes in correct JSX casing (frameBorder, referrerPolicy, allowFullScreen). It takes src, and an optional title defaulting to "YouTube video player".

Migrate all 8 call sites and give each embed a real title lifted from the video on YouTube, replacing the generic default.