### PR TITLE
Fix slash command regex apostrophe

### DIFF
--- a/developers/interactions/application-commands.mdx
+++ b/developers/interactions/application-commands.mdx
@@ -15,7 +15,7 @@ Application commands are native ways to interact with apps in the Discord client
 <ManualAnchor id="application-command-object-application-command-naming" />
 ###### Application Command Naming
 
-`CHAT_INPUT` command names and command option names must match the following regex `^[-_'\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$` with the unicode flag set. If there is a lowercase variant of any letters used, you must use those. Characters with no lowercase variants and/or uncased letters are still allowed. `USER` and `MESSAGE` commands may be mixed case and can include spaces.
+`CHAT_INPUT` command names and command option names must match the following regex `^[-_\u02BC\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$` with the unicode flag set. If there is a lowercase variant of any letters used, you must use those. Characters with no lowercase variants and/or uncased letters are still allowed. `USER` and `MESSAGE` commands may be mixed case and can include spaces.
 
 <ManualAnchor id="application-command-object-application-command-structure" />
 ###### Application Command Structure


### PR DESCRIPTION
fixes #7371

due to #5094 we added support for the character `ʼ` (modifier letter apostrophe). #7303 then incorrectly added `'` (apostrophe) to the docs regex. I corrected this to \u02BC (modifier letter apostrophe) which is what we have in our code.
