### PR TITLE
Clarify accepted image-data formats (emoji also accepts WebP/AVIF)

### DIFF
--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -377,13 +377,13 @@ Sticker GIFs do not use the CDN base url, and can be accessed at `https://media.
 
 ## Image Data
 
-Image data is a [Data URI scheme](https://en.wikipedia.org/wiki/Data_URI_scheme) that supports JPG, GIF, and PNG formats. An example Data URI format is:
+Image data is a [Data URI scheme](https://en.wikipedia.org/wiki/Data_URI_scheme) carrying a base64-encoded image. Most endpoints accept JPG, GIF, and PNG; some accept additional formats — for example, [emoji](/docs/resources/emoji#emoji-object-emoji-formats) also accept WebP and AVIF. Refer to the specific resource for the formats it supports. An example Data URI format is:
 
 ```
 data:image/jpeg;base64,BASE64_ENCODED_JPEG_IMAGE_DATA
 ```
 
-Ensure you use the proper content type (`image/jpeg`, `image/png`, `image/gif`) that matches the image data being provided.
+The accepted format is determined from the encoded image data itself, so you should set a content type (`image/jpeg`, `image/png`, `image/gif`, etc.) that matches the image being provided.
 
 ### Signed Attachment CDN URLs
 


### PR DESCRIPTION
## Summary

The **Image Data** section in `reference.mdx` states the Data URI "supports JPG, GIF, and PNG formats" with no qualification. That contradicts the **Emoji Formats** section (`emoji.mdx`), which correctly lists JPEG, PNG, GIF, WebP, and AVIF for emoji — and it contradicts actual API behavior, where the accepted format is determined per-resource by sniffing the encoded image bytes, not from the declared data-URI content type.

This tripped up an integration: a developer reading the emoji endpoint's `image` field followed the link to Image Data, saw "JPG, GIF, PNG only," and concluded animated WebP couldn't be uploaded — when in fact it can.

## Change

Reword the Image Data section to:
- describe the Data URI as carrying a base64-encoded image;
- note most endpoints accept JPG/GIF/PNG while some (e.g. emoji) accept additional formats like WebP/AVIF, and point readers to the specific resource;
- clarify that the accepted format is determined from the image data itself.

No endpoint behavior changes — docs only.