### PR TITLE
fix: Add the missing "topic" field in patch stage instance

### DIFF
--- a/developers/resources/stage-instance.mdx
+++ b/developers/resources/stage-instance.mdx
@@ -112,6 +112,7 @@ This endpoint supports the `X-Audit-Log-Reason` header.
 
 | Field          | Type    | Description                                                                                                         |
 |----------------|---------|---------------------------------------------------------------------------------------------------------------------|
+| topic?         | string  | The topic of the Stage instance (1-120 characters)                                                                  |
 | privacy_level? | integer | The [privacy level](/developers/resources/stage-instance#stage-instance-object-privacy-level) of the Stage instance |
 
 ## Delete Stage Instance


### PR DESCRIPTION
Migration missed the `topic` field in PATCH `/stage-instances/{channel.id}`.
Compared [before](https://github.com/discord/discord-api-docs/blob/4487d29dfba42309f16674e8293df46b49a7cf67/docs/resources/stage-instance.mdx) and [after](https://github.com/discord/discord-api-docs/blob/35f3280dc8fe9f00db39e0d5eecc3620a6059d8d/developers/resources/stage-instance.mdx).