### PR TITLE
lobby: document additional_name on Create and Modify Lobby

### DIFF
--- a/developers/resources/lobby.mdx
+++ b/developers/resources/lobby.mdx
@@ -29,12 +29,12 @@ Represents a member of a lobby, including optional metadata and flags.
 <ManualAnchor id="lobby-member-object-lobby-member-structure" />
 ###### Lobby Member Structure
 
-| Field            | Type                    | Description                                                                                                                                                                                                                                                                                                                                                 |
-|------------------|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| id               | snowflake               | the id of the user                                                                                                                                                                                                                                                                                                                                          |
-| metadata?        | ?dict\<string, string\> | dictionary of string key/value pairs. The max total length is 1000.                                                                                                                                                                                                                                                                                         |
-| flags?           | integer                 | [lobby member flags](/developers/resources/lobby#lobby-member-object-lobby-member-flags) combined as a [bitfield](https://en.wikipedia.org/wiki/Bit_field)                                                                                                                                                                                                  |
-| additional_name? | string                  | an additional 1-80 character display name for the member, such as an in-game character name. Can only be set via [Add a Member to a Lobby](/developers/resources/lobby#add-a-member-to-a-lobby) or [Bulk Update Lobby Members](/developers/resources/lobby#bulk-update-lobby-members). Accessible via the Social SDK with [`MessageHandle::AdditionalName`] |
+| Field            | Type                    | Description                                                                                                                                                                                                                           |
+|------------------|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| id               | snowflake               | the id of the user                                                                                                                                                                                                                    |
+| metadata?        | ?dict\<string, string\> | dictionary of string key/value pairs. The max total length is 1000.                                                                                                                                                                   |
+| flags?           | integer                 | [lobby member flags](/developers/resources/lobby#lobby-member-object-lobby-member-flags) combined as a [bitfield](https://en.wikipedia.org/wiki/Bit_field)                                                                            |
+| additional_name? | string                  | an additional 1-80 character display name for the member, such as an in-game character name. Can only be set through the HTTP API, not from a Social SDK client. Accessible via the Social SDK with [`MessageHandle::AdditionalName`] |
 
 <ManualAnchor id="lobby-member-object-lobby-member-flags" />
 ###### Lobby Member Flags
@@ -89,11 +89,12 @@ Returns a [lobby](/developers/resources/lobby#lobby-object) object.
 
 #### Lobby Member JSON Params
 
-| Field     | Type                    | Description                                                                                                                                                |
-|-----------|-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| id        | snowflake               | Discord user id of the user to add to the lobby                                                                                                            |
-| metadata? | ?dict\<string, string\> | optional dictionary of string key/value pairs. The max total length is 1000.                                                                               |
-| flags?    | integer                 | [lobby member flags](/developers/resources/lobby#lobby-member-object-lobby-member-flags) combined as a [bitfield](https://en.wikipedia.org/wiki/Bit_field) |
+| Field            | Type                    | Description                                                                                                                                                                                                  |
+|------------------|-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| id               | snowflake               | Discord user id of the user to add to the lobby                                                                                                                                                              |
+| metadata?        | ?dict\<string, string\> | optional dictionary of string key/value pairs. The max total length is 1000.                                                                                                                                 |
+| flags?           | integer                 | [lobby member flags](/developers/resources/lobby#lobby-member-object-lobby-member-flags) combined as a [bitfield](https://en.wikipedia.org/wiki/Bit_field)                                                   |
+| additional_name? | ?string                 | an additional display name for the member, such as an in-game character name. 1-80 characters. When updating an existing member, omit the field to preserve their current value, or send `null` to clear it. |
 
 ## Create or Join Lobby
 <Route method="PUT">/lobbies</Route>
@@ -127,11 +128,11 @@ Returns the updated [lobby](/developers/resources/lobby#lobby-object) object.
 
 ### JSON Params
 
-| Field                 | Type                                                                             | Description                                                                                                                                                            |
-|-----------------------|----------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| metadata?             | ?dict\<string, string\>                                                          | optional dictionary of string key/value pairs. The max total length is 1000. Overwrites any existing metadata.                                                         |
-| members?              | array of [lobby member](/developers/resources/lobby#lobby-member-object) objects | optional array of up to 25 users to replace the lobby members with. If provided, lobby members not in this list will be removed from the lobby.                        |
-| idle_timeout_seconds? | integer                                                                          | seconds to wait before shutting down a lobby after it becomes idle. Value can be between 5 and 604800 (7 days). See [`LobbyHandle`] for more details on this behavior. |
+| Field                 | Type                                                                             | Description                                                                                                                                                                                                                                                   |
+|-----------------------|----------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| metadata?             | ?dict\<string, string\>                                                          | optional dictionary of string key/value pairs. The max total length is 1000. Overwrites any existing metadata.                                                                                                                                                |
+| members?              | array of [lobby member](/developers/resources/lobby#lobby-member-object) objects | optional array of up to 25 users to replace the lobby members with. If provided, lobby members not in this list will be removed from the lobby. See [Lobby Member JSON Params](/developers/resources/lobby#lobby-member-json-params) for the accepted fields. |
+| idle_timeout_seconds? | integer                                                                          | seconds to wait before shutting down a lobby after it becomes idle. Value can be between 5 and 604800 (7 days). See [`LobbyHandle`] for more details on this behavior.                                                                                        |
 
 ## Delete Lobby
 <Route method="DELETE">/lobbies/[\{lobby.id\}](/developers/resources/lobby#lobby-object)</Route>
@@ -338,6 +339,14 @@ These are per-application rate limits, not per-user.
 </Info>
 
 These limitations are designed to provide sufficient capacity for development, testing, and small-scale demos while ensuring system stability.
+
+---
+
+## Change Log
+
+| Date            | Changes                                                            |
+|-----------------|--------------------------------------------------------------------|
+| August 12, 2026 | `additional_name` can now be set via Create Lobby and Modify Lobby |
 
 {/* Autogenerated Reference Links */}
 [`Client::CreateOrJoinLobby`]: https://discord.com/developers/docs/social-sdk/classdiscordpp_1_1Client.html#a8b4e195555ecaa89ccdfc0acd28d3512


### PR DESCRIPTION
additional_name is now accepted in the inline members array of POST /lobbies and PATCH /lobbies/{lobby.id}.

- Drop the "can only be set via Add a Member to a Lobby or Bulk Update Lobby Members" caveat from the Lobby Member Structure table, keeping the constraint that still holds: HTTP API only, never settable from a Social SDK client.
- Add additional_name to the Lobby Member JSON Params table — omit to preserve an existing member's value, null to clear, string to set.
- Point the members rows on Create Lobby and Modify Lobby at that shared table rather than duplicating it.
- Add a page-level Change Log.