### PR TITLE
Fix incorrect formatting under Identify Connection Properties section

### DIFF
--- a/developers/events/gateway-events.mdx
+++ b/developers/events/gateway-events.mdx
@@ -111,7 +111,7 @@ Details about identifying is in the [Gateway documentation](/developers/events/g
 | device  | string | Your library name     |
 
 <Warning>
-These fields originally were $ prefixed (i.e: `$browser`) but [this syntax is deprecated](/developers/change-log#updated-connection-property-field-names). While they currently still work, it is recommended to move to non-prefixed fields.
+These fields originally were `$` prefixed (i.e: `$browser`) but [this syntax is deprecated](/developers/change-log#updated-connection-property-field-names). While they currently still work, it is recommended to move to non-prefixed fields.
 </Warning>
 
 <ManualAnchor id="identify-example-identify" />


### PR DESCRIPTION
Under the [live docs, Events > Gateway Events > Identify Connection Properties](https://github.com/discord/discord-api-docs/blob/main/developers/events/gateway-events.mdx), the `$` sign in "originally were $ prefixed" incorrectly triggers LaTeX formatting. This PR adds a code block around the dollar sign to fix this.
<img width="908" height="92" alt="image" src="https://github.com/user-attachments/assets/34b67f32-16fd-4d0e-91c5-a144761328e8" />
