### PR TITLE
Add Gateway Guild Tag

### DIFF
--- a/developers/events/gateway-events.mdx
+++ b/developers/events/gateway-events.mdx
@@ -771,6 +771,7 @@ The inner payload can be:
 | stage_instances        | array of [stage instance](/developers/resources/stage-instance#stage-instance-object) objects                      | Stage instances in the guild                                                                                               |
 | guild_scheduled_events | array of [guild scheduled event](/developers/resources/guild-scheduled-event#guild-scheduled-event-object) objects | Scheduled events in the guild                                                                                              |
 | soundboard_sounds      | array of [soundboard sound](/developers/resources/soundboard#soundboard-sound-object) objects                      | Soundboard sounds in the guild                                                                                             |
+| profile                | ?[guild tag](/developers/resources/guild#guild-tag-object) object                                                  | The guild tag that the guild has set                                                                                       |
 
 <Warning>
 If your bot does not have the `GUILD_PRESENCES` [Gateway Intent](/developers/events/gateway#gateway-intents), or if the guild has over 75k members, members and presences returned in this event will only contain your bot and users in voice channels.

--- a/developers/events/gateway-events.mdx
+++ b/developers/events/gateway-events.mdx
@@ -781,6 +781,13 @@ If your bot does not have the `GUILD_PRESENCES` [Gateway Intent](/developers/eve
 
 Sent when a guild is updated. The inner payload is a [guild](/developers/resources/guild#guild-object) object.
 
+<ManualAnchor id="guild-update-guild-update-extra-fields" />
+###### Guild Update Extra Fields
+
+| Field    | Type                                                              | Description                          |
+|----------|-------------------------------------------------------------------|--------------------------------------|
+| profile? | ?[guild tag](/developers/resources/guild#guild-tag-object) object | The guild tag that the guild has set |
+
 #### Guild Delete
 
 Sent when a guild becomes or was already unavailable due to an outage, or when the user leaves or is removed from a guild. The inner payload is an [unavailable guild](/developers/resources/guild#unavailable-guild-object) object. If the `unavailable` field is not set, the user was removed from the guild.

--- a/developers/resources/guild.mdx
+++ b/developers/resources/guild.mdx
@@ -743,6 +743,28 @@ We are making significant changes to the Membership Screening API specifically r
 }
 ```
 
+### Guild Tag Object
+
+The [guild tag](https://support.discord.com/hc/en-us/articles/31444248479639-Server-Tags) that a guild has set.
+
+<ManualAnchor id="guild-tag-object-guild-tag-structure" />
+###### Guild Tag Structure
+
+| Field | Type   | Description                                                        |
+|-------|--------|--------------------------------------------------------------------|
+| tag   | string | the text of the guild tag. Limited to 4 characters                 |
+| badge | string | the [guild tag badge hash](/developers/reference#image-formatting) |
+
+<ManualAnchor id="guild-tag-object-example-guild-tag" />
+###### Example Guild Tag
+
+```json
+{
+  "tag": "CAP",
+  "badge": "ebdff4ff0e6d49275ab44d1f24e758d6"
+}
+```
+
 ## Get Guild
 <Route method="GET">/guilds/[\{guild.id\}](/developers/resources/guild#guild-object)</Route>
 


### PR DESCRIPTION
I saw that `GUILD_CREATE` guilds have a `profile` field with some stuff about the guild's tag. Since gateway fields aren't in the spec and this field is used by the client, I thought it might be okay to make a PR